### PR TITLE
Add comprehensive monotonic clock expiry tests

### DIFF
--- a/app/src/androidTest/kotlin/io/privkey/keep/nip55/PermissionDatabaseIntegrationTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/nip55/PermissionDatabaseIntegrationTest.kt
@@ -21,6 +21,58 @@ class PermissionDatabaseIntegrationTest {
     private lateinit var auditLogDao: Nip55AuditLogDao
     private lateinit var appSettingsDao: Nip55AppSettingsDao
 
+    private fun createPermission(
+        callerPackage: String = "com.test.app",
+        requestType: String = "SIGN_EVENT",
+        eventKind: Int = 1,
+        decision: String = "allow",
+        expiresAt: Long? = null,
+        createdAt: Long = System.currentTimeMillis(),
+        createdAtElapsed: Long = 0,
+        durationMs: Long? = null
+    ) = Nip55Permission(
+        callerPackage = callerPackage,
+        requestType = requestType,
+        eventKind = eventKind,
+        decision = decision,
+        expiresAt = expiresAt,
+        createdAt = createdAt,
+        createdAtElapsed = createdAtElapsed,
+        durationMs = durationMs
+    )
+
+    private fun createAuditLog(
+        timestamp: Long = System.currentTimeMillis(),
+        callerPackage: String = "com.test.app",
+        requestType: String = "SIGN_EVENT",
+        eventKind: Int? = 1,
+        decision: String = "allow",
+        wasAutomatic: Boolean = false
+    ) = Nip55AuditLog(
+        timestamp = timestamp,
+        callerPackage = callerPackage,
+        requestType = requestType,
+        eventKind = eventKind,
+        decision = decision,
+        wasAutomatic = wasAutomatic
+    )
+
+    private fun createAppSettings(
+        callerPackage: String,
+        expiresAt: Long? = null,
+        signPolicyOverride: Int? = null,
+        createdAt: Long = System.currentTimeMillis(),
+        createdAtElapsed: Long = 0,
+        durationMs: Long? = null
+    ) = Nip55AppSettings(
+        callerPackage = callerPackage,
+        expiresAt = expiresAt,
+        signPolicyOverride = signPolicyOverride,
+        createdAt = createdAt,
+        createdAtElapsed = createdAtElapsed,
+        durationMs = durationMs
+    )
+
     @Before
     fun setup() {
         database = Room.inMemoryDatabaseBuilder(
@@ -39,14 +91,7 @@ class PermissionDatabaseIntegrationTest {
 
     @Test
     fun insertAndRetrievePermission() = runBlocking {
-        val permission = Nip55Permission(
-            callerPackage = "com.test.app",
-            requestType = "SIGN_EVENT",
-            eventKind = 1,
-            decision = "allow",
-            expiresAt = null,
-            createdAt = System.currentTimeMillis()
-        )
+        val permission = createPermission()
         permissionDao.insertPermission(permission)
 
         val retrieved = permissionDao.getPermission("com.test.app", "SIGN_EVENT", 1)
@@ -59,14 +104,7 @@ class PermissionDatabaseIntegrationTest {
 
     @Test
     fun getPermissionWithGenericEventKind() = runBlocking {
-        val permission = Nip55Permission(
-            callerPackage = "com.test.app",
-            requestType = "GET_PUBLIC_KEY",
-            eventKind = EVENT_KIND_GENERIC,
-            decision = "allow",
-            expiresAt = null,
-            createdAt = System.currentTimeMillis()
-        )
+        val permission = createPermission(requestType = "GET_PUBLIC_KEY", eventKind = EVENT_KIND_GENERIC)
         permissionDao.insertPermission(permission)
 
         val retrieved = permissionDao.getPermission("com.test.app", "GET_PUBLIC_KEY", EVENT_KIND_GENERIC)
@@ -77,14 +115,7 @@ class PermissionDatabaseIntegrationTest {
 
     @Test
     fun updateExistingPermission() = runBlocking {
-        val permission = Nip55Permission(
-            callerPackage = "com.test.app",
-            requestType = "SIGN_EVENT",
-            eventKind = 1,
-            decision = "allow",
-            expiresAt = null,
-            createdAt = System.currentTimeMillis()
-        )
+        val permission = createPermission()
         permissionDao.insertPermission(permission)
 
         val updated = permission.copy(decision = "deny")
@@ -99,76 +130,53 @@ class PermissionDatabaseIntegrationTest {
         val now = System.currentTimeMillis()
         val nowElapsed = 100000L
 
-        val expiredByWallClock = Nip55Permission(
+        val expiredByWallClock = createPermission(
             callerPackage = "com.test.expired.wallclock",
-            requestType = "SIGN_EVENT",
-            eventKind = 1,
-            decision = "allow",
             expiresAt = now - 1000,
             createdAt = now - 2000
         )
-        val expiredByClockManipulation = Nip55Permission(
+        val expiredByClockManipulation = createPermission(
             callerPackage = "com.test.expired.manipulation",
-            requestType = "SIGN_EVENT",
-            eventKind = 1,
-            decision = "allow",
             expiresAt = now + 60000,
             createdAt = now + 120000
         )
-        val expiredByMonotonicTime = Nip55Permission(
+        val expiredByMonotonicTime = createPermission(
             callerPackage = "com.test.expired.monotonic",
-            requestType = "SIGN_EVENT",
-            eventKind = 1,
-            decision = "allow",
-            expiresAt = null,
             createdAt = now - 70000,
             createdAtElapsed = nowElapsed - 70000,
             durationMs = 60000
         )
-        val expiredByElapsedRegression = Nip55Permission(
+        val expiredByElapsedRegression = createPermission(
             callerPackage = "com.test.expired.elapsed_regression",
-            requestType = "SIGN_EVENT",
-            eventKind = 1,
-            decision = "allow",
-            expiresAt = null,
             createdAt = now,
             createdAtElapsed = nowElapsed + 50000,
             durationMs = 60000
         )
-        val validByWallClock = Nip55Permission(
+        val validByWallClock = createPermission(
             callerPackage = "com.test.valid.wallclock",
-            requestType = "SIGN_EVENT",
-            eventKind = 1,
-            decision = "allow",
             expiresAt = now + 60000,
             createdAt = now
         )
-        val validByMonotonicTime = Nip55Permission(
+        val validByMonotonicTime = createPermission(
             callerPackage = "com.test.valid.monotonic",
-            requestType = "SIGN_EVENT",
-            eventKind = 1,
-            decision = "allow",
-            expiresAt = null,
             createdAt = now,
             createdAtElapsed = nowElapsed - 10000,
             durationMs = 60000
         )
-        val permanent = Nip55Permission(
+        val permanent = createPermission(
             callerPackage = "com.test.permanent",
-            requestType = "SIGN_EVENT",
-            eventKind = 1,
-            decision = "allow",
-            expiresAt = null,
             createdAt = now
         )
 
-        permissionDao.insertPermission(expiredByWallClock)
-        permissionDao.insertPermission(expiredByClockManipulation)
-        permissionDao.insertPermission(expiredByMonotonicTime)
-        permissionDao.insertPermission(expiredByElapsedRegression)
-        permissionDao.insertPermission(validByWallClock)
-        permissionDao.insertPermission(validByMonotonicTime)
-        permissionDao.insertPermission(permanent)
+        listOf(
+            expiredByWallClock,
+            expiredByClockManipulation,
+            expiredByMonotonicTime,
+            expiredByElapsedRegression,
+            validByWallClock,
+            validByMonotonicTime,
+            permanent
+        ).forEach { permissionDao.insertPermission(it) }
 
         permissionDao.deleteExpired(now, nowElapsed)
 
@@ -183,31 +191,9 @@ class PermissionDatabaseIntegrationTest {
 
     @Test
     fun deleteForCaller() = runBlocking {
-        val now = System.currentTimeMillis()
-        permissionDao.insertPermission(Nip55Permission(
-            callerPackage = "com.test.app",
-            requestType = "SIGN_EVENT",
-            eventKind = 1,
-            decision = "allow",
-            expiresAt = null,
-            createdAt = now
-        ))
-        permissionDao.insertPermission(Nip55Permission(
-            callerPackage = "com.test.app",
-            requestType = "GET_PUBLIC_KEY",
-            eventKind = EVENT_KIND_GENERIC,
-            decision = "allow",
-            expiresAt = null,
-            createdAt = now
-        ))
-        permissionDao.insertPermission(Nip55Permission(
-            callerPackage = "com.other.app",
-            requestType = "SIGN_EVENT",
-            eventKind = 1,
-            decision = "allow",
-            expiresAt = null,
-            createdAt = now
-        ))
+        permissionDao.insertPermission(createPermission())
+        permissionDao.insertPermission(createPermission(requestType = "GET_PUBLIC_KEY", eventKind = EVENT_KIND_GENERIC))
+        permissionDao.insertPermission(createPermission(callerPackage = "com.other.app"))
 
         permissionDao.deleteForCaller("com.test.app")
 
@@ -218,16 +204,8 @@ class PermissionDatabaseIntegrationTest {
 
     @Test
     fun getDistinctCallers() = runBlocking {
-        val now = System.currentTimeMillis()
         listOf("com.app1", "com.app2", "com.app1", "com.app3").forEachIndexed { index, pkg ->
-            permissionDao.insertPermission(Nip55Permission(
-                callerPackage = pkg,
-                requestType = "SIGN_EVENT",
-                eventKind = index + 1,
-                decision = "allow",
-                expiresAt = null,
-                createdAt = now
-            ))
+            permissionDao.insertPermission(createPermission(callerPackage = pkg, eventKind = index + 1))
         }
 
         val callers = permissionDao.getDistinctCallers()
@@ -237,15 +215,7 @@ class PermissionDatabaseIntegrationTest {
 
     @Test
     fun insertAndRetrieveAuditLog() = runBlocking {
-        val log = Nip55AuditLog(
-            timestamp = System.currentTimeMillis(),
-            callerPackage = "com.test.app",
-            requestType = "SIGN_EVENT",
-            eventKind = 1,
-            decision = "allow",
-            wasAutomatic = true
-        )
-        auditLogDao.insert(log)
+        auditLogDao.insert(createAuditLog(wasAutomatic = true))
 
         val retrieved = auditLogDao.getRecent(10)
         assertEquals(1, retrieved.size)
@@ -257,14 +227,7 @@ class PermissionDatabaseIntegrationTest {
     fun auditLogPagination() = runBlocking {
         val now = System.currentTimeMillis()
         repeat(25) { i ->
-            auditLogDao.insert(Nip55AuditLog(
-                timestamp = now - i * 1000,
-                callerPackage = "com.test.app",
-                requestType = "SIGN_EVENT",
-                eventKind = i,
-                decision = "allow",
-                wasAutomatic = false
-            ))
+            auditLogDao.insert(createAuditLog(timestamp = now - i * 1000, eventKind = i))
         }
 
         val page1 = auditLogDao.getPage(10, 0)
@@ -279,30 +242,9 @@ class PermissionDatabaseIntegrationTest {
     @Test
     fun getLastUsedTime() = runBlocking {
         val now = System.currentTimeMillis()
-        auditLogDao.insert(Nip55AuditLog(
-            timestamp = now - 10000,
-            callerPackage = "com.test.app",
-            requestType = "SIGN_EVENT",
-            eventKind = 1,
-            decision = "allow",
-            wasAutomatic = false
-        ))
-        auditLogDao.insert(Nip55AuditLog(
-            timestamp = now - 5000,
-            callerPackage = "com.test.app",
-            requestType = "SIGN_EVENT",
-            eventKind = 1,
-            decision = "allow",
-            wasAutomatic = false
-        ))
-        auditLogDao.insert(Nip55AuditLog(
-            timestamp = now - 3000,
-            callerPackage = "com.test.app",
-            requestType = "SIGN_EVENT",
-            eventKind = 1,
-            decision = "deny",
-            wasAutomatic = false
-        ))
+        auditLogDao.insert(createAuditLog(timestamp = now - 10000))
+        auditLogDao.insert(createAuditLog(timestamp = now - 5000))
+        auditLogDao.insert(createAuditLog(timestamp = now - 3000, decision = "deny"))
 
         val lastUsed = auditLogDao.getLastUsedTime("com.test.app")
         assertNotNull(lastUsed)
@@ -312,22 +254,8 @@ class PermissionDatabaseIntegrationTest {
     @Test
     fun deleteOldAuditLogs() = runBlocking {
         val now = System.currentTimeMillis()
-        auditLogDao.insert(Nip55AuditLog(
-            timestamp = now - 100000,
-            callerPackage = "com.old.app",
-            requestType = "SIGN_EVENT",
-            eventKind = 1,
-            decision = "allow",
-            wasAutomatic = false
-        ))
-        auditLogDao.insert(Nip55AuditLog(
-            timestamp = now - 1000,
-            callerPackage = "com.recent.app",
-            requestType = "SIGN_EVENT",
-            eventKind = 1,
-            decision = "allow",
-            wasAutomatic = false
-        ))
+        auditLogDao.insert(createAuditLog(timestamp = now - 100000, callerPackage = "com.old.app"))
+        auditLogDao.insert(createAuditLog(timestamp = now - 1000, callerPackage = "com.recent.app"))
 
         auditLogDao.deleteOlderThan(now - 50000)
 
@@ -338,11 +266,12 @@ class PermissionDatabaseIntegrationTest {
 
     @Test
     fun insertAndRetrieveAppSettings() = runBlocking {
-        val settings = Nip55AppSettings(
+        val now = System.currentTimeMillis()
+        val settings = createAppSettings(
             callerPackage = "com.test.app",
-            expiresAt = System.currentTimeMillis() + 60000,
+            expiresAt = now + 60000,
             signPolicyOverride = 1,
-            createdAt = System.currentTimeMillis()
+            createdAt = now
         )
         appSettingsDao.insertOrUpdate(settings)
 
@@ -356,48 +285,41 @@ class PermissionDatabaseIntegrationTest {
         val now = System.currentTimeMillis()
         val nowElapsed = 100000L
 
-        appSettingsDao.insertOrUpdate(Nip55AppSettings(
-            callerPackage = "com.expired.wallclock",
-            expiresAt = now - 1000,
-            signPolicyOverride = null,
-            createdAt = now - 2000
-        ))
-        appSettingsDao.insertOrUpdate(Nip55AppSettings(
-            callerPackage = "com.expired.manipulation",
-            expiresAt = now + 60000,
-            signPolicyOverride = null,
-            createdAt = now + 120000
-        ))
-        appSettingsDao.insertOrUpdate(Nip55AppSettings(
-            callerPackage = "com.expired.monotonic",
-            expiresAt = null,
-            signPolicyOverride = null,
-            createdAt = now - 70000,
-            createdAtElapsed = nowElapsed - 70000,
-            durationMs = 60000
-        ))
-        appSettingsDao.insertOrUpdate(Nip55AppSettings(
-            callerPackage = "com.expired.elapsed_regression",
-            expiresAt = null,
-            signPolicyOverride = null,
-            createdAt = now,
-            createdAtElapsed = nowElapsed + 50000,
-            durationMs = 60000
-        ))
-        appSettingsDao.insertOrUpdate(Nip55AppSettings(
-            callerPackage = "com.valid.wallclock",
-            expiresAt = now + 60000,
-            signPolicyOverride = null,
-            createdAt = now
-        ))
-        appSettingsDao.insertOrUpdate(Nip55AppSettings(
-            callerPackage = "com.valid.monotonic",
-            expiresAt = null,
-            signPolicyOverride = null,
-            createdAt = now,
-            createdAtElapsed = nowElapsed - 10000,
-            durationMs = 60000
-        ))
+        listOf(
+            createAppSettings(
+                callerPackage = "com.expired.wallclock",
+                expiresAt = now - 1000,
+                createdAt = now - 2000
+            ),
+            createAppSettings(
+                callerPackage = "com.expired.manipulation",
+                expiresAt = now + 60000,
+                createdAt = now + 120000
+            ),
+            createAppSettings(
+                callerPackage = "com.expired.monotonic",
+                createdAt = now - 70000,
+                createdAtElapsed = nowElapsed - 70000,
+                durationMs = 60000
+            ),
+            createAppSettings(
+                callerPackage = "com.expired.elapsed_regression",
+                createdAt = now,
+                createdAtElapsed = nowElapsed + 50000,
+                durationMs = 60000
+            ),
+            createAppSettings(
+                callerPackage = "com.valid.wallclock",
+                expiresAt = now + 60000,
+                createdAt = now
+            ),
+            createAppSettings(
+                callerPackage = "com.valid.monotonic",
+                createdAt = now,
+                createdAtElapsed = nowElapsed - 10000,
+                durationMs = 60000
+            )
+        ).forEach { appSettingsDao.insertOrUpdate(it) }
 
         val expired = appSettingsDao.getExpiredPackages(now, nowElapsed)
         assertEquals(4, expired.size)
@@ -417,15 +339,7 @@ class PermissionDatabaseIntegrationTest {
 
     @Test
     fun updateDecision() = runBlocking {
-        val permission = Nip55Permission(
-            callerPackage = "com.test.app",
-            requestType = "SIGN_EVENT",
-            eventKind = 1,
-            decision = "allow",
-            expiresAt = null,
-            createdAt = System.currentTimeMillis()
-        )
-        permissionDao.insertPermission(permission)
+        permissionDao.insertPermission(createPermission())
 
         val inserted = permissionDao.getPermission("com.test.app", "SIGN_EVENT", 1)
         assertNotNull(inserted)
@@ -439,22 +353,8 @@ class PermissionDatabaseIntegrationTest {
     @Test
     fun uniqueConstraintOnPermission() = runBlocking {
         val now = System.currentTimeMillis()
-        permissionDao.insertPermission(Nip55Permission(
-            callerPackage = "com.test.app",
-            requestType = "SIGN_EVENT",
-            eventKind = 1,
-            decision = "allow",
-            expiresAt = null,
-            createdAt = now
-        ))
-        permissionDao.insertPermission(Nip55Permission(
-            callerPackage = "com.test.app",
-            requestType = "SIGN_EVENT",
-            eventKind = 1,
-            decision = "deny",
-            expiresAt = null,
-            createdAt = now + 1000
-        ))
+        permissionDao.insertPermission(createPermission(createdAt = now))
+        permissionDao.insertPermission(createPermission(decision = "deny", createdAt = now + 1000))
 
         val all = permissionDao.getAll()
         assertEquals(1, all.size)


### PR DESCRIPTION
Adds test coverage for permission expiry with monotonic clock tracking:
- Wall clock expiry
- Clock manipulation detection
- Monotonic time expiry
- Elapsed time regression detection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test helpers for creating permission, audit log, and app settings test data.
  * Replaced inline test setups with factories and expanded coverage for multiple entity scenarios.
  * Added validations for expiry and timing across wall-clock, monotonic, and elapsed-based cases.

---

Note: Internal test improvements only; no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->