### PR TITLE
Improve biometric and signing error messages across all flows

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/BackupRestoreScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/BackupRestoreScreen.kt
@@ -91,7 +91,12 @@ fun BackupRestoreScreen(
     }
 
     fun requireBiometricAuth(onAuthed: (authedCipher: Cipher) -> Unit) {
-        val cipher = onGetCipher()
+        val cipher = try {
+            onGetCipher()
+        } catch (e: BiometricHelper.BiometricNotReadyException) {
+            Toast.makeText(context, e.message ?: "Biometric authentication is unavailable", Toast.LENGTH_LONG).show()
+            return
+        }
         if (cipher == null) {
             Toast.makeText(context, "Authentication unavailable", Toast.LENGTH_SHORT).show()
             return

--- a/app/src/main/kotlin/io/privkey/keep/BiometricHelper.kt
+++ b/app/src/main/kotlin/io/privkey/keep/BiometricHelper.kt
@@ -126,4 +126,20 @@ class BiometricHelper(
         .build()
 
     class BiometricException(val errorCode: Int, message: String) : Exception(message)
+    class BiometricNotReadyException(message: String) : Exception(message)
+
+    companion object {
+        fun requireBiometricReady(status: BiometricStatus) {
+            val message = when (status) {
+                BiometricStatus.AVAILABLE -> return
+                BiometricStatus.NOT_ENROLLED ->
+                    "Please enroll a fingerprint or face in your device settings to use Keep"
+                BiometricStatus.NOT_AVAILABLE ->
+                    "This device does not support biometric authentication required by Keep"
+                BiometricStatus.ERROR ->
+                    "Biometric authentication is currently unavailable"
+            }
+            throw BiometricNotReadyException(message)
+        }
+    }
 }

--- a/app/src/main/kotlin/io/privkey/keep/BiometricHelper.kt
+++ b/app/src/main/kotlin/io/privkey/keep/BiometricHelper.kt
@@ -129,17 +129,19 @@ class BiometricHelper(
     class BiometricNotReadyException(message: String) : Exception(message)
 
     companion object {
+        fun getBiometricNotReadyMessage(status: BiometricStatus): String = when (status) {
+            BiometricStatus.AVAILABLE -> ""
+            BiometricStatus.NOT_ENROLLED ->
+                "Please enroll a fingerprint or face in your device settings to use Keep"
+            BiometricStatus.NOT_AVAILABLE ->
+                "This device does not support biometric authentication required by Keep"
+            BiometricStatus.ERROR ->
+                "Biometric authentication is currently unavailable"
+        }
+
         fun requireBiometricReady(status: BiometricStatus) {
-            val message = when (status) {
-                BiometricStatus.AVAILABLE -> return
-                BiometricStatus.NOT_ENROLLED ->
-                    "Please enroll a fingerprint or face in your device settings to use Keep"
-                BiometricStatus.NOT_AVAILABLE ->
-                    "This device does not support biometric authentication required by Keep"
-                BiometricStatus.ERROR ->
-                    "Biometric authentication is currently unavailable"
-            }
-            throw BiometricNotReadyException(message)
+            if (status == BiometricStatus.AVAILABLE) return
+            throw BiometricNotReadyException(getBiometricNotReadyMessage(status))
         }
     }
 }

--- a/app/src/main/kotlin/io/privkey/keep/ExportShareScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ExportShareScreen.kt
@@ -318,7 +318,12 @@ fun ExportShareScreen(
                             return@ExportInputForm
                         }
                         cipherError = null
-                        val cipher = onGetCipher()
+                        val cipher = try {
+                            onGetCipher()
+                        } catch (e: BiometricHelper.BiometricNotReadyException) {
+                            cipherError = e.message ?: "Biometric authentication is unavailable"
+                            return@ExportInputForm
+                        }
                         if (cipher == null) {
                             cipherError = "No encryption key available"
                             return@ExportInputForm

--- a/app/src/main/kotlin/io/privkey/keep/ImportNsecScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ImportNsecScreen.kt
@@ -192,9 +192,11 @@ fun ImportNsecScreen(
                     } catch (e: KeyPermanentlyInvalidatedException) {
                         if (BuildConfig.DEBUG) Log.e("ImportNsec", "Biometric key invalidated: ${e::class.simpleName}")
                         onError("Biometric key invalidated. Please re-enroll biometrics.")
+                    } catch (e: BiometricHelper.BiometricNotReadyException) {
+                        onError(e.message ?: "Biometric authentication is unavailable")
                     } catch (e: Exception) {
                         if (BuildConfig.DEBUG) Log.e("ImportNsec", "Failed to initialize cipher: ${e::class.simpleName}: ${e.message}", e)
-                        onError(e.message ?: "Failed to initialize encryption")
+                        onError("Failed to initialize encryption")
                     }
                 }
             )

--- a/app/src/main/kotlin/io/privkey/keep/ImportNsecScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ImportNsecScreen.kt
@@ -194,7 +194,7 @@ fun ImportNsecScreen(
                         onError("Biometric key invalidated. Please re-enroll biometrics.")
                     } catch (e: Exception) {
                         if (BuildConfig.DEBUG) Log.e("ImportNsec", "Failed to initialize cipher: ${e::class.simpleName}: ${e.message}", e)
-                        onError("Failed to initialize encryption")
+                        onError(e.message ?: "Failed to initialize encryption")
                     }
                 }
             )

--- a/app/src/main/kotlin/io/privkey/keep/ImportNsecScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ImportNsecScreen.kt
@@ -193,7 +193,7 @@ fun ImportNsecScreen(
                         if (BuildConfig.DEBUG) Log.e("ImportNsec", "Biometric key invalidated: ${e::class.simpleName}")
                         onError("Biometric key invalidated. Please re-enroll biometrics.")
                     } catch (e: BiometricHelper.BiometricNotReadyException) {
-                        onError(e.message?.trim()?.takeIf { it.isNotBlank() } ?: "Biometric authentication is unavailable")
+                        onError(e.message ?: "Biometric authentication is unavailable")
                     } catch (e: Exception) {
                         if (BuildConfig.DEBUG) Log.e("ImportNsec", "Failed to initialize cipher: ${e::class.simpleName}: ${e.message}", e)
                         onError("Failed to initialize encryption")

--- a/app/src/main/kotlin/io/privkey/keep/ImportNsecScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ImportNsecScreen.kt
@@ -193,7 +193,7 @@ fun ImportNsecScreen(
                         if (BuildConfig.DEBUG) Log.e("ImportNsec", "Biometric key invalidated: ${e::class.simpleName}")
                         onError("Biometric key invalidated. Please re-enroll biometrics.")
                     } catch (e: BiometricHelper.BiometricNotReadyException) {
-                        onError(e.message ?: "Biometric authentication is unavailable")
+                        onError(e.message?.trim()?.takeIf { it.isNotBlank() } ?: "Biometric authentication is unavailable")
                     } catch (e: Exception) {
                         if (BuildConfig.DEBUG) Log.e("ImportNsec", "Failed to initialize cipher: ${e::class.simpleName}: ${e.message}", e)
                         onError("Failed to initialize encryption")

--- a/app/src/main/kotlin/io/privkey/keep/ImportShareScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ImportShareScreen.kt
@@ -258,10 +258,13 @@ fun ImportShareScreen(
                     clearChars()
                     if (BuildConfig.DEBUG) Log.e("ImportShare", "Biometric key invalidated during cipher init: ${e::class.simpleName}")
                     onError("Biometric key invalidated. Please re-enroll biometrics.")
+                } catch (e: BiometricHelper.BiometricNotReadyException) {
+                    clearChars()
+                    onError(e.message ?: "Biometric authentication is unavailable")
                 } catch (e: Exception) {
                     clearChars()
                     if (BuildConfig.DEBUG) Log.e("ImportShare", "Failed to initialize cipher for biometric auth: ${e::class.simpleName}")
-                    onError(e.message ?: "Failed to initialize encryption")
+                    onError("Failed to initialize encryption")
                 }
             }
         )

--- a/app/src/main/kotlin/io/privkey/keep/ImportShareScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ImportShareScreen.kt
@@ -260,7 +260,7 @@ fun ImportShareScreen(
                     onError("Biometric key invalidated. Please re-enroll biometrics.")
                 } catch (e: BiometricHelper.BiometricNotReadyException) {
                     clearChars()
-                    onError(e.message ?: "Biometric authentication is unavailable")
+                    onError(e.message?.trim()?.takeIf { it.isNotBlank() } ?: "Biometric authentication is unavailable")
                 } catch (e: Exception) {
                     clearChars()
                     if (BuildConfig.DEBUG) Log.e("ImportShare", "Failed to initialize cipher for biometric auth: ${e::class.simpleName}")

--- a/app/src/main/kotlin/io/privkey/keep/ImportShareScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ImportShareScreen.kt
@@ -260,7 +260,7 @@ fun ImportShareScreen(
                     onError("Biometric key invalidated. Please re-enroll biometrics.")
                 } catch (e: BiometricHelper.BiometricNotReadyException) {
                     clearChars()
-                    onError(e.message?.trim()?.takeIf { it.isNotBlank() } ?: "Biometric authentication is unavailable")
+                    onError(e.message ?: "Biometric authentication is unavailable")
                 } catch (e: Exception) {
                     clearChars()
                     if (BuildConfig.DEBUG) Log.e("ImportShare", "Failed to initialize cipher for biometric auth: ${e::class.simpleName}")

--- a/app/src/main/kotlin/io/privkey/keep/ImportShareScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ImportShareScreen.kt
@@ -261,7 +261,7 @@ fun ImportShareScreen(
                 } catch (e: Exception) {
                     clearChars()
                     if (BuildConfig.DEBUG) Log.e("ImportShare", "Failed to initialize cipher for biometric auth: ${e::class.simpleName}")
-                    onError("Failed to initialize encryption")
+                    onError(e.message ?: "Failed to initialize encryption")
                 }
             }
         )

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -737,7 +737,7 @@ fun MainScreen(
                                     getShareAwareCipher(storage)
                                 }
                             } catch (e: BiometricHelper.BiometricNotReadyException) {
-                                Toast.makeText(appContext, e.message, Toast.LENGTH_LONG).show()
+                                Toast.makeText(appContext, e.message ?: "Biometric authentication is unavailable", Toast.LENGTH_LONG).show()
                                 return@launch
                             }
                             if (cipher == null) {

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -626,7 +626,10 @@ fun MainScreen(
             onImport = { data, passphrase, name, cipher ->
                 accountActions.importShare(data, passphrase, name, cipher) { importState = it }
             },
-            onGetCipher = { storage.getCipherForEncryption() },
+            onGetCipher = {
+                if (!biometricAvailable) throw IllegalStateException("Please enroll a fingerprint or face in your device settings to use Keep")
+                storage.getCipherForEncryption()
+            },
             onBiometricAuth = { cipher, callback ->
                 onBiometricRequest("Import Share", "Authenticate to store share securely", cipher, callback)
             },
@@ -644,7 +647,10 @@ fun MainScreen(
             onImport = { nsec, name, cipher ->
                 accountActions.importNsec(nsec, name, cipher) { importState = it }
             },
-            onGetCipher = { storage.getCipherForEncryption() },
+            onGetCipher = {
+                if (!biometricAvailable) throw IllegalStateException("Please enroll a fingerprint or face in your device settings to use Keep")
+                storage.getCipherForEncryption()
+            },
             onBiometricAuth = { cipher, callback ->
                 onBiometricRequest("Import nsec", "Authenticate to store key securely", cipher, callback)
             },

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -88,12 +88,13 @@ class MainActivity : FragmentActivity() {
                 mutableStateOf(pinStore?.isSessionValid() ?: true)
             }
 
-            var biometricAvailable by remember {
+            var biometricStatus by remember {
                 mutableStateOf(
-                    biometricHelper?.checkBiometricStatus() ==
-                        BiometricHelper.BiometricStatus.AVAILABLE
+                    biometricHelper?.checkBiometricStatus()
+                        ?: BiometricHelper.BiometricStatus.NOT_AVAILABLE
                 )
             }
+            val biometricAvailable = biometricStatus == BiometricHelper.BiometricStatus.AVAILABLE
 
             var isBiometricUnlocked by remember {
                 val lockOnLaunch = biometricAvailable &&
@@ -105,8 +106,8 @@ class MainActivity : FragmentActivity() {
                 val observer = LifecycleEventObserver { _, event ->
                     if (event == Lifecycle.Event.ON_RESUME) {
                         isPinUnlocked = pinStore?.isSessionValid() ?: true
-                        biometricAvailable = biometricHelper?.checkBiometricStatus() ==
-                            BiometricHelper.BiometricStatus.AVAILABLE
+                        biometricStatus = biometricHelper?.checkBiometricStatus()
+                            ?: BiometricHelper.BiometricStatus.NOT_AVAILABLE
                         if (biometricAvailable &&
                             biometricTimeoutStore?.isLockOnLaunchEnabled() == true &&
                             biometricTimeoutStore.requiresBiometric()) {
@@ -173,7 +174,7 @@ class MainActivity : FragmentActivity() {
                             permissionStore = safePermissionStore,
                             securityLevel = safeStorage.getSecurityLevel(),
                             lifecycleOwner = this@MainActivity,
-                            biometricAvailable = biometricAvailable,
+                            biometricStatus = biometricStatus,
                             onRelaysChanged = { relays ->
                                 lifecycleScope.launch { app.initializeWithRelays(relays) }
                             },
@@ -248,7 +249,7 @@ fun MainScreen(
     onRelaysChanged: (List<String>) -> Unit,
     onConnect: (Cipher, (Boolean, String?) -> Unit) -> Unit,
     onBiometricRequest: (String, String, Cipher, (Cipher?) -> Unit) -> Unit,
-    biometricAvailable: Boolean = false,
+    biometricStatus: BiometricHelper.BiometricStatus = BiometricHelper.BiometricStatus.NOT_AVAILABLE,
     onBiometricAuth: (suspend () -> Boolean)? = null,
     onAutoStartChanged: (Boolean) -> Unit = {},
     onForegroundServiceChanged: (Boolean) -> Unit = {},
@@ -260,6 +261,8 @@ fun MainScreen(
     onAccountSwitched: suspend () -> Unit = {}
 ) {
     val appContext = LocalContext.current.applicationContext
+    val biometricAvailable = biometricStatus == BiometricHelper.BiometricStatus.AVAILABLE
+    val requireBiometricReady = { BiometricHelper.requireBiometricReady(biometricStatus) }
     var hasShare by remember { mutableStateOf(keepMobile.hasShare()) }
     var shareInfo by remember { mutableStateOf(keepMobile.getShareInfo()) }
     var allAccounts by remember { mutableStateOf<List<AccountInfo>>(emptyList()) }
@@ -483,7 +486,7 @@ fun MainScreen(
         BackupRestoreScreen(
             keepMobile = keepMobile,
             storage = storage,
-            onGetCipher = { getShareAwareCipher(storage) },
+            onGetCipher = { requireBiometricReady(); getShareAwareCipher(storage) },
             onBiometricAuth = { cipher, callback ->
                 onBiometricRequest("Vault Backup", "Authenticate to access backup", cipher, callback)
             },
@@ -497,7 +500,7 @@ fun MainScreen(
             keepMobile = keepMobile,
             storage = storage,
             shareInfo = shareInfo,
-            onGetCipher = { getShareAwareCipher(storage) },
+            onGetCipher = { requireBiometricReady(); getShareAwareCipher(storage) },
             onBiometricAuth = { cipher, callback ->
                 onBiometricRequest("Recover nsec", "Authenticate to export vault share", cipher, callback)
             },
@@ -537,7 +540,7 @@ fun MainScreen(
             keepMobile = keepMobile,
             shareInfo = currentShareInfoForScreens,
             storage = storage,
-            onGetCipher = { getShareAwareCipher(storage) },
+            onGetCipher = { requireBiometricReady(); getShareAwareCipher(storage) },
             onBiometricAuth = { cipher, callback ->
                 onBiometricRequest("Export Share", "Authenticate to export share", cipher, callback)
             },
@@ -627,7 +630,7 @@ fun MainScreen(
                 accountActions.importShare(data, passphrase, name, cipher) { importState = it }
             },
             onGetCipher = {
-                if (!biometricAvailable) throw IllegalStateException("Please enroll a fingerprint or face in your device settings to use Keep")
+                requireBiometricReady()
                 storage.getCipherForEncryption()
             },
             onBiometricAuth = { cipher, callback ->
@@ -648,7 +651,7 @@ fun MainScreen(
                 accountActions.importNsec(nsec, name, cipher) { importState = it }
             },
             onGetCipher = {
-                if (!biometricAvailable) throw IllegalStateException("Please enroll a fingerprint or face in your device settings to use Keep")
+                requireBiometricReady()
                 storage.getCipherForEncryption()
             },
             onBiometricAuth = { cipher, callback ->
@@ -728,8 +731,14 @@ fun MainScreen(
                     onImportNsec = { showImportNsecScreen = true },
                     onConnect = {
                         coroutineScope.launch {
-                            val cipher = withContext(Dispatchers.IO) {
-                                getShareAwareCipher(storage)
+                            val cipher = try {
+                                requireBiometricReady()
+                                withContext(Dispatchers.IO) {
+                                    getShareAwareCipher(storage)
+                                }
+                            } catch (e: BiometricHelper.BiometricNotReadyException) {
+                                Toast.makeText(appContext, e.message, Toast.LENGTH_LONG).show()
+                                return@launch
                             }
                             if (cipher == null) {
                                 Toast.makeText(appContext, "Failed to initialize encryption", Toast.LENGTH_SHORT).show()

--- a/app/src/main/kotlin/io/privkey/keep/RecoverNsecScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/RecoverNsecScreen.kt
@@ -195,7 +195,12 @@ fun RecoverNsecScreen(
         if (shareInfo != null && !vaultSlotPopulated) {
             OutlinedButton(
                 onClick = {
-                    val cipher = onGetCipher()
+                    val cipher = try {
+                        onGetCipher()
+                    } catch (e: BiometricHelper.BiometricNotReadyException) {
+                        recoveryState = RecoveryState.Error(e.message ?: "Biometric authentication is unavailable")
+                        return@OutlinedButton
+                    }
                     if (cipher == null) {
                         recoveryState = RecoveryState.Error("No encryption key available")
                         return@OutlinedButton

--- a/app/src/main/kotlin/io/privkey/keep/nip46/Nip46ApprovalActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip46/Nip46ApprovalActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.lifecycleScope
+import android.widget.Toast
 import io.privkey.keep.BiometricHelper
 import io.privkey.keep.BuildConfig
 import io.privkey.keep.KeepMobileApp
@@ -118,6 +119,16 @@ class Nip46ApprovalActivity : FragmentActivity() {
 
         val keystoreStorage = storage
         if (keystoreStorage == null || killSwitchStore?.isEnabled() == true) {
+            if (killSwitchStore?.isEnabled() == true) {
+                Toast.makeText(this, "Signing is disabled (kill switch is active)", Toast.LENGTH_SHORT).show()
+            }
+            respond(false, null)
+            return
+        }
+
+        val status = biometricHelper.checkBiometricStatus()
+        if (status != BiometricHelper.BiometricStatus.AVAILABLE) {
+            Toast.makeText(this, BiometricHelper.getBiometricNotReadyMessage(status), Toast.LENGTH_LONG).show()
             respond(false, null)
             return
         }
@@ -128,6 +139,7 @@ class Nip46ApprovalActivity : FragmentActivity() {
                 .getOrNull()
 
             if (cipher == null) {
+                Toast.makeText(this@Nip46ApprovalActivity, "Failed to access stored keys", Toast.LENGTH_SHORT).show()
                 respond(false, null)
                 return@launch
             }

--- a/app/src/main/kotlin/io/privkey/keep/nip46/NostrConnectActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip46/NostrConnectActivity.kt
@@ -102,6 +102,9 @@ class NostrConnectActivity : FragmentActivity() {
 
         val keystoreStorage = storage
         if (keystoreStorage == null || killSwitchStore?.isEnabled() == true) {
+            if (killSwitchStore?.isEnabled() == true) {
+                Toast.makeText(this, "Signing is disabled (kill switch is active)", Toast.LENGTH_SHORT).show()
+            }
             onComplete(false)
             finish()
             return

--- a/app/src/main/kotlin/io/privkey/keep/nip46/NostrConnectActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip46/NostrConnectActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
+import android.widget.Toast
 import android.view.WindowManager
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
@@ -59,6 +60,7 @@ class NostrConnectActivity : FragmentActivity() {
         }
 
         if (killSwitchStore?.isEnabled() == true) {
+            Toast.makeText(this, "Signing is disabled (kill switch is active)", Toast.LENGTH_SHORT).show()
             finish()
             return
         }
@@ -105,12 +107,21 @@ class NostrConnectActivity : FragmentActivity() {
             return
         }
 
+        val status = biometricHelper.checkBiometricStatus()
+        if (status != BiometricHelper.BiometricStatus.AVAILABLE) {
+            Toast.makeText(this, BiometricHelper.getBiometricNotReadyMessage(status), Toast.LENGTH_LONG).show()
+            onComplete(false)
+            finish()
+            return
+        }
+
         lifecycleScope.launch {
             val cipher = runCatching { keystoreStorage.getCipherForDecryption() }
                 .onFailure { if (BuildConfig.DEBUG) Log.e(TAG, "Failed to get cipher: ${it::class.simpleName}") }
                 .getOrNull()
 
             if (cipher == null) {
+                Toast.makeText(this@NostrConnectActivity, "Failed to access stored keys", Toast.LENGTH_SHORT).show()
                 onComplete(false)
                 finish()
                 return@launch

--- a/app/src/main/kotlin/io/privkey/keep/nip55/Nip55Activity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/Nip55Activity.kt
@@ -54,7 +54,6 @@ class Nip55Activity : FragmentActivity() {
     companion object {
         private const val TAG = "Nip55Activity"
         private val signingDispatcher = Dispatchers.Default.limitedParallelism(1)
-        private const val GENERIC_ERROR_MESSAGE = "An error occurred"
         private const val MAX_CONTENT_LENGTH = 1024 * 1024
         private const val MAX_PUBKEY_LENGTH = 128
         private const val MAX_EXTRA_LENGTH = 2048
@@ -379,6 +378,12 @@ class Nip55Activity : FragmentActivity() {
             return false
         }
 
+        val status = biometricHelper.checkBiometricStatus()
+        if (status != BiometricHelper.BiometricStatus.AVAILABLE) {
+            finishWithError("biometric_not_ready")
+            return false
+        }
+
         val cipher = runCatching { keystoreStorage.getCipherForDecryption() }
             .onFailure { if (BuildConfig.DEBUG) Log.e(TAG, "Failed to get cipher: ${it::class.simpleName}") }
             .getOrNull()
@@ -413,6 +418,8 @@ class Nip55Activity : FragmentActivity() {
 
         if (app.liveState != null) return true
 
+        if (biometricHelper.checkBiometricStatus() != BiometricHelper.BiometricStatus.AVAILABLE) return false
+
         val cipher = runCatching { keystoreStorage.getCipherForDecryption() }
             .getOrNull() ?: return false
 
@@ -435,6 +442,27 @@ class Nip55Activity : FragmentActivity() {
         } finally {
             keystoreStorage.clearPendingCipher(initId)
         }
+    }
+
+    private fun mapErrorToUserMessage(error: String): String = when (error) {
+        "signing_disabled" -> "Signing is disabled (kill switch is active)"
+        "locked" -> "Keep is locked, please unlock it first"
+        "unknown_caller" -> "Request from unverified app"
+        "Storage unavailable" -> "Key storage is not available"
+        "Storage error" -> "Failed to access stored keys"
+        "No share stored" -> "No key is stored in Keep"
+        "Authentication failed" -> "Biometric authentication failed"
+        "biometric_not_ready" -> BiometricHelper.getBiometricNotReadyMessage(
+            biometricHelper.checkBiometricStatus()
+        )
+        "request_failed" -> "Request failed"
+        "rate_limited" -> "Too many requests, please try again later"
+        "not_initialized" -> "Keep is not connected to the network"
+        "pubkey_mismatch" -> "Public key does not match the stored key"
+        "invalid_timestamp" -> "Request has an invalid timestamp"
+        "pubkey_verification_failed" -> "Public key verification failed"
+        "Node initialization failed" -> "Failed to connect to network"
+        else -> error
     }
 
     private fun mapExceptionToError(e: Throwable): String = when (e) {
@@ -503,7 +531,7 @@ class Nip55Activity : FragmentActivity() {
             Log.e(TAG, "NIP-55 request failed: $error$idSuffix")
         }
         val resultIntent = Intent().apply {
-            putExtra("error", GENERIC_ERROR_MESSAGE)
+            putExtra("error", mapErrorToUserMessage(error))
         }
         setResult(RESULT_CANCELED, resultIntent)
         finish()

--- a/app/src/main/kotlin/io/privkey/keep/nip55/Nip55Activity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/Nip55Activity.kt
@@ -317,8 +317,14 @@ class Nip55Activity : FragmentActivity() {
             val currentApp = application as? KeepMobileApp
 
             if (keystoreStorage != null && currentApp != null && req.requestType != Nip55RequestType.GET_PUBLIC_KEY) {
-                if (!initializeNodeIfNeeded(keystoreStorage, currentApp)) {
-                    finishWithError("Node initialization failed")
+                try {
+                    val initError = initializeNodeIfNeeded(keystoreStorage, currentApp)
+                    if (initError != null) {
+                        finishWithError("Node initialization failed", initError)
+                        return@launch
+                    }
+                } catch (e: BiometricHelper.BiometricNotReadyException) {
+                    finishWithError("biometric_not_ready", e.message)
                     return@launch
                 }
             }
@@ -378,9 +384,9 @@ class Nip55Activity : FragmentActivity() {
             return false
         }
 
-        val status = biometricHelper.checkBiometricStatus()
-        if (status != BiometricHelper.BiometricStatus.AVAILABLE) {
-            finishWithError("biometric_not_ready")
+        val biometricStatus = biometricHelper.checkBiometricStatus()
+        if (biometricStatus != BiometricHelper.BiometricStatus.AVAILABLE) {
+            finishWithError("biometric_not_ready", BiometricHelper.getBiometricNotReadyMessage(biometricStatus))
             return false
         }
 
@@ -412,16 +418,16 @@ class Nip55Activity : FragmentActivity() {
         return true
     }
 
-    private suspend fun initializeNodeIfNeeded(keystoreStorage: AndroidKeystoreStorage, app: KeepMobileApp): Boolean {
-        val mobile = app.getKeepMobile() ?: return false
-        if (!mobile.hasShare()) return false
+    private suspend fun initializeNodeIfNeeded(keystoreStorage: AndroidKeystoreStorage, app: KeepMobileApp): String? {
+        val mobile = app.getKeepMobile() ?: return "No key is stored in Keep"
+        if (!mobile.hasShare()) return "No key is stored in Keep"
 
-        if (app.liveState != null) return true
+        if (app.liveState != null) return null
 
-        if (biometricHelper.checkBiometricStatus() != BiometricHelper.BiometricStatus.AVAILABLE) return false
+        BiometricHelper.requireBiometricReady(biometricHelper.checkBiometricStatus())
 
         val cipher = runCatching { keystoreStorage.getCipherForDecryption() }
-            .getOrNull() ?: return false
+            .getOrNull() ?: return "Failed to access stored keys"
 
         val authedCipher = runCatching {
             biometricHelper.authenticateWithCrypto(
@@ -429,16 +435,16 @@ class Nip55Activity : FragmentActivity() {
                 title = "Connect to Network",
                 subtitle = "Authenticate to enable signing"
             )
-        }.getOrNull() ?: return false
+        }.getOrNull() ?: return "Authentication failed"
 
         val initId = UUID.randomUUID().toString()
         keystoreStorage.setPendingCipher(initId, authedCipher)
         return try {
             app.ensureInitialized(requestId = initId)
-            true
+            null
         } catch (e: Exception) {
             if (BuildConfig.DEBUG) Log.e(TAG, "Node initialization failed: ${e::class.simpleName}")
-            false
+            "Failed to connect to network"
         } finally {
             keystoreStorage.clearPendingCipher(initId)
         }
@@ -452,9 +458,6 @@ class Nip55Activity : FragmentActivity() {
         "Storage error" -> "Failed to access stored keys"
         "No share stored" -> "No key is stored in Keep"
         "Authentication failed" -> "Biometric authentication failed"
-        "biometric_not_ready" -> BiometricHelper.getBiometricNotReadyMessage(
-            biometricHelper.checkBiometricStatus()
-        )
         "request_failed" -> "Request failed"
         "rate_limited" -> "Too many requests, please try again later"
         "not_initialized" -> "Keep is not connected to the network"
@@ -462,7 +465,9 @@ class Nip55Activity : FragmentActivity() {
         "invalid_timestamp" -> "Request has an invalid timestamp"
         "pubkey_verification_failed" -> "Public key verification failed"
         "Node initialization failed" -> "Failed to connect to network"
-        else -> error
+        "User rejected" -> "Request was declined"
+        "biometric_not_ready" -> "Biometric authentication is currently unavailable"
+        else -> "Request failed"
     }
 
     private fun mapExceptionToError(e: Throwable): String = when (e) {
@@ -524,14 +529,14 @@ class Nip55Activity : FragmentActivity() {
         finish()
     }
 
-    private fun finishWithError(error: String) {
+    private fun finishWithError(error: String, userMessage: String? = null) {
         notificationManager?.cancelNotification(notificationRequestId)
         if (BuildConfig.DEBUG) {
             val idSuffix = requestId?.let { " (requestId=$it)" }.orEmpty()
             Log.e(TAG, "NIP-55 request failed: $error$idSuffix")
         }
         val resultIntent = Intent().apply {
-            putExtra("error", mapErrorToUserMessage(error))
+            putExtra("error", userMessage ?: mapErrorToUserMessage(error))
         }
         setResult(RESULT_CANCELED, resultIntent)
         finish()

--- a/app/src/main/kotlin/io/privkey/keep/nip55/Nip55ContentProvider.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/Nip55ContentProvider.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.ContentProvider
+import io.privkey.keep.BiometricHelper
 import android.content.ContentValues
 import android.content.Context
 import android.content.pm.PackageManager
@@ -104,7 +105,14 @@ class Nip55ContentProvider : ContentProvider() {
         selectionArgs: Array<out String>?,
         sortOrder: String?
     ): Cursor? {
-        val currentApp = app ?: return errorCursor("Keep is not initialized", null)
+        val currentApp = app ?: return errorCursor("Request denied", null)
+
+        val callerPackage = getVerifiedCaller() ?: return errorCursor("Request denied", null)
+        if (callerPackage.isBlank()) {
+            if (BuildConfig.DEBUG) Log.w(TAG, "Caller package is blank")
+            return errorCursor("Request denied", null)
+        }
+
         if (currentApp.getKillSwitchStore()?.isEnabled() == true) {
             return errorCursor("Signing is disabled (kill switch is active)", null)
         }
@@ -113,12 +121,6 @@ class Nip55ContentProvider : ContentProvider() {
         }
         val h = currentApp.getNip55Handler() ?: return errorCursor("Signing service is not available", null)
         val store = currentApp.getPermissionStore()
-
-        val callerPackage = getVerifiedCaller() ?: return errorCursor("Request from unverified app", null)
-        if (callerPackage.isBlank()) {
-            if (BuildConfig.DEBUG) Log.w(TAG, "Caller package is blank")
-            return errorCursor("Request from unverified app", null)
-        }
 
         if (!rateLimiter.checkRateLimit(callerPackage)) {
             if (BuildConfig.DEBUG) Log.w(TAG, "Rate limit exceeded for ${hashPackageName(callerPackage)}")
@@ -374,7 +376,11 @@ class Nip55ContentProvider : ContentProvider() {
             }
             .getOrElse { e ->
                 if (BuildConfig.DEBUG) Log.e(TAG, "Background request failed: ${e::class.simpleName}: ${e.message}")
-                errorCursor("Request failed", id)
+                if (e is BiometricHelper.BiometricNotReadyException) {
+                    errorCursor(e.message ?: "Biometric authentication is unavailable", id)
+                } else {
+                    errorCursor("Request failed", id)
+                }
             }
     }
 

--- a/app/src/main/kotlin/io/privkey/keep/nip55/Nip55ContentProvider.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/Nip55ContentProvider.kt
@@ -37,8 +37,6 @@ import java.util.concurrent.atomic.AtomicInteger
 class Nip55ContentProvider : ContentProvider() {
     companion object {
         private const val TAG = "Nip55ContentProvider"
-        private const val GENERIC_ERROR_MESSAGE = "An error occurred"
-
         private const val AUTHORITY_GET_PUBLIC_KEY = "io.privkey.keep.GET_PUBLIC_KEY"
         private const val AUTHORITY_SIGN_EVENT = "io.privkey.keep.SIGN_EVENT"
         private const val AUTHORITY_NIP04_ENCRYPT = "io.privkey.keep.NIP04_ENCRYPT"
@@ -106,25 +104,25 @@ class Nip55ContentProvider : ContentProvider() {
         selectionArgs: Array<out String>?,
         sortOrder: String?
     ): Cursor? {
-        val currentApp = app ?: return errorCursor(GENERIC_ERROR_MESSAGE, null)
+        val currentApp = app ?: return errorCursor("Keep is not initialized", null)
         if (currentApp.getKillSwitchStore()?.isEnabled() == true) {
-            return errorCursor(GENERIC_ERROR_MESSAGE, null)
+            return errorCursor("Signing is disabled (kill switch is active)", null)
         }
         if (currentApp.getPinStore()?.requiresAuthentication() == true) {
-            return errorCursor(GENERIC_ERROR_MESSAGE, null)
+            return errorCursor("Keep is locked, please unlock it first", null)
         }
-        val h = currentApp.getNip55Handler() ?: return errorCursor(GENERIC_ERROR_MESSAGE, null)
+        val h = currentApp.getNip55Handler() ?: return errorCursor("Signing service is not available", null)
         val store = currentApp.getPermissionStore()
 
-        val callerPackage = getVerifiedCaller() ?: return errorCursor(GENERIC_ERROR_MESSAGE, null)
+        val callerPackage = getVerifiedCaller() ?: return errorCursor("Request from unverified app", null)
         if (callerPackage.isBlank()) {
             if (BuildConfig.DEBUG) Log.w(TAG, "Caller package is blank")
-            return errorCursor(GENERIC_ERROR_MESSAGE, null)
+            return errorCursor("Request from unverified app", null)
         }
 
         if (!rateLimiter.checkRateLimit(callerPackage)) {
             if (BuildConfig.DEBUG) Log.w(TAG, "Rate limit exceeded for ${hashPackageName(callerPackage)}")
-            return errorCursor(GENERIC_ERROR_MESSAGE, null)
+            return errorCursor("Too many requests, please try again later", null)
         }
 
         val requestType = when (val authority = uri.authority) {
@@ -137,7 +135,7 @@ class Nip55ContentProvider : ContentProvider() {
             AUTHORITY_DECRYPT_ZAP_EVENT -> Nip55RequestType.DECRYPT_ZAP_EVENT
             else -> {
                 if (BuildConfig.DEBUG) Log.w(TAG, "Unexpected authority: $authority")
-                return errorCursor(GENERIC_ERROR_MESSAGE, null)
+                return errorCursor("Invalid request", null)
             }
         }
 
@@ -146,13 +144,13 @@ class Nip55ContentProvider : ContentProvider() {
         val currentUser = projection?.getOrNull(2)?.takeIf { it.isNotBlank() }
 
         if (rawContent.length > MAX_CONTENT_LENGTH)
-            return errorCursor(GENERIC_ERROR_MESSAGE, null)
+            return errorCursor("Request content is too large", null)
         if (rawPubkey != null && rawPubkey.length > MAX_PUBKEY_LENGTH)
-            return errorCursor(GENERIC_ERROR_MESSAGE, null)
+            return errorCursor("Invalid public key", null)
 
         val eventKind = if (requestType == Nip55RequestType.SIGN_EVENT) parseEventKind(rawContent)?.takeIf { it >= 0 } else null
 
-        if (store == null) return errorCursor(GENERIC_ERROR_MESSAGE, null)
+        if (store == null) return errorCursor("Permission store is not available", null)
 
         val velocityCursor = checkVelocityLimits(store, callerPackage, requestType, eventKind)
         if (velocityCursor != null) return velocityCursor
@@ -376,7 +374,7 @@ class Nip55ContentProvider : ContentProvider() {
             }
             .getOrElse { e ->
                 if (BuildConfig.DEBUG) Log.e(TAG, "Background request failed: ${e::class.simpleName}: ${e.message}")
-                errorCursor(GENERIC_ERROR_MESSAGE, id)
+                errorCursor("Request failed", id)
             }
     }
 


### PR DESCRIPTION
## Summary
- Show specific error messages when biometrics are not enrolled or unavailable, distinguishing between "not enrolled" and "no hardware"
- Centralize biometric readiness check via `BiometricHelper.requireBiometricReady()` across all cipher flows (import, backup, restore, export, connect)
- Replace generic "An error occurred" in NIP-55 activity and content provider with specific messages (kill switch active, locked, unverified app, rate limited, etc.)
- Show error toasts in NIP-46 approval and NostrConnect flows instead of silently rejecting
- Stop leaking raw exception messages to UI; use controlled messages for known exceptions and generic fallback for unknown ones

## Test plan
- [x] Test import nsec on device without biometrics enrolled, verify new error message
- [x] Test import nsec on device with biometrics enrolled, verify normal flow works
- [x] Test import share on device without biometrics enrolled, verify new error message

### Test results
Verified on Pixel 7a and Pixel 9a (arm64-v8a, debug build):
- **No biometrics enrolled**: Import nsec/share shows "Please enroll a fingerprint or face in your device settings to use Keep"
- **Biometrics enrolled**: Import nsec completes normally through biometric prompt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer, user-friendly biometric error messages when biometrics aren't ready, preventing cryptographic or export/import failures.
  * Biometric readiness checks added to multiple flows to avoid failed operations and abort gracefully.
* **New Features**
  * User-facing toast notifications for biometric status, keystore access failures, and kill‑switch conditions.
  * Error responses now surface specific user-facing messages instead of a single generic error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->