### PR TITLE
Add event preview for NIP-55 signing requests

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/nip55/Nip55ApprovalScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/Nip55ApprovalScreen.kt
@@ -282,7 +282,7 @@ private fun ColumnScope.RequestDetailsCard(request: Nip55Request, eventPreview: 
 
             if (eventPreview != null) {
                 EventPreviewSection(eventPreview)
-            } else if (request.content.isNotEmpty() && request.requestType != Nip55RequestType.SIGN_EVENT) {
+            } else if (request.content.isNotEmpty()) {
                 Spacer(modifier = Modifier.height(12.dp))
                 ExpandableContentSection(request.content)
             }

--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
@@ -2,6 +2,7 @@ package io.privkey.keep.storage
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.util.Log
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyInfo
 import android.security.keystore.KeyPermanentlyInvalidatedException
@@ -24,6 +25,7 @@ import javax.crypto.spec.GCMParameterSpec
 class AndroidKeystoreStorage(private val context: Context) : SecureStorage {
 
     companion object {
+        private const val TAG = "AndroidKeystoreStorage"
         private const val KEYSTORE_ALIAS = "keep_frost_share"
         private const val KEYSTORE_PREFIX = "keep_frost_"
         private const val PREFS_NAME = "keep_secure_prefs"
@@ -239,6 +241,7 @@ class AndroidKeystoreStorage(private val context: Context) : SecureStorage {
             groupPubkey = Base64.decode(groupPubkeyB64, Base64.NO_WRAP)
         )
     } catch (e: Exception) {
+        Log.e(TAG, "Failed to parse stored key metadata", e)
         null
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rich event preview for signing requests: shows event kind, formatted recipient pubkey, truncated/expandable content, compact tag/reference summaries, and a unified sensitive-kind warning.

* **Improvements**
  * Approval screen and details card redesigned with better spacing and vertical scrolling for long content.
  * Per-key share storage: supports multiple per-key shares, improved listing and metadata handling, safer deletion and registry updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->