### PR TITLE
Security hardening: monotonic clock, logging, and configs

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,8 +20,10 @@
     <application
         android:name=".KeepMobileApp"
         android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="true"
         android:theme="@style/Theme.KeepAndroid">
 

--- a/app/src/main/kotlin/io/privkey/keep/ExportShareScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ExportShareScreen.kt
@@ -2,6 +2,7 @@ package io.privkey.keep
 
 import android.util.Log
 import android.widget.Toast
+import io.privkey.keep.BuildConfig
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
@@ -293,7 +294,7 @@ fun ExportShareScreen(
                                                 val frames = generateFrames(data, MAX_SINGLE_QR_BYTES)
                                                 exportState = ExportState.Success(data, frames)
                                             } catch (e: Exception) {
-                                                Log.e("ExportShare", "Export failed: ${e::class.simpleName}")
+                                                if (BuildConfig.DEBUG) Log.e("ExportShare", "Export failed: ${e::class.simpleName}")
                                                 exportState = ExportState.Error("Export failed. Please try again.")
                                             } finally {
                                                 Arrays.fill(passphraseChars, '\u0000')
@@ -307,7 +308,7 @@ fun ExportShareScreen(
                                     }
                                 }
                             } catch (e: Exception) {
-                                Log.e("ExportShare", "Failed to init cipher: ${e::class.simpleName}")
+                                if (BuildConfig.DEBUG) Log.e("ExportShare", "Failed to init cipher: ${e::class.simpleName}")
                                 cipherError = "Failed to initialize encryption"
                             }
                         },

--- a/app/src/main/kotlin/io/privkey/keep/ImportShareScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ImportShareScreen.kt
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager
 import android.security.keystore.KeyPermanentlyInvalidatedException
 import android.util.Log
 import android.util.Size
+import io.privkey.keep.BuildConfig
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.camera.core.CameraSelector
@@ -201,10 +202,10 @@ fun ImportShareScreen(
                         }
                         null
                     } catch (e: KeyPermanentlyInvalidatedException) {
-                        Log.e("ImportShare", "Biometric key invalidated during cipher init", e)
+                        if (BuildConfig.DEBUG) Log.e("ImportShare", "Biometric key invalidated during cipher init", e)
                         "Biometric key invalidated. Please re-enroll biometrics."
                     } catch (e: Exception) {
-                        Log.e("ImportShare", "Failed to initialize cipher for biometric auth", e)
+                        if (BuildConfig.DEBUG) Log.e("ImportShare", "Failed to initialize cipher for biometric auth", e)
                         "Failed to initialize encryption"
                     }
                 }

--- a/app/src/main/kotlin/io/privkey/keep/KeepMobileApp.kt
+++ b/app/src/main/kotlin/io/privkey/keep/KeepMobileApp.kt
@@ -2,6 +2,7 @@ package io.privkey.keep
 
 import android.app.Application
 import android.util.Log
+import io.privkey.keep.BuildConfig
 import io.privkey.keep.nip46.BunkerService
 import io.privkey.keep.nip55.AutoSigningSafeguards
 import io.privkey.keep.nip55.CallerVerificationStore
@@ -89,7 +90,7 @@ class KeepMobileApp : Application() {
             keepMobile = newKeepMobile
             nip55Handler = Nip55Handler(newKeepMobile)
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to initialize KeepMobile: ${e::class.simpleName}", e)
+            if (BuildConfig.DEBUG) Log.e(TAG, "Failed to initialize KeepMobile: ${e::class.simpleName}", e)
         }
     }
 
@@ -118,7 +119,7 @@ class KeepMobileApp : Application() {
                 callerVerificationStore?.cleanupExpiredNonces()
             }
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to initialize PermissionStore: ${e::class.simpleName}")
+            if (BuildConfig.DEBUG) Log.e(TAG, "Failed to initialize PermissionStore: ${e::class.simpleName}")
         }
     }
 
@@ -128,7 +129,7 @@ class KeepMobileApp : Application() {
             signingNotificationManager = manager
             applicationScope.launch { manager.cleanupStaleEntries() }
         }.onFailure { e ->
-            Log.e(TAG, "Failed to initialize SigningNotificationManager: ${e::class.simpleName}", e)
+            if (BuildConfig.DEBUG) Log.e(TAG, "Failed to initialize SigningNotificationManager: ${e::class.simpleName}", e)
         }
     }
 
@@ -140,7 +141,7 @@ class KeepMobileApp : Application() {
                 BunkerService.start(this)
             }
         }.onFailure { e ->
-            Log.e(TAG, "Failed to initialize BunkerService: ${e::class.simpleName}", e)
+            if (BuildConfig.DEBUG) Log.e(TAG, "Failed to initialize BunkerService: ${e::class.simpleName}", e)
         }
     }
 
@@ -217,7 +218,7 @@ class KeepMobileApp : Application() {
                         _connectionState.value = ConnectionState()
                         return@onFailure
                     }
-                    Log.e(TAG, "Failed to connect: ${e::class.simpleName}: ${e.message}", e)
+                    if (BuildConfig.DEBUG) Log.e(TAG, "Failed to connect: ${e::class.simpleName}: ${e.message}", e)
                     _connectionState.value = ConnectionState(error = "Connection failed")
                     withContext(Dispatchers.Main) { onError("Connection failed") }
                 }
@@ -242,7 +243,7 @@ class KeepMobileApp : Application() {
                 runCatching {
                     val currentRelays = config.getRelays()
                     if (currentRelays.isEmpty()) {
-                        Log.w(TAG, "No relays configured, skipping peer check")
+                        if (BuildConfig.DEBUG) Log.w(TAG, "No relays configured, skipping peer check")
                         return@runCatching
                     }
                     val peers = mobile.getPeers()
@@ -250,7 +251,7 @@ class KeepMobileApp : Application() {
                         Log.d(TAG, "Peer check #${iteration + 1}, peers: ${peers.size}")
                     }
                 }.onFailure {
-                    Log.e(TAG, "Peer check failed on iteration ${iteration + 1}", it)
+                    if (BuildConfig.DEBUG) Log.e(TAG, "Peer check failed on iteration ${iteration + 1}", it)
                     if (it is CancellationException) throw it
                 }
             }
@@ -267,7 +268,7 @@ class KeepMobileApp : Application() {
 
         applicationScope.launch {
             runCatching { mobile.initialize(relays) }
-                .onFailure { Log.e(TAG, "Failed to reconnect relays: ${it::class.simpleName}") }
+                .onFailure { if (BuildConfig.DEBUG) Log.e(TAG, "Failed to reconnect relays: ${it::class.simpleName}") }
         }
     }
 

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -475,7 +475,7 @@ fun MainScreen(
                         if (activeKey != null) storage.getCipherForShareDecryption(activeKey)
                         else storage.getCipherForDecryption()
                     }.onFailure {
-                        Log.e("MainActivity", "Failed to get cipher for connection", it)
+                        if (BuildConfig.DEBUG) Log.e("MainActivity", "Failed to get cipher for connection", it)
                     }.getOrNull() ?: return@ConnectCard
 
                     onBiometricRequest("Connect to Relays", "Authenticate to connect", cipher) { authedCipher ->

--- a/app/src/main/kotlin/io/privkey/keep/nip46/BunkerService.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip46/BunkerService.kt
@@ -209,7 +209,7 @@ class BunkerService : Service() {
         val app = applicationContext as? KeepMobileApp
         val keepMobile = app?.getKeepMobile()
         if (keepMobile == null) {
-            Log.e(TAG, "KeepMobile not available")
+            if (BuildConfig.DEBUG) Log.e(TAG, "KeepMobile not available")
             _status.value = BunkerStatus.ERROR
             stopSelf()
             return START_NOT_STICKY
@@ -219,7 +219,7 @@ class BunkerService : Service() {
 
         val relays = configStore?.getRelays() ?: emptyList()
         if (relays.isEmpty()) {
-            Log.e(TAG, "No bunker relays configured")
+            if (BuildConfig.DEBUG) Log.e(TAG, "No bunker relays configured")
             _status.value = BunkerStatus.ERROR
             stopSelf()
             return START_NOT_STICKY
@@ -271,7 +271,7 @@ class BunkerService : Service() {
 
             updateNotification(isActive = true)
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to start bunker: ${e::class.simpleName}")
+            if (BuildConfig.DEBUG) Log.e(TAG, "Failed to start bunker: ${e::class.simpleName}")
             _status.value = BunkerStatus.ERROR
         }
     }
@@ -304,7 +304,7 @@ class BunkerService : Service() {
 
     private fun handleApprovalRequest(request: BunkerApprovalRequest): Boolean {
         if (Looper.myLooper() == Looper.getMainLooper()) {
-            Log.e(TAG, "handleApprovalRequest called from main thread - rejecting to avoid ANR")
+            if (BuildConfig.DEBUG) Log.e(TAG, "handleApprovalRequest called from main thread - rejecting to avoid ANR")
             return false
         }
 

--- a/app/src/main/kotlin/io/privkey/keep/nip46/Nip46ApprovalActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip46/Nip46ApprovalActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import android.view.WindowManager
+import io.privkey.keep.BuildConfig
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
@@ -39,14 +40,14 @@ class Nip46ApprovalActivity : FragmentActivity() {
 
         requestId = intent.getStringExtra(EXTRA_REQUEST_ID)
         if (requestId == null) {
-            Log.e(TAG, "No request ID provided")
+            if (BuildConfig.DEBUG) Log.e(TAG, "No request ID provided")
             finish()
             return
         }
 
         val pendingApproval = BunkerService.getPendingApproval(requestId!!)
         if (pendingApproval == null) {
-            Log.e(TAG, "No pending approval found for $requestId")
+            if (BuildConfig.DEBUG) Log.e(TAG, "No pending approval found for $requestId")
             finish()
             return
         }
@@ -91,7 +92,7 @@ class Nip46ApprovalActivity : FragmentActivity() {
 
         lifecycleScope.launch {
             val cipher = runCatching { keystoreStorage.getCipherForDecryption() }
-                .onFailure { Log.e(TAG, "Failed to get cipher: ${it::class.simpleName}") }
+                .onFailure { if (BuildConfig.DEBUG) Log.e(TAG, "Failed to get cipher: ${it::class.simpleName}") }
                 .getOrNull()
 
             if (cipher == null) {
@@ -105,7 +106,7 @@ class Nip46ApprovalActivity : FragmentActivity() {
                     title = "Approve NIP-46 Request",
                     subtitle = "Authenticate to sign"
                 )
-            }.onFailure { Log.e(TAG, "Biometric auth failed: ${it::class.simpleName}") }
+            }.onFailure { if (BuildConfig.DEBUG) Log.e(TAG, "Biometric auth failed: ${it::class.simpleName}") }
                 .getOrNull()
 
             if (authedCipher == null) {

--- a/app/src/main/kotlin/io/privkey/keep/nip55/AppPermissionsScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/AppPermissionsScreen.kt
@@ -3,6 +3,7 @@ package io.privkey.keep.nip55
 import android.graphics.drawable.Drawable
 import android.widget.Toast
 import androidx.compose.foundation.Image
+import io.privkey.keep.BuildConfig
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -55,7 +56,7 @@ fun AppPermissionsScreen(
             val pm = context.packageManager
             val pkgHash = packageName.hashCode().toString(16).takeLast(8)
             val appInfo = runCatching { pm.getApplicationInfo(packageName, 0) }
-                .onFailure { android.util.Log.e("AppPermissions", "Failed to verify app package [hash:$pkgHash]", it) }
+                .onFailure { if (BuildConfig.DEBUG) android.util.Log.e("AppPermissions", "Failed to verify app package [hash:$pkgHash]", it) }
                 .getOrNull()
 
             val label = appInfo?.let { pm.getApplicationLabel(it).toString() }
@@ -63,12 +64,12 @@ fun AppPermissionsScreen(
             val verified = appInfo != null
 
             val permissions = runCatching { permissionStore.getPermissionsForCaller(packageName) }
-                .onFailure { android.util.Log.e("AppPermissions", "Failed to load permissions [hash:$pkgHash]", it) }
+                .onFailure { if (BuildConfig.DEBUG) android.util.Log.e("AppPermissions", "Failed to load permissions [hash:$pkgHash]", it) }
                 .getOrDefault(emptyList())
 
             val loadedSettings = permissionStore.getAppSettings(packageName)
             val signPolicyOverride = runCatching { permissionStore.getAppSignPolicyOverride(packageName) }
-                .onFailure { android.util.Log.e("AppPermissions", "Failed to load sign policy [hash:$pkgHash]", it) }
+                .onFailure { if (BuildConfig.DEBUG) android.util.Log.e("AppPermissions", "Failed to load sign policy [hash:$pkgHash]", it) }
                 .getOrNull()
 
             Pair(AppState(label, icon, verified, permissions, signPolicyOverride, isLoading = false), loadedSettings)
@@ -165,7 +166,7 @@ fun AppPermissionsScreen(
                                             }
                                             appState = appState.copy(signPolicyOverride = newOverride)
                                         } catch (e: Exception) {
-                                            android.util.Log.e("AppPermissions", "Failed to update sign policy", e)
+                                            if (BuildConfig.DEBUG) android.util.Log.e("AppPermissions", "Failed to update sign policy", e)
                                             Toast.makeText(context, "Failed to update sign policy", Toast.LENGTH_SHORT).show()
                                         }
                                     }
@@ -224,7 +225,7 @@ fun AppPermissionsScreen(
                                     appState = appState.copy(permissions = newPermissions)
                                     updateError = null
                                 } catch (e: Exception) {
-                                    android.util.Log.e("AppPermissions", "Failed to update permission", e)
+                                    if (BuildConfig.DEBUG) android.util.Log.e("AppPermissions", "Failed to update permission", e)
                                     updateError = "Failed to update permission"
                                 }
                             }
@@ -242,7 +243,7 @@ fun AppPermissionsScreen(
                                     appState = appState.copy(permissions = newPermissions)
                                     if (newPermissions.isEmpty()) onDismiss()
                                 } catch (e: Exception) {
-                                    android.util.Log.e("AppPermissions", "Failed to revoke permission", e)
+                                    if (BuildConfig.DEBUG) android.util.Log.e("AppPermissions", "Failed to revoke permission", e)
                                     Toast.makeText(context, "Failed to revoke permission", Toast.LENGTH_SHORT).show()
                                 }
                             }

--- a/app/src/main/kotlin/io/privkey/keep/nip55/ConnectedAppsScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/ConnectedAppsScreen.kt
@@ -4,6 +4,7 @@ import android.content.pm.PackageManager
 import android.graphics.drawable.Drawable
 import android.util.Log
 import androidx.compose.foundation.Image
+import io.privkey.keep.BuildConfig
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -46,8 +47,8 @@ fun ConnectedAppsScreen(
         try {
             connectedApps = withContext(Dispatchers.IO) { permissionStore.getConnectedApps() }
         } catch (e: Exception) {
-            Log.e("ConnectedApps", "Failed to load connected apps", e)
-            loadError = e.message ?: "Failed to load connected apps"
+            if (BuildConfig.DEBUG) Log.e("ConnectedApps", "Failed to load connected apps", e)
+            loadError = "Failed to load connected apps"
         }
         isLoading = false
     }
@@ -152,7 +153,7 @@ private fun ConnectedAppItem(
                     verified = true
                 )
             } catch (e: PackageManager.NameNotFoundException) {
-                Log.w("ConnectedApps", "Package not found")
+                if (BuildConfig.DEBUG) Log.w("ConnectedApps", "Package not found")
                 AppInfoResult(label = null, icon = null, verified = false)
             }
         }

--- a/app/src/main/kotlin/io/privkey/keep/nip55/Nip55Activity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/Nip55Activity.kt
@@ -82,7 +82,7 @@ class Nip55Activity : FragmentActivity() {
 
         identifyCaller(intent)
         if (callerPackage == null) {
-            Log.w(TAG, "Rejecting request from unverified caller")
+            if (BuildConfig.DEBUG) Log.w(TAG, "Rejecting request from unverified caller")
             return finishWithError("unknown_caller")
         }
 
@@ -219,7 +219,7 @@ class Nip55Activity : FragmentActivity() {
                 callerPendingFirstUse = false
                 callerVerified = true
             } else {
-                Log.w(TAG, "Trust persistence skipped: verification store unavailable")
+                if (BuildConfig.DEBUG) Log.w(TAG, "Trust persistence skipped: verification store unavailable")
             }
         }
 
@@ -258,7 +258,7 @@ class Nip55Activity : FragmentActivity() {
         }
 
         val cipher = runCatching { keystoreStorage.getCipherForDecryption() }
-            .onFailure { Log.e(TAG, "Failed to get cipher: ${it::class.simpleName}") }
+            .onFailure { if (BuildConfig.DEBUG) Log.e(TAG, "Failed to get cipher: ${it::class.simpleName}") }
             .getOrNull()
 
         if (cipher == null) {
@@ -272,7 +272,7 @@ class Nip55Activity : FragmentActivity() {
                 title = "Approve Request",
                 subtitle = req.requestType.displayName()
             )
-        }.onFailure { Log.e(TAG, "Biometric authentication failed: ${it::class.simpleName}") }
+        }.onFailure { if (BuildConfig.DEBUG) Log.e(TAG, "Biometric authentication failed: ${it::class.simpleName}") }
             .getOrNull()
 
         if (authedCipher == null) {

--- a/app/src/main/kotlin/io/privkey/keep/nip55/Nip55ContentProvider.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/Nip55ContentProvider.kt
@@ -243,7 +243,7 @@ class Nip55ContentProvider : ContentProvider() {
                     runWithTimeout { store.logOperation(callerPackage, requestType, eventKind, "allow", wasAutomatic = true) }
                     showBackgroundSigningNotification(callerPackage, requestType, eventKind)
                 }.onFailure { e ->
-                    Log.e(TAG, "Post-success side effects failed: ${e::class.simpleName}")
+                    if (BuildConfig.DEBUG) Log.e(TAG, "Post-success side effects failed: ${e::class.simpleName}")
                 }
             }
             .map { response ->
@@ -253,7 +253,7 @@ class Nip55ContentProvider : ContentProvider() {
                 cursor
             }
             .getOrElse { e ->
-                Log.e(TAG, "Background request failed: ${e::class.simpleName}")
+                if (BuildConfig.DEBUG) Log.e(TAG, "Background request failed: ${e::class.simpleName}")
                 errorCursor(GENERIC_ERROR_MESSAGE, id)
             }
     }

--- a/app/src/main/kotlin/io/privkey/keep/storage/PinStore.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/PinStore.kt
@@ -6,6 +6,7 @@ import android.os.SystemClock
 import android.util.Base64
 import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
+import io.privkey.keep.BuildConfig
 import androidx.security.crypto.MasterKey
 import java.security.MessageDigest
 import java.security.SecureRandom
@@ -304,7 +305,7 @@ class PinStore(context: Context) {
         }
 
         if (!editor.commit()) {
-            Log.e("PinStore", "Failed to persist lockout state")
+            if (BuildConfig.DEBUG) Log.e("PinStore", "Failed to persist lockout state")
         }
     }
 

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="database" path="." />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="database" path="." />
+    </device-transfer>
+</data-extraction-rules>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
## Summary
- **#71**: Use `SystemClock.elapsedRealtime()` for permission expiry to prevent clock manipulation attacks
- **#70**: Gate all exception logging behind `BuildConfig.DEBUG` to prevent leaking implementation details
- **#68**: Add data extraction rules to prevent backup of sensitive data on Android 12+
- **#67**: Add network security config to disable cleartext traffic

## Test plan
- [ ] Verify permissions expire correctly using monotonic time
- [ ] Verify no exception details logged in release builds
- [ ] Verify app installs and runs on Android 12+
- [ ] Verify HTTPS connections work, cleartext blocked

Closes #67, #68, #70, #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new permission decision option for granular control

* **Bug Fixes**
  * Improved reliability of permission expiry timestamps by using monotonic clock instead of system time
  * Fixed potential issues with clock adjustments affecting permission logic

* **Security**
  * Added network security configuration to restrict cleartext traffic
  * Added data extraction rules to protect stored data

* **Improvements**
  * Reduced diagnostic logs in production builds for cleaner output
  * Enhanced test infrastructure for time-dependent features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->