### PR TITLE
Separate metadata key for non-biometric storage & Connection tested

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
@@ -82,19 +82,16 @@ class AndroidKeystoreStorage(private val context: Context) : SecureStorage {
     private fun loadMetadata(key: String): ByteArray {
         val sharePrefs = getSharePrefs(key)
         val encryptedData = sharePrefs.getString(KEY_SHARE_DATA, null)
-            ?: throw KeepMobileException.StorageNotFound()
+            ?: throw KeepMobileException.StorageException("No metadata stored")
         val ivBase64 = sharePrefs.getString(KEY_SHARE_IV, null)
-            ?: throw KeepMobileException.StorageNotFound()
+            ?: throw KeepMobileException.StorageException("No metadata stored")
         return try {
             val cipher = initCipherWithKey(getOrCreateMetadataKey(), Cipher.DECRYPT_MODE, ivBase64)
             decryptWithCipher(cipher, encryptedData)
-        } catch (_: KeepMobileException.StorageException) {
-            sharePrefs.edit().clear().apply()
-            throw KeepMobileException.StorageNotFound()
         } catch (e: Exception) {
             if (BuildConfig.DEBUG) Log.e(TAG, "Metadata key recovery: ${e::class.simpleName}", e)
             sharePrefs.edit().clear().apply()
-            throw KeepMobileException.StorageNotFound()
+            throw KeepMobileException.StorageException("No metadata stored")
         }
     }
 


### PR DESCRIPTION
## Summary
- Add non-biometric AES-256-GCM keystore key for `__keep_*` metadata, fixing connection failure when Rust core calls SecureStorage for metadata after biometric cipher is consumed
- Clean up metadata keystore alias on share deletion, add synchronized access, StrongBox backing
- Deduplicate key creation by parameterizing `getOrCreateKeyWithAlias` with `requireUserAuth`
- Handle stale metadata recovery after key deletion

## Test plan
- [x] Verify biometric prompt appears once, connection succeeds
- [x] Verify metadata (cert pins, policy, velocity) persists across app restarts
- [x] Verify share deletion clears metadata key
- [x] Verify re-initialization after share deletion recreates metadata

All tests verified on physical device (Pixel 6a, 3A111JEHN13565) with debug APK via adb logcat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added metadata storage support with separate handling and lifecycle management for metadata keys and values.

* **Bug Fixes**
  * Implemented error handling and recovery mechanisms for metadata operations to ensure graceful degradation when metadata cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->