### PR TITLE
Add FLAG_SECURE to PinUnlockScreen and reduce clipboard timeout

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/PinUnlockScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/PinUnlockScreen.kt
@@ -24,18 +24,16 @@ fun PinUnlockScreen(
     onUnlocked: () -> Unit,
     onBiometricFallback: (() -> Unit)? = null
 ) {
-    val context = LocalContext.current
     var pinInput by remember { mutableStateOf("") }
     var error by remember { mutableStateOf<String?>(null) }
     var isLockedOut by remember { mutableStateOf(pinStore.isLockedOut()) }
     var lockoutRemaining by remember { mutableStateOf(pinStore.getLockoutRemainingMs()) }
     val focusRequester = remember { FocusRequester() }
+    val context = LocalContext.current
 
-    DisposableEffect(Unit) {
+    DisposableEffect(context) {
         setSecureScreen(context, true)
-        onDispose {
-            setSecureScreen(context, false)
-        }
+        onDispose { setSecureScreen(context, false) }
     }
 
     LaunchedEffect(isLockedOut) {

--- a/app/src/main/kotlin/io/privkey/keep/QrCodeDisplay.kt
+++ b/app/src/main/kotlin/io/privkey/keep/QrCodeDisplay.kt
@@ -295,11 +295,11 @@ private fun generateQrCode(content: String): Bitmap? {
 private object ClipboardClearManager {
     private val handler = Handler(Looper.getMainLooper())
     private var pendingClear: Runnable? = null
-    private var clipboardRef: java.lang.ref.WeakReference<ClipboardManager>? = null
+    private var clipboardRef: WeakReference<ClipboardManager>? = null
 
     fun scheduleClear(clipboard: ClipboardManager, delayMs: Long) {
         pendingClear?.let { handler.removeCallbacks(it) }
-        clipboardRef = java.lang.ref.WeakReference(clipboard)
+        clipboardRef = WeakReference(clipboard)
         val runnable = Runnable {
             pendingClear = null
             clipboardRef?.get()?.let { cb ->
@@ -390,7 +390,13 @@ private fun Context.findActivity(): Activity? {
 }
 
 internal fun setSecureScreen(context: Context, secure: Boolean) {
-    val activity = context.findActivity() ?: return
+    val activity = context.findActivity()
+    if (activity == null) {
+        if (BuildConfig.DEBUG) {
+            android.util.Log.w("SecureScreen", "setSecureScreen called with non-Activity context: ${context.javaClass.name}")
+        }
+        return
+    }
     if (secure) {
         SecureScreenManager.acquire(activity)
     } else {


### PR DESCRIPTION
- Add FLAG_SECURE to prevent screenshots of PIN entry
- Reduce clipboard clear timeout from 10s to 2s
- Add reference counting to SecureScreenManager

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lifecycle-controlled secure-screen protection for PIN unlock and QR code screens, ensuring screens remain protected while active.
  * Centralized secure-screen management to reliably enable/disable protection across screens.

* **Bug Fixes**
  * Reduced QR code clipboard auto-clear delay from 10s to 5s for faster cleanup.

* **Refactor**
  * Consolidated secure-screen handling for improved reliability and main-thread safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->