### PR TITLE
Add NIP-49 ncryptsec export for single-key shares

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: privkeyio/keep
-          ref: e06064199fc7af752d1b36174dd857a1e0411110
+          ref: 657ebbd084f3a8261bb95f764864714f525b044d
           path: keep
 
       - name: Set up JDK 17
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: privkeyio/keep
-          ref: e06064199fc7af752d1b36174dd857a1e0411110
+          ref: 657ebbd084f3a8261bb95f764864714f525b044d
           path: keep
 
       - name: Set up JDK 17

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: privkeyio/keep
-          ref: e06064199fc7af752d1b36174dd857a1e0411110
+          ref: 657ebbd084f3a8261bb95f764864714f525b044d
           path: keep
 
       - name: Set up JDK 17

--- a/app/src/main/kotlin/io/privkey/keep/ExportNcryptsecScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ExportNcryptsecScreen.kt
@@ -68,11 +68,14 @@ fun ExportNcryptsecScreen(
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
+    var exportJob by remember { mutableStateOf<Job?>(null) }
 
     DisposableEffect(lifecycleOwner) {
         setSecureScreen(context, true)
 
         fun clearSensitiveData() {
+            exportJob?.cancel()
+            exportJob = null
             password.clear()
             confirmPassword.clear()
             passwordDisplay = ""
@@ -128,11 +131,11 @@ fun ExportNcryptsecScreen(
                     confirmPasswordDisplay = confirmPasswordDisplay,
                     onPasswordChange = {
                         password.update(it)
-                        passwordDisplay = it
+                        passwordDisplay = if (password.length == it.length) it else passwordDisplay
                     },
                     onConfirmPasswordChange = {
                         confirmPassword.update(it)
-                        confirmPasswordDisplay = it
+                        confirmPasswordDisplay = if (confirmPassword.length == it.length) it else confirmPasswordDisplay
                     },
                     onExport = {
                         if (password.length < MIN_PASSWORD_LENGTH) {
@@ -166,7 +169,7 @@ fun ExportNcryptsecScreen(
                                     val exportId = java.util.UUID.randomUUID().toString()
                                     storage.setPendingCipher(exportId, authedCipher)
                                     exportState = NcryptsecExportState.Encrypting
-                                    coroutineScope.launch {
+                                    exportJob = coroutineScope.launch {
                                         currentCoroutineContext()[Job]?.invokeOnCompletion { cause ->
                                             if (cause is CancellationException) {
                                                 clearChars()
@@ -182,6 +185,11 @@ fun ExportNcryptsecScreen(
                                                     storage.clearRequestIdContext()
                                                 }
                                             }
+                                            clearChars()
+                                            password.clear()
+                                            confirmPassword.clear()
+                                            passwordDisplay = ""
+                                            confirmPasswordDisplay = ""
                                             (exportState as? NcryptsecExportState.Success)?.clear()
                                             exportState = NcryptsecExportState.Success(ncryptsec)
                                         } catch (e: Exception) {

--- a/app/src/main/kotlin/io/privkey/keep/ExportNcryptsecScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ExportNcryptsecScreen.kt
@@ -285,6 +285,15 @@ private fun PasswordStrengthIndicator(strength: PasswordStrength) {
 }
 
 @Composable
+private fun ErrorCard(message: String) {
+    StatusCard(
+        text = message,
+        containerColor = MaterialTheme.colorScheme.errorContainer,
+        contentColor = MaterialTheme.colorScheme.onErrorContainer
+    )
+}
+
+@Composable
 private fun NcryptsecInputForm(
     errorMessage: String?,
     cipherError: String?,
@@ -312,20 +321,12 @@ private fun NcryptsecInputForm(
     Spacer(modifier = Modifier.height(16.dp))
 
     errorMessage?.let {
-        StatusCard(
-            text = it,
-            containerColor = MaterialTheme.colorScheme.errorContainer,
-            contentColor = MaterialTheme.colorScheme.onErrorContainer
-        )
+        ErrorCard(it)
         Spacer(modifier = Modifier.height(16.dp))
     }
 
     cipherError?.let {
-        StatusCard(
-            text = it,
-            containerColor = MaterialTheme.colorScheme.errorContainer,
-            contentColor = MaterialTheme.colorScheme.onErrorContainer
-        )
+        ErrorCard(it)
         Spacer(modifier = Modifier.height(16.dp))
     }
 

--- a/app/src/main/kotlin/io/privkey/keep/ExportNcryptsecScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ExportNcryptsecScreen.kt
@@ -249,8 +249,8 @@ private fun calculatePasswordStrength(password: SecurePassphrase): PasswordStren
     if (password.length < MIN_PASSWORD_LENGTH) return PasswordStrength.WEAK
 
     var score = 0
-    if (password.length >= 12) score++
     if (password.length >= 16) score++
+    if (password.length >= 20) score++
     if (password.any { it.isUpperCase() } && password.any { it.isLowerCase() }) score++
     if (password.any { it.isDigit() }) score++
     if (password.any { !it.isLetterOrDigit() }) score++
@@ -420,6 +420,7 @@ private fun NcryptsecSuccessContent(
     QrCodeDisplay(
         data = ncryptsec,
         label = "NIP-49 Encrypted Key",
+        onTapToCopy = { showClipboardWarning = true },
         onCopied = showCopiedToast
     )
 

--- a/app/src/main/kotlin/io/privkey/keep/ExportNcryptsecScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ExportNcryptsecScreen.kt
@@ -68,11 +68,13 @@ fun ExportNcryptsecScreen(
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     var exportJob by remember { mutableStateOf<Job?>(null) }
+    val sessionCanceled = remember { java.util.concurrent.atomic.AtomicBoolean(false) }
 
     DisposableEffect(lifecycleOwner) {
         setSecureScreen(context, true)
 
         fun clearSensitiveData() {
+            sessionCanceled.set(true)
             exportJob?.cancel()
             exportJob = null
             password.clear()
@@ -162,8 +164,13 @@ fun ExportNcryptsecScreen(
                         }
                         val passwordChars = password.toCharArray()
                         fun clearChars() = Arrays.fill(passwordChars, '\u0000')
+                        sessionCanceled.set(false)
                         try {
                             onBiometricAuth(cipher) { authedCipher ->
+                                if (sessionCanceled.get()) {
+                                    clearChars()
+                                    return@onBiometricAuth
+                                }
                                 if (authedCipher != null) {
                                     val exportId = java.util.UUID.randomUUID().toString()
                                     storage.setPendingCipher(exportId, authedCipher)
@@ -198,7 +205,7 @@ fun ExportNcryptsecScreen(
                                         job.invokeOnCompletion {
                                             clearChars()
                                             storage.clearPendingCipher(exportId)
-                                            exportJob = null
+                                            if (exportJob === job) exportJob = null
                                         }
                                     }
                                 } else {

--- a/app/src/main/kotlin/io/privkey/keep/ExportNcryptsecScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ExportNcryptsecScreen.kt
@@ -1,0 +1,465 @@
+package io.privkey.keep
+
+import android.util.Log
+import android.widget.Toast
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import io.privkey.keep.storage.AndroidKeystoreStorage
+import io.privkey.keep.uniffi.KeepMobile
+import io.privkey.keep.uniffi.ShareInfo
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.util.Arrays
+import javax.crypto.Cipher
+
+private const val MIN_PASSWORD_LENGTH = 15
+
+private sealed class NcryptsecExportState {
+    object Idle : NcryptsecExportState()
+    object Encrypting : NcryptsecExportState()
+    data class Error(val message: String) : NcryptsecExportState()
+
+    class Success(ncryptsec: String) : NcryptsecExportState() {
+        private var chars: CharArray? = ncryptsec.toCharArray()
+
+        val ncryptsec: String @Synchronized get() = chars?.let { String(it) } ?: ""
+
+        @Synchronized
+        fun clear() {
+            chars?.let { Arrays.fill(it, '\u0000') }
+            chars = null
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExportNcryptsecScreen(
+    keepMobile: KeepMobile,
+    shareInfo: ShareInfo,
+    storage: AndroidKeystoreStorage,
+    onGetCipher: () -> Cipher?,
+    onBiometricAuth: (Cipher, (Cipher?) -> Unit) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val password = remember { SecurePassphrase() }
+    val confirmPassword = remember { SecurePassphrase() }
+    var passwordDisplay by remember { mutableStateOf("") }
+    var confirmPasswordDisplay by remember { mutableStateOf("") }
+    var exportState by remember { mutableStateOf<NcryptsecExportState>(NcryptsecExportState.Idle) }
+    var cipherError by remember { mutableStateOf<String?>(null) }
+    val coroutineScope = rememberCoroutineScope()
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(lifecycleOwner) {
+        setSecureScreen(context, true)
+
+        fun clearSensitiveData() {
+            password.clear()
+            confirmPassword.clear()
+            passwordDisplay = ""
+            confirmPasswordDisplay = ""
+            (exportState as? NcryptsecExportState.Success)?.clear()
+            exportState = NcryptsecExportState.Idle
+        }
+
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_PAUSE || event == Lifecycle.Event.ON_STOP) {
+                clearSensitiveData()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            clearSensitiveData()
+            setSecureScreen(context, false)
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .statusBarsPadding()
+            .padding(24.dp)
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Export Encrypted Key",
+            style = MaterialTheme.typography.headlineMedium
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = shareInfo.name,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        when (val state = exportState) {
+            is NcryptsecExportState.Idle, is NcryptsecExportState.Error -> {
+                NcryptsecInputForm(
+                    errorMessage = (state as? NcryptsecExportState.Error)?.message,
+                    cipherError = cipherError,
+                    password = password,
+                    confirmPassword = confirmPassword,
+                    passwordDisplay = passwordDisplay,
+                    confirmPasswordDisplay = confirmPasswordDisplay,
+                    onPasswordChange = {
+                        password.update(it)
+                        passwordDisplay = it
+                    },
+                    onConfirmPasswordChange = {
+                        confirmPassword.update(it)
+                        confirmPasswordDisplay = it
+                    },
+                    onExport = {
+                        if (password.length < MIN_PASSWORD_LENGTH) {
+                            exportState = NcryptsecExportState.Error("Password must be at least $MIN_PASSWORD_LENGTH characters")
+                            return@NcryptsecInputForm
+                        }
+                        if (!password.contentEquals(confirmPassword)) {
+                            exportState = NcryptsecExportState.Error("Passwords do not match")
+                            return@NcryptsecInputForm
+                        }
+                        if (calculatePasswordStrength(password) == PasswordStrength.WEAK) {
+                            exportState = NcryptsecExportState.Error("Password is too weak. Add length, mixed case, numbers, or symbols.")
+                            return@NcryptsecInputForm
+                        }
+                        cipherError = null
+                        val cipher = try {
+                            onGetCipher()
+                        } catch (e: BiometricHelper.BiometricNotReadyException) {
+                            cipherError = e.message ?: "Biometric authentication is unavailable"
+                            return@NcryptsecInputForm
+                        }
+                        if (cipher == null) {
+                            cipherError = "No encryption key available"
+                            return@NcryptsecInputForm
+                        }
+                        val passwordChars = password.toCharArray()
+                        fun clearChars() = Arrays.fill(passwordChars, '\u0000')
+                        try {
+                            onBiometricAuth(cipher) { authedCipher ->
+                                if (authedCipher != null) {
+                                    val exportId = java.util.UUID.randomUUID().toString()
+                                    storage.setPendingCipher(exportId, authedCipher)
+                                    exportState = NcryptsecExportState.Encrypting
+                                    coroutineScope.launch {
+                                        currentCoroutineContext()[Job]?.invokeOnCompletion { cause ->
+                                            if (cause is CancellationException) {
+                                                clearChars()
+                                                storage.clearPendingCipher(exportId)
+                                            }
+                                        }
+                                        try {
+                                            val ncryptsec = withContext(Dispatchers.IO) {
+                                                storage.setRequestIdContext(exportId)
+                                                try {
+                                                    keepMobile.exportNcryptsec(String(passwordChars))
+                                                } finally {
+                                                    storage.clearRequestIdContext()
+                                                }
+                                            }
+                                            (exportState as? NcryptsecExportState.Success)?.clear()
+                                            exportState = NcryptsecExportState.Success(ncryptsec)
+                                        } catch (e: Exception) {
+                                            if (BuildConfig.DEBUG) Log.e("ExportNcryptsec", "Export failed: ${e::class.simpleName}")
+                                            exportState = NcryptsecExportState.Error("Export failed. Please try again.")
+                                        } finally {
+                                            clearChars()
+                                            storage.clearPendingCipher(exportId)
+                                        }
+                                    }
+                                } else {
+                                    clearChars()
+                                    exportState = NcryptsecExportState.Error("Authentication cancelled")
+                                    Toast.makeText(context, "Authentication cancelled", Toast.LENGTH_SHORT).show()
+                                }
+                            }
+                        } catch (e: Exception) {
+                            clearChars()
+                            if (BuildConfig.DEBUG) Log.e("ExportNcryptsec", "Failed to init cipher: ${e::class.simpleName}")
+                            cipherError = "Failed to initialize encryption"
+                        }
+                    },
+                    onCancel = {
+                        password.clear()
+                        confirmPassword.clear()
+                        passwordDisplay = ""
+                        confirmPasswordDisplay = ""
+                        onDismiss()
+                    }
+                )
+            }
+
+            is NcryptsecExportState.Encrypting -> {
+                CircularProgressIndicator()
+                Spacer(modifier = Modifier.height(16.dp))
+                Text("Encrypting key...")
+            }
+
+            is NcryptsecExportState.Success -> {
+                NcryptsecSuccessContent(
+                    ncryptsec = state.ncryptsec,
+                    onDismiss = onDismiss
+                )
+            }
+        }
+    }
+}
+
+private enum class PasswordStrength(val label: String) {
+    WEAK("Weak"),
+    FAIR("Fair"),
+    GOOD("Good"),
+    STRONG("Strong")
+}
+
+@Composable
+private fun PasswordStrength.color() = when (this) {
+    PasswordStrength.WEAK -> MaterialTheme.colorScheme.error
+    PasswordStrength.FAIR -> MaterialTheme.colorScheme.tertiary
+    PasswordStrength.GOOD -> MaterialTheme.colorScheme.primary
+    PasswordStrength.STRONG -> MaterialTheme.colorScheme.primary
+}
+
+private fun calculatePasswordStrength(password: SecurePassphrase): PasswordStrength {
+    if (password.length < MIN_PASSWORD_LENGTH) return PasswordStrength.WEAK
+
+    var score = 0
+    if (password.length >= 12) score++
+    if (password.length >= 16) score++
+    if (password.any { it.isUpperCase() } && password.any { it.isLowerCase() }) score++
+    if (password.any { it.isDigit() }) score++
+    if (password.any { !it.isLetterOrDigit() }) score++
+
+    return when {
+        score >= 4 -> PasswordStrength.STRONG
+        score >= 3 -> PasswordStrength.GOOD
+        score >= 2 -> PasswordStrength.FAIR
+        else -> PasswordStrength.WEAK
+    }
+}
+
+@Composable
+private fun PasswordStrengthIndicator(strength: PasswordStrength) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        LinearProgressIndicator(
+            progress = { (strength.ordinal + 1) / 4f },
+            modifier = Modifier.weight(1f).height(4.dp),
+            color = strength.color(),
+            trackColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = strength.label,
+            style = MaterialTheme.typography.labelSmall,
+            color = strength.color()
+        )
+    }
+}
+
+@Composable
+private fun NcryptsecInputForm(
+    errorMessage: String?,
+    cipherError: String?,
+    password: SecurePassphrase,
+    confirmPassword: SecurePassphrase,
+    passwordDisplay: String,
+    confirmPasswordDisplay: String,
+    onPasswordChange: (String) -> Unit,
+    onConfirmPasswordChange: (String) -> Unit,
+    onExport: () -> Unit,
+    onCancel: () -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer)
+    ) {
+        Text(
+            text = "This encrypts your private key using NIP-49 (ncryptsec). The result can be imported into any Nostr client that supports NIP-49.",
+            modifier = Modifier.padding(16.dp),
+            color = MaterialTheme.colorScheme.onTertiaryContainer,
+            style = MaterialTheme.typography.bodySmall
+        )
+    }
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    errorMessage?.let {
+        StatusCard(
+            text = it,
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+            contentColor = MaterialTheme.colorScheme.onErrorContainer
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+
+    cipherError?.let {
+        StatusCard(
+            text = it,
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+            contentColor = MaterialTheme.colorScheme.onErrorContainer
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+
+    OutlinedTextField(
+        value = passwordDisplay,
+        onValueChange = onPasswordChange,
+        label = { Text("Encryption Password") },
+        placeholder = { Text("Enter a password to encrypt") },
+        modifier = Modifier.fillMaxWidth(),
+        visualTransformation = PasswordVisualTransformation(),
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+        singleLine = true
+    )
+
+    if (password.length > 0) {
+        Spacer(modifier = Modifier.height(8.dp))
+        PasswordStrengthIndicator(calculatePasswordStrength(password))
+    }
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    OutlinedTextField(
+        value = confirmPasswordDisplay,
+        onValueChange = onConfirmPasswordChange,
+        label = { Text("Confirm Password") },
+        placeholder = { Text("Re-enter password") },
+        modifier = Modifier.fillMaxWidth(),
+        visualTransformation = PasswordVisualTransformation(),
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+        singleLine = true,
+        isError = confirmPassword.length > 0 && !password.contentEquals(confirmPassword),
+        supportingText = if (confirmPassword.length > 0 && !password.contentEquals(confirmPassword)) {
+            { Text("Passwords do not match") }
+        } else null
+    )
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    Text(
+        text = "This password encrypts your private key. You will need it to decrypt in another Nostr client.",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+    )
+
+    Spacer(modifier = Modifier.height(24.dp))
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        OutlinedButton(
+            onClick = onCancel,
+            modifier = Modifier.weight(1f)
+        ) {
+            Text("Cancel")
+        }
+        Button(
+            onClick = onExport,
+            modifier = Modifier.weight(1f),
+            enabled = password.length >= MIN_PASSWORD_LENGTH &&
+                password.contentEquals(confirmPassword) &&
+                calculatePasswordStrength(password) != PasswordStrength.WEAK
+        ) {
+            Text("Encrypt")
+        }
+    }
+}
+
+@Composable
+private fun NcryptsecSuccessContent(
+    ncryptsec: String,
+    onDismiss: () -> Unit
+) {
+    val context = LocalContext.current
+    val showCopiedToast = { Toast.makeText(context, "ncryptsec copied", Toast.LENGTH_SHORT).show() }
+    var showClipboardWarning by remember { mutableStateOf(false) }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer)
+    ) {
+        Text(
+            text = "Anyone with this string and the password can access your private key. Do not share it publicly.",
+            modifier = Modifier.padding(16.dp),
+            color = MaterialTheme.colorScheme.onErrorContainer,
+            style = MaterialTheme.typography.bodySmall
+        )
+    }
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    QrCodeDisplay(
+        data = ncryptsec,
+        label = "NIP-49 Encrypted Key",
+        onCopied = showCopiedToast
+    )
+
+    Spacer(modifier = Modifier.height(24.dp))
+
+    OutlinedButton(
+        onClick = { showClipboardWarning = true },
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Text("Copy to Clipboard")
+    }
+
+    if (showClipboardWarning) {
+        AlertDialog(
+            onDismissRequest = { showClipboardWarning = false },
+            title = { Text("Copy to clipboard?") },
+            text = { Text("Other apps on your device may be able to read clipboard contents. The QR code export is more secure.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    showClipboardWarning = false
+                    copySensitiveText(context, ncryptsec)
+                    showCopiedToast()
+                }) {
+                    Text("Copy anyway")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showClipboardWarning = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    Button(
+        onClick = onDismiss,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Text("Done")
+    }
+}

--- a/app/src/main/kotlin/io/privkey/keep/ExportNcryptsecScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ExportNcryptsecScreen.kt
@@ -23,7 +23,6 @@ import io.privkey.keep.uniffi.ShareInfo
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.Arrays
@@ -169,13 +168,11 @@ fun ExportNcryptsecScreen(
                                     val exportId = java.util.UUID.randomUUID().toString()
                                     storage.setPendingCipher(exportId, authedCipher)
                                     exportState = NcryptsecExportState.Encrypting
+                                    // NOTE: String(passwordChars) below materializes an unwipable
+                                    // copy because the UniFFI surface requires String. Residual
+                                    // risk: password bytes linger in the String's backing array
+                                    // until GC. Same applies to the returned ncryptsec.
                                     exportJob = coroutineScope.launch {
-                                        currentCoroutineContext()[Job]?.invokeOnCompletion { cause ->
-                                            if (cause is CancellationException) {
-                                                clearChars()
-                                                storage.clearPendingCipher(exportId)
-                                            }
-                                        }
                                         try {
                                             val ncryptsec = withContext(Dispatchers.IO) {
                                                 storage.setRequestIdContext(exportId)
@@ -185,19 +182,23 @@ fun ExportNcryptsecScreen(
                                                     storage.clearRequestIdContext()
                                                 }
                                             }
-                                            clearChars()
                                             password.clear()
                                             confirmPassword.clear()
                                             passwordDisplay = ""
                                             confirmPasswordDisplay = ""
                                             (exportState as? NcryptsecExportState.Success)?.clear()
                                             exportState = NcryptsecExportState.Success(ncryptsec)
+                                        } catch (e: CancellationException) {
+                                            throw e
                                         } catch (e: Exception) {
                                             if (BuildConfig.DEBUG) Log.e("ExportNcryptsec", "Export failed: ${e::class.simpleName}")
                                             exportState = NcryptsecExportState.Error("Export failed. Please try again.")
-                                        } finally {
+                                        }
+                                    }.also { job ->
+                                        job.invokeOnCompletion {
                                             clearChars()
                                             storage.clearPendingCipher(exportId)
+                                            exportJob = null
                                         }
                                     }
                                 } else {

--- a/app/src/main/kotlin/io/privkey/keep/ExportShareScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ExportShareScreen.kt
@@ -22,6 +22,7 @@ import io.privkey.keep.uniffi.KeepMobile
 import io.privkey.keep.uniffi.ShareInfo
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.Arrays
@@ -236,11 +237,16 @@ fun ExportShareScreen(
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
+    var exportJob by remember { mutableStateOf<Job?>(null) }
+    val sessionCanceled = remember { java.util.concurrent.atomic.AtomicBoolean(false) }
 
     DisposableEffect(lifecycleOwner) {
         setSecureScreen(context, true)
 
         fun clearSensitiveData() {
+            sessionCanceled.set(true)
+            exportJob?.cancel()
+            exportJob = null
             passphrase.clear()
             confirmPassphrase.clear()
             passphraseDisplay = ""
@@ -328,13 +334,18 @@ fun ExportShareScreen(
                         }
                         val passphraseChars = passphrase.toCharArray()
                         fun clearChars() = Arrays.fill(passphraseChars, '\u0000')
+                        sessionCanceled.set(false)
                         try {
                             onBiometricAuth(cipher) { authedCipher ->
+                                if (sessionCanceled.get()) {
+                                    clearChars()
+                                    return@onBiometricAuth
+                                }
                                 if (authedCipher != null) {
                                     val exportId = java.util.UUID.randomUUID().toString()
                                     storage.setPendingCipher(exportId, authedCipher)
                                     exportState = ExportState.Exporting
-                                    coroutineScope.launch {
+                                    exportJob = coroutineScope.launch {
                                         try {
                                             val data = withContext(Dispatchers.IO) {
                                                 storage.setRequestIdContext(exportId)
@@ -344,6 +355,10 @@ fun ExportShareScreen(
                                                     storage.clearRequestIdContext()
                                                 }
                                             }
+                                            passphrase.clear()
+                                            confirmPassphrase.clear()
+                                            passphraseDisplay = ""
+                                            confirmPassphraseDisplay = ""
                                             (exportState as? ExportState.Success)?.clear()
                                             val frames = try {
                                                 withContext(Dispatchers.Default) {
@@ -368,6 +383,7 @@ fun ExportShareScreen(
                                         job.invokeOnCompletion {
                                             clearChars()
                                             storage.clearPendingCipher(exportId)
+                                            if (exportJob === job) exportJob = null
                                         }
                                     }
                                 } else {

--- a/app/src/main/kotlin/io/privkey/keep/ExportShareScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ExportShareScreen.kt
@@ -22,8 +22,6 @@ import io.privkey.keep.uniffi.KeepMobile
 import io.privkey.keep.uniffi.ShareInfo
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.Arrays
@@ -337,12 +335,6 @@ fun ExportShareScreen(
                                     storage.setPendingCipher(exportId, authedCipher)
                                     exportState = ExportState.Exporting
                                     coroutineScope.launch {
-                                        currentCoroutineContext()[Job]?.invokeOnCompletion { cause ->
-                                            if (cause is CancellationException) {
-                                                clearChars()
-                                                storage.clearPendingCipher(exportId)
-                                            }
-                                        }
                                         try {
                                             val data = withContext(Dispatchers.IO) {
                                                 storage.setRequestIdContext(exportId)
@@ -366,10 +358,14 @@ fun ExportShareScreen(
                                                 listOf(data)
                                             }
                                             exportState = ExportState.Success(data, frames)
+                                        } catch (e: CancellationException) {
+                                            throw e
                                         } catch (e: Exception) {
                                             if (BuildConfig.DEBUG) Log.e("ExportShare", "Export failed: ${e::class.simpleName}")
                                             exportState = ExportState.Error("Export failed. Please try again.")
-                                        } finally {
+                                        }
+                                    }.also { job ->
+                                        job.invokeOnCompletion {
                                             clearChars()
                                             storage.clearPendingCipher(exportId)
                                         }

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -272,6 +272,7 @@ fun MainScreen(
     var showImportNsecScreen by remember { mutableStateOf(false) }
     var showShareDetails by remember { mutableStateOf(false) }
     var showExportScreen by remember { mutableStateOf(false) }
+    var showExportNcryptsecScreen by remember { mutableStateOf(false) }
     var showPermissionsScreen by remember { mutableStateOf(false) }
     var showHistoryScreen by remember { mutableStateOf(false) }
     var showSignPolicyScreen by remember { mutableStateOf(false) }
@@ -547,6 +548,20 @@ fun MainScreen(
                 onBiometricRequest("Export Share", "Authenticate to export share", cipher, callback)
             },
             onDismiss = { showExportScreen = false }
+        )
+        return
+    }
+
+    if (showExportNcryptsecScreen && currentShareInfoForScreens != null) {
+        ExportNcryptsecScreen(
+            keepMobile = keepMobile,
+            shareInfo = currentShareInfoForScreens,
+            storage = storage,
+            onGetCipher = { requireBiometricReady(); getShareAwareCipher(storage) },
+            onBiometricAuth = { cipher, callback ->
+                onBiometricRequest("Export Encrypted Key", "Authenticate to export encrypted key", cipher, callback)
+            },
+            onDismiss = { showExportNcryptsecScreen = false }
         )
         return
     }
@@ -932,6 +947,7 @@ fun MainScreen(
                     onAccountSwitcherClick = { showAccountSwitcher = true },
                     onShareDetailsClick = { showShareDetails = true },
                     onExportClick = { showExportScreen = true },
+                    onExportNcryptsecClick = { showExportNcryptsecScreen = true },
                     onImport = { showImportScreen = true },
                     onImportNsec = { showImportNsecScreen = true },
                     onCreateAccount = { showCreateAccountScreen = true },
@@ -1256,6 +1272,7 @@ private fun AccountTab(
     onAccountSwitcherClick: () -> Unit,
     onShareDetailsClick: () -> Unit,
     onExportClick: () -> Unit,
+    onExportNcryptsecClick: () -> Unit,
     onImport: () -> Unit,
     onImportNsec: () -> Unit,
     onCreateAccount: () -> Unit,
@@ -1298,6 +1315,15 @@ private fun AccountTab(
                         modifier = Modifier.fillMaxWidth()
                     ) {
                         Text("Export Share")
+                    }
+                    if (shareInfo.threshold == 1u.toUShort() && shareInfo.totalShares == 1u.toUShort()) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        OutlinedButton(
+                            onClick = onExportNcryptsecClick,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text("Export Encrypted (NIP-49)")
+                        }
                     }
                     Spacer(modifier = Modifier.height(8.dp))
                     Row(

--- a/app/src/main/kotlin/io/privkey/keep/QrCodeDisplay.kt
+++ b/app/src/main/kotlin/io/privkey/keep/QrCodeDisplay.kt
@@ -117,6 +117,7 @@ private fun QrDisplayContainer(
     copyData: String,
     onCopied: () -> Unit,
     modifier: Modifier = Modifier,
+    onTapToCopy: (() -> Unit)? = null,
     extraContent: @Composable (ColumnScope.() -> Unit)? = null,
     qrContent: @Composable BoxScope.() -> Unit
 ) {
@@ -132,8 +133,12 @@ private fun QrDisplayContainer(
                 .clip(RoundedCornerShape(16.dp))
                 .background(Color.White)
                 .clickable {
-                    copySensitiveText(context, copyData)
-                    onCopied()
+                    if (onTapToCopy != null) {
+                        onTapToCopy()
+                    } else {
+                        copySensitiveText(context, copyData)
+                        onCopied()
+                    }
                 },
             contentAlignment = Alignment.Center,
             content = qrContent
@@ -182,6 +187,7 @@ fun QrCodeDisplay(
     data: String,
     label: String,
     modifier: Modifier = Modifier,
+    onTapToCopy: (() -> Unit)? = null,
     onCopied: () -> Unit = {}
 ) {
     @SuppressLint("ProduceStateDoesNotAssignValue")
@@ -195,6 +201,7 @@ fun QrCodeDisplay(
         copyData = data,
         onCopied = onCopied,
         modifier = modifier,
+        onTapToCopy = onTapToCopy,
         qrContent = {
             val bmp = bitmap
             if (bmp != null) {


### PR DESCRIPTION
## Summary
- Add NIP-49 encrypted key (ncryptsec) export screen for single-key shares
- Password strength validation with 15-char minimum and strength meter
- Biometric authentication required before export
- QR code display with clipboard warning dialog
- Secure screen flag and lifecycle-aware sensitive data cleanup

## Test plan
- [x] Verify ncryptsec export button appears only for single-key shares (threshold=1, totalShares=1)
- [x] Verify biometric prompt before export
- [x] Verify password strength meter rejects weak passwords
- [x] Verify QR code displays and tap-to-copy shows clipboard warning
- [x] Verify "Copy to Clipboard" button shows warning dialog
- [x] Verify sensitive data clears on app background/screen lock
- [x] Import exported ncryptsec in another NIP-49 compatible client

## Verification results
Manually verified on two devices with a 1-of-1 nsec share:

| # | Test | Pixel 7a | Pixel 9a |
|---|------|----------|----------|
| 1 | Export button only for 1-of-1 shares | Pass | Pass |
| 2 | Biometric prompt before export | Pass | Pass |
| 3 | Password strength rejects weak passwords | Pass | Pass |
| 4 | QR code displays with tap-to-copy warning | Pass | Pass |
| 5 | "Copy to Clipboard" button warning dialog | Pass | Pass |
| 6 | Sensitive data clears on background/lock | Pass | Pass |
| 7 | External NIP-49 roundtrip import | Pass | Pass |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Export Encrypted (NIP-49) flow with password protection, biometric verification, progress/error/success screens, and a conditional "Export Encrypted (NIP-49)" button.
  * QR display now supports tap-to-copy with explicit tap handling and copy confirmation.

* **Bug Fixes**
  * Improved sensitive-data cleanup and lifecycle handling to cancel exports, wipe passwords, and avoid leaving cryptographic state on pause/stop.
  * Better error handling for authentication cancellation and export failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->