### PR TITLE
Add seed word backup verification and retrieval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: privkeyio/keep
-          ref: bf1d9e3d6d553a5fb630b958da2f992ad57e813b
+          ref: 81a820f6b29b8d10025bf4c7e7bdd9f986b01378
           path: keep
 
       - name: Set up JDK 17
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: privkeyio/keep
-          ref: bf1d9e3d6d553a5fb630b958da2f992ad57e813b
+          ref: 81a820f6b29b8d10025bf4c7e7bdd9f986b01378
           path: keep
 
       - name: Set up JDK 17

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: privkeyio/keep
-          ref: 657ebbd084f3a8261bb95f764864714f525b044d
+          ref: bf1d9e3d6d553a5fb630b958da2f992ad57e813b
           path: keep
 
       - name: Set up JDK 17
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: privkeyio/keep
-          ref: 657ebbd084f3a8261bb95f764864714f525b044d
+          ref: bf1d9e3d6d553a5fb630b958da2f992ad57e813b
           path: keep
 
       - name: Set up JDK 17

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: privkeyio/keep
-          ref: bf1d9e3d6d553a5fb630b958da2f992ad57e813b
+          ref: 81a820f6b29b8d10025bf4c7e7bdd9f986b01378
           path: keep
 
       - name: Set up JDK 17

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: privkeyio/keep
-          ref: 657ebbd084f3a8261bb95f764864714f525b044d
+          ref: bf1d9e3d6d553a5fb630b958da2f992ad57e813b
           path: keep
 
       - name: Set up JDK 17

--- a/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
+++ b/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
@@ -409,7 +409,7 @@ internal class AccountActions(
                     }
                     onComplete(true)
                 } catch (e: Exception) {
-                    logAndToast("Mark backed up failed", "Failed to mark account as backed up", e)
+                    if (BuildConfig.DEBUG) Log.e("AccountActions", "Mark backed up failed", e)
                     onComplete(false)
                 } finally {
                     if (pendingSet) storage.clearPendingCipher(requestId)

--- a/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
+++ b/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
@@ -72,7 +72,9 @@ internal class AccountActions(
             val accounts = storage.listAllShares().map { it.toAccountInfo() }
             val config = runCatching { keepMobile.getRelayConfig(activeKey) }.getOrNull()
                 ?: EMPTY_RELAY_CONFIG
-            val activeDidBackup = runCatching { keepMobile.getActiveShareMetadata()?.didBackup }.getOrNull()
+            val activeDidBackup = runCatching { keepMobile.getActiveShareMetadata()?.didBackup }
+                .onFailure { Log.w("AccountActions", "getActiveShareMetadata failed; treating as not backed up: ${it::class.simpleName}") }
+                .getOrDefault(false)
             AccountState(hasShare, shareInfo, activeKey, accounts, config.frostRelays, config.profileRelays, activeDidBackup)
         }
         onStateChanged(result)
@@ -280,34 +282,39 @@ internal class AccountActions(
         onDismiss: (Boolean) -> Unit
     ) {
         withBiometricAuth(account.groupPubkeyHex, "View Seed Words", "Authenticate to view seed words", { onDismiss(false) }) { authedCipher ->
-            val requestId = UUID.randomUUID().toString()
-            var pendingSet = false
-            var result: String? = null
-            var success = false
-            try {
-                val activeNow = withContext(Dispatchers.IO) { storage.getActiveShareKey() }
-                if (activeNow != account.groupPubkeyHex) {
-                    onResult(null)
-                    return@withBiometricAuth
-                }
-                storage.setPendingCipher(requestId, authedCipher)
-                pendingSet = true
-                withContext(Dispatchers.IO) {
-                    storage.setRequestIdContext(requestId)
-                    try {
-                        result = keepMobile.getSeedWords(account.groupPubkeyHex)
-                    } finally {
-                        storage.clearRequestIdContext()
+            accountMutex.withLock {
+                val requestId = UUID.randomUUID().toString()
+                var pendingSet = false
+                var result: String? = null
+                var success = false
+                try {
+                    val activeNow = withContext(Dispatchers.IO) { storage.getActiveShareKey() }
+                    if (activeNow != account.groupPubkeyHex) {
+                        onResult(null)
+                        return@withLock
                     }
+                    storage.setPendingCipher(requestId, authedCipher)
+                    pendingSet = true
+                    withContext(Dispatchers.IO) {
+                        storage.setRequestIdContext(requestId)
+                        try {
+                            result = keepMobile.getSeedWords(account.groupPubkeyHex)
+                        } finally {
+                            storage.clearRequestIdContext()
+                        }
+                    }
+                    val toDeliver = result
+                    result = null
+                    onResult(toDeliver)
+                    success = toDeliver != null
+                } catch (e: Exception) {
+                    logAndToast("View seed words failed", "Failed to retrieve seed words", e)
+                    onResult(null)
+                } finally {
+                    result = null
+                    if (pendingSet) storage.clearPendingCipher(requestId)
+                    onDismiss(success)
                 }
-                success = result != null
-                onResult(result)
-            } catch (e: Exception) {
-                logAndToast("View seed words failed", "Failed to retrieve seed words", e)
-                onResult(null)
-            } finally {
-                if (pendingSet) storage.clearPendingCipher(requestId)
-                onDismiss(success)
             }
         }
     }

--- a/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
+++ b/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
@@ -355,8 +355,8 @@ internal class AccountActions(
                                 var pendingSet = false
                                 try {
                                     storage.setPendingCipher(requestId, authedDecrypt)
-                                    storage.setPendingCipher(requestId, authedEncrypt)
                                     pendingSet = true
+                                    storage.setPendingCipher(requestId, authedEncrypt)
                                     withContext(Dispatchers.IO) {
                                         storage.setRequestIdContext(requestId)
                                         try {

--- a/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
+++ b/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
@@ -277,13 +277,19 @@ internal class AccountActions(
     fun viewSeedWords(
         account: AccountInfo,
         onResult: (String?) -> Unit,
-        onDismiss: () -> Unit
+        onDismiss: (Boolean) -> Unit
     ) {
-        withBiometricAuth(account.groupPubkeyHex, "View Seed Words", "Authenticate to view seed words", onDismiss) { authedCipher ->
+        withBiometricAuth(account.groupPubkeyHex, "View Seed Words", "Authenticate to view seed words", { onDismiss(false) }) { authedCipher ->
             val requestId = UUID.randomUUID().toString()
             var pendingSet = false
             var result: String? = null
+            var success = false
             try {
+                val activeNow = withContext(Dispatchers.IO) { storage.getActiveShareKey() }
+                if (activeNow != account.groupPubkeyHex) {
+                    onResult(null)
+                    return@withBiometricAuth
+                }
                 storage.setPendingCipher(requestId, authedCipher)
                 pendingSet = true
                 withContext(Dispatchers.IO) {
@@ -294,14 +300,14 @@ internal class AccountActions(
                         storage.clearRequestIdContext()
                     }
                 }
+                success = result != null
                 onResult(result)
             } catch (e: Exception) {
-                if (BuildConfig.DEBUG) Log.e("AccountActions", "View seed words failed: ${e::class.simpleName}")
                 logAndToast("View seed words failed", "Failed to retrieve seed words", e)
                 onResult(null)
             } finally {
                 if (pendingSet) storage.clearPendingCipher(requestId)
-                onDismiss()
+                onDismiss(success)
             }
         }
     }

--- a/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
+++ b/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
@@ -394,9 +394,6 @@ internal class AccountActions(
                     storage.setPendingCipher(requestId, authedDecrypt)
                     pendingSet = true
                     storage.setPendingCipher(requestId, authedEncrypt)
-                    // The decrypt cipher was enqueued before the second biometric prompt; refresh
-                    // both entries so user idle time on that prompt cannot expire them mid-FFI.
-                    storage.refreshPendingCipher(requestId)
                     withContext(Dispatchers.IO) {
                         storage.setRequestIdContext(requestId)
                         try {

--- a/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
+++ b/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
@@ -308,9 +308,9 @@ internal class AccountActions(
                             storage.clearRequestIdContext()
                         }
                     }
-                    success = seedWords != null
                     delivered = true
                     onResult(seedWords)
+                    success = seedWords != null
                 } catch (e: Exception) {
                     logAndToast("View seed words failed", "Failed to retrieve seed words", e)
                     if (!delivered) {

--- a/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
+++ b/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
@@ -308,6 +308,11 @@ internal class AccountActions(
                             storage.clearRequestIdContext()
                         }
                     }
+                    if (seedWords == null) {
+                        coroutineScope.launch(Dispatchers.Main) {
+                            Toast.makeText(appContext, "No seed words available for this account", Toast.LENGTH_SHORT).show()
+                        }
+                    }
                     delivered = true
                     onResult(seedWords)
                     success = seedWords != null
@@ -389,6 +394,9 @@ internal class AccountActions(
                     storage.setPendingCipher(requestId, authedDecrypt)
                     pendingSet = true
                     storage.setPendingCipher(requestId, authedEncrypt)
+                    // The decrypt cipher was enqueued before the second biometric prompt; refresh
+                    // both entries so user idle time on that prompt cannot expire them mid-FFI.
+                    storage.refreshPendingCipher(requestId)
                     withContext(Dispatchers.IO) {
                         storage.setRequestIdContext(requestId)
                         try {

--- a/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
+++ b/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
@@ -276,6 +276,10 @@ internal class AccountActions(
         }
     }
 
+    // NOTE: The Rust FFI `keepMobile.getSeedWords` returns a Kotlin String, which lives on
+    // the JVM heap and cannot be zeroed. We minimize the reference's lifetime here (single
+    // local, handed directly to onResult, no intermediate copies), but a full mitigation
+    // requires changing the FFI to return a CharArray/ByteArray that Kotlin can wipe.
     fun viewSeedWords(
         account: AccountInfo,
         onResult: (String?) -> Unit,
@@ -285,33 +289,35 @@ internal class AccountActions(
             accountMutex.withLock {
                 val requestId = UUID.randomUUID().toString()
                 var pendingSet = false
-                var result: String? = null
                 var success = false
+                var delivered = false
                 try {
                     val activeNow = withContext(Dispatchers.IO) { storage.getActiveShareKey() }
                     if (activeNow != account.groupPubkeyHex) {
+                        delivered = true
                         onResult(null)
                         return@withLock
                     }
                     storage.setPendingCipher(requestId, authedCipher)
                     pendingSet = true
-                    withContext(Dispatchers.IO) {
+                    val seedWords = withContext(Dispatchers.IO) {
                         storage.setRequestIdContext(requestId)
                         try {
-                            result = keepMobile.getSeedWords(account.groupPubkeyHex)
+                            keepMobile.getSeedWords(account.groupPubkeyHex)
                         } finally {
                             storage.clearRequestIdContext()
                         }
                     }
-                    val toDeliver = result
-                    result = null
-                    onResult(toDeliver)
-                    success = toDeliver != null
+                    success = seedWords != null
+                    delivered = true
+                    onResult(seedWords)
                 } catch (e: Exception) {
                     logAndToast("View seed words failed", "Failed to retrieve seed words", e)
-                    onResult(null)
+                    if (!delivered) {
+                        delivered = true
+                        onResult(null)
+                    }
                 } finally {
-                    result = null
                     if (pendingSet) storage.clearPendingCipher(requestId)
                     onDismiss(success)
                 }

--- a/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
+++ b/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
@@ -72,7 +72,7 @@ internal class AccountActions(
             val accounts = storage.listAllShares().map { it.toAccountInfo() }
             val config = runCatching { keepMobile.getRelayConfig(activeKey) }.getOrNull()
                 ?: EMPTY_RELAY_CONFIG
-            val activeDidBackup = runCatching { keepMobile.getActiveShare()?.didBackup }.getOrNull()
+            val activeDidBackup = runCatching { keepMobile.getActiveShareMetadata()?.didBackup }.getOrNull()
             AccountState(hasShare, shareInfo, activeKey, accounts, config.frostRelays, config.profileRelays, activeDidBackup)
         }
         onStateChanged(result)

--- a/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
+++ b/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
@@ -73,8 +73,8 @@ internal class AccountActions(
             val config = runCatching { keepMobile.getRelayConfig(activeKey) }.getOrNull()
                 ?: EMPTY_RELAY_CONFIG
             val activeDidBackup = runCatching { keepMobile.getActiveShareMetadata()?.didBackup }
-                .onFailure { Log.w("AccountActions", "getActiveShareMetadata failed; treating as not backed up: ${it::class.simpleName}") }
-                .getOrDefault(false)
+                .onFailure { Log.w("AccountActions", "getActiveShareMetadata failed: ${it::class.simpleName}") }
+                .getOrNull()
             AccountState(hasShare, shareInfo, activeKey, accounts, config.frostRelays, config.profileRelays, activeDidBackup)
         }
         onStateChanged(result)

--- a/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
+++ b/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
@@ -313,10 +313,7 @@ internal class AccountActions(
                     success = seedWords != null
                 } catch (e: Exception) {
                     logAndToast("View seed words failed", "Failed to retrieve seed words", e)
-                    if (!delivered) {
-                        delivered = true
-                        onResult(null)
-                    }
+                    if (!delivered) onResult(null)
                 } finally {
                     if (pendingSet) storage.clearPendingCipher(requestId)
                     onDismiss(success)
@@ -342,66 +339,82 @@ internal class AccountActions(
                     onComplete(false)
                     return@onBiometricRequest
                 }
-                coroutineScope.launch {
-                    val encryptCipher = accountMutex.withLock {
-                        withContext(Dispatchers.IO) {
-                            val stillExists = storage.listAllShares()
-                                .any { it.toAccountInfo().groupPubkeyHex == account.groupPubkeyHex }
-                            if (!stillExists) null
-                            else runCatching { storage.getCipherForShareEncryption(account.groupPubkeyHex) }.getOrNull()
+                requestEncryptCipherAndFinishBackup(account, authedDecrypt, onComplete)
+            }
+        }
+    }
+
+    private fun requestEncryptCipherAndFinishBackup(
+        account: AccountInfo,
+        authedDecrypt: Cipher,
+        onComplete: (Boolean) -> Unit
+    ) {
+        coroutineScope.launch {
+            val encryptCipher = accountMutex.withLock {
+                withContext(Dispatchers.IO) {
+                    if (!shareExists(account.groupPubkeyHex)) null
+                    else runCatching { storage.getCipherForShareEncryption(account.groupPubkeyHex) }.getOrNull()
+                }
+            }
+            if (encryptCipher == null) {
+                onComplete(false)
+                return@launch
+            }
+            onBiometricRequest("Confirm Backup", "Authenticate again to save", encryptCipher) { authedEncrypt ->
+                if (authedEncrypt == null) {
+                    onComplete(false)
+                    return@onBiometricRequest
+                }
+                finishMarkBackedUp(account, authedDecrypt, authedEncrypt, onComplete)
+            }
+        }
+    }
+
+    private fun finishMarkBackedUp(
+        account: AccountInfo,
+        authedDecrypt: Cipher,
+        authedEncrypt: Cipher,
+        onComplete: (Boolean) -> Unit
+    ) {
+        coroutineScope.launch {
+            accountMutex.withLock {
+                val stillExists = withContext(Dispatchers.IO) { shareExists(account.groupPubkeyHex) }
+                if (!stillExists) {
+                    onComplete(false)
+                    return@withLock
+                }
+                val requestId = UUID.randomUUID().toString()
+                var pendingSet = false
+                try {
+                    storage.setPendingCipher(requestId, authedDecrypt)
+                    pendingSet = true
+                    storage.setPendingCipher(requestId, authedEncrypt)
+                    withContext(Dispatchers.IO) {
+                        storage.setRequestIdContext(requestId)
+                        try {
+                            keepMobile.markShareBackedUp(account.groupPubkeyHex)
+                        } finally {
+                            storage.clearRequestIdContext()
                         }
                     }
-                    if (encryptCipher == null) {
-                        onComplete(false)
-                        return@launch
+                    try {
+                        refreshAccountState()
+                    } catch (e: Exception) {
+                        if (BuildConfig.DEBUG) Log.e("AccountActions", "Post-mark refresh failed: ${e::class.simpleName}")
                     }
-                    onBiometricRequest("Confirm Backup", "Authenticate again to save", encryptCipher) { authedEncrypt ->
-                        if (authedEncrypt == null) {
-                            onComplete(false)
-                            return@onBiometricRequest
-                        }
-                        coroutineScope.launch {
-                            accountMutex.withLock {
-                                val stillExists = withContext(Dispatchers.IO) {
-                                    storage.listAllShares().any { it.toAccountInfo().groupPubkeyHex == account.groupPubkeyHex }
-                                }
-                                if (!stillExists) {
-                                    onComplete(false)
-                                    return@withLock
-                                }
-                                val requestId = UUID.randomUUID().toString()
-                                var pendingSet = false
-                                try {
-                                    storage.setPendingCipher(requestId, authedDecrypt)
-                                    pendingSet = true
-                                    storage.setPendingCipher(requestId, authedEncrypt)
-                                    withContext(Dispatchers.IO) {
-                                        storage.setRequestIdContext(requestId)
-                                        try {
-                                            keepMobile.markShareBackedUp(account.groupPubkeyHex)
-                                        } finally {
-                                            storage.clearRequestIdContext()
-                                        }
-                                    }
-                                    try {
-                                        refreshAccountState()
-                                    } catch (e: Exception) {
-                                        if (BuildConfig.DEBUG) Log.e("AccountActions", "Post-mark refresh failed: ${e::class.simpleName}")
-                                    }
-                                    onComplete(true)
-                                } catch (e: Exception) {
-                                    logAndToast("Mark backed up failed", "Failed to mark account as backed up", e)
-                                    onComplete(false)
-                                } finally {
-                                    if (pendingSet) storage.clearPendingCipher(requestId)
-                                }
-                            }
-                        }
-                    }
+                    onComplete(true)
+                } catch (e: Exception) {
+                    logAndToast("Mark backed up failed", "Failed to mark account as backed up", e)
+                    onComplete(false)
+                } finally {
+                    if (pendingSet) storage.clearPendingCipher(requestId)
                 }
             }
         }
     }
+
+    private fun shareExists(groupPubkeyHex: String): Boolean =
+        storage.listAllShares().any { it.toAccountInfo().groupPubkeyHex == groupPubkeyHex }
 
     private fun executeImport(
         cipher: Cipher,

--- a/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
+++ b/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
@@ -337,8 +337,13 @@ internal class AccountActions(
                     return@onBiometricRequest
                 }
                 coroutineScope.launch {
-                    val encryptCipher = withContext(Dispatchers.IO) {
-                        runCatching { storage.getCipherForShareEncryption(account.groupPubkeyHex) }.getOrNull()
+                    val encryptCipher = accountMutex.withLock {
+                        withContext(Dispatchers.IO) {
+                            val stillExists = storage.listAllShares()
+                                .any { it.toAccountInfo().groupPubkeyHex == account.groupPubkeyHex }
+                            if (!stillExists) null
+                            else runCatching { storage.getCipherForShareEncryption(account.groupPubkeyHex) }.getOrNull()
+                        }
                     }
                     if (encryptCipher == null) {
                         onComplete(false)
@@ -351,6 +356,13 @@ internal class AccountActions(
                         }
                         coroutineScope.launch {
                             accountMutex.withLock {
+                                val stillExists = withContext(Dispatchers.IO) {
+                                    storage.listAllShares().any { it.toAccountInfo().groupPubkeyHex == account.groupPubkeyHex }
+                                }
+                                if (!stillExists) {
+                                    onComplete(false)
+                                    return@withLock
+                                }
                                 val requestId = UUID.randomUUID().toString()
                                 var pendingSet = false
                                 try {

--- a/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
+++ b/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
@@ -34,7 +34,8 @@ internal class AccountActions(
         val activeAccountKey: String?,
         val allAccounts: List<AccountInfo>,
         val relays: List<String>,
-        val profileRelays: List<String>
+        val profileRelays: List<String>,
+        val activeDidBackup: Boolean?
     )
 
     private val accountMutex = Mutex()
@@ -71,7 +72,8 @@ internal class AccountActions(
             val accounts = storage.listAllShares().map { it.toAccountInfo() }
             val config = runCatching { keepMobile.getRelayConfig(activeKey) }.getOrNull()
                 ?: EMPTY_RELAY_CONFIG
-            AccountState(hasShare, shareInfo, activeKey, accounts, config.frostRelays, config.profileRelays)
+            val activeDidBackup = runCatching { keepMobile.getActiveShare()?.didBackup }.getOrNull()
+            AccountState(hasShare, shareInfo, activeKey, accounts, config.frostRelays, config.profileRelays, activeDidBackup)
         }
         onStateChanged(result)
     }
@@ -269,6 +271,104 @@ internal class AccountActions(
         onImportStateChanged(ImportState.Importing)
         executeImport(cipher, onImportStateChanged) {
             keepMobile.createAccountFromMnemonic(mnemonic, passphrase, name)
+        }
+    }
+
+    fun viewSeedWords(
+        account: AccountInfo,
+        onResult: (String?) -> Unit,
+        onDismiss: () -> Unit
+    ) {
+        withBiometricAuth(account.groupPubkeyHex, "View Seed Words", "Authenticate to view seed words", onDismiss) { authedCipher ->
+            val requestId = UUID.randomUUID().toString()
+            var pendingSet = false
+            var result: String? = null
+            try {
+                storage.setPendingCipher(requestId, authedCipher)
+                pendingSet = true
+                withContext(Dispatchers.IO) {
+                    storage.setRequestIdContext(requestId)
+                    try {
+                        result = keepMobile.getSeedWords(account.groupPubkeyHex)
+                    } finally {
+                        storage.clearRequestIdContext()
+                    }
+                }
+                onResult(result)
+            } catch (e: Exception) {
+                if (BuildConfig.DEBUG) Log.e("AccountActions", "View seed words failed: ${e::class.simpleName}")
+                logAndToast("View seed words failed", "Failed to retrieve seed words", e)
+                onResult(null)
+            } finally {
+                if (pendingSet) storage.clearPendingCipher(requestId)
+                onDismiss()
+            }
+        }
+    }
+
+    fun markBackedUp(
+        account: AccountInfo,
+        onComplete: (Boolean) -> Unit
+    ) {
+        coroutineScope.launch {
+            val decryptCipher = withContext(Dispatchers.IO) {
+                runCatching { storage.getCipherForShareDecryption(account.groupPubkeyHex) }.getOrNull()
+            }
+            if (decryptCipher == null) {
+                onComplete(false)
+                return@launch
+            }
+            onBiometricRequest("Confirm Backup", "Authenticate to confirm backup", decryptCipher) { authedDecrypt ->
+                if (authedDecrypt == null) {
+                    onComplete(false)
+                    return@onBiometricRequest
+                }
+                coroutineScope.launch {
+                    val encryptCipher = withContext(Dispatchers.IO) {
+                        runCatching { storage.getCipherForShareEncryption(account.groupPubkeyHex) }.getOrNull()
+                    }
+                    if (encryptCipher == null) {
+                        onComplete(false)
+                        return@launch
+                    }
+                    onBiometricRequest("Confirm Backup", "Authenticate again to save", encryptCipher) { authedEncrypt ->
+                        if (authedEncrypt == null) {
+                            onComplete(false)
+                            return@onBiometricRequest
+                        }
+                        coroutineScope.launch {
+                            accountMutex.withLock {
+                                val requestId = UUID.randomUUID().toString()
+                                var pendingSet = false
+                                try {
+                                    storage.setPendingCipher(requestId, authedDecrypt)
+                                    storage.setPendingCipher(requestId, authedEncrypt)
+                                    pendingSet = true
+                                    withContext(Dispatchers.IO) {
+                                        storage.setRequestIdContext(requestId)
+                                        try {
+                                            keepMobile.markShareBackedUp(account.groupPubkeyHex)
+                                        } finally {
+                                            storage.clearRequestIdContext()
+                                        }
+                                    }
+                                    try {
+                                        refreshAccountState()
+                                    } catch (e: Exception) {
+                                        if (BuildConfig.DEBUG) Log.e("AccountActions", "Post-mark refresh failed: ${e::class.simpleName}")
+                                    }
+                                    onComplete(true)
+                                } catch (e: Exception) {
+                                    logAndToast("Mark backed up failed", "Failed to mark account as backed up", e)
+                                    onComplete(false)
+                                } finally {
+                                    if (pendingSet) storage.clearPendingCipher(requestId)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -320,6 +320,10 @@ fun MainScreen(
     val seedWordsData = remember { SecureShareData(MAX_SEED_WORDS_LENGTH) }
     var seedWordsLoading by remember { mutableStateOf(false) }
 
+    DisposableEffect(Unit) {
+        onDispose { seedWordsData.clear() }
+    }
+
     val proxyConfig = remember { runCatching { keepMobile.getProxyConfig() }.getOrNull() }
     var proxyEnabled by remember { mutableStateOf(proxyConfig?.enabled == true) }
     var proxyPort by remember { mutableStateOf(proxyConfig?.port?.toInt() ?: 9050) }
@@ -722,16 +726,13 @@ fun MainScreen(
         return
     }
 
-    DisposableEffect(Unit) {
-        onDispose { seedWordsData.clear() }
-    }
-
     if (showSeedWordsScreen) {
         val activeAccount = remember(activeAccountKey, allAccounts) {
             activeAccountKey?.let { key -> allAccounts.firstOrNull { it.groupPubkeyHex == key } }
         }
         SeedWordsScreen(
-            mnemonicData = if (seedWordsLoading) null else seedWordsData,
+            mnemonicData = seedWordsData,
+            isLoading = seedWordsLoading,
             didBackup = activeDidBackup == true,
             onConfirmBackedUp = {
                 val acct = activeAccount
@@ -1003,9 +1004,9 @@ fun MainScreen(
                                     }
                                     seedWordsLoading = false
                                 },
-                                onDismiss = {
+                                onDismiss = { success ->
                                     seedWordsLoading = false
-                                    if (!seedWordsData.isNotBlank()) {
+                                    if (!success) {
                                         showSeedWordsScreen = false
                                     }
                                 }

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -990,8 +990,9 @@ fun MainScreen(
                     onExportClick = { showExportScreen = true },
                     onExportNcryptsecClick = { showExportNcryptsecScreen = true },
                     onViewSeedWords = {
-                        val activeKey = activeAccountKey
-                        val acct = activeKey?.let { k -> allAccounts.firstOrNull { it.groupPubkeyHex == k } }
+                        val acct = activeAccountKey?.let { key ->
+                            allAccounts.firstOrNull { it.groupPubkeyHex == key }
+                        }
                         if (acct != null) {
                             seedWordsLoading = true
                             seedWordsData.clear()

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -743,7 +743,9 @@ fun MainScreen(
                         if (success) {
                             seedWordsData.clear()
                             showSeedWordsScreen = false
-                        } else {
+                        } else if (showSeedWordsScreen) {
+                            // Only surface the toast while the sheet is still attached; ON_STOP
+                            // may have already torn it down and called onDismiss.
                             Toast.makeText(
                                 appContext,
                                 "Failed to confirm backup. Please try again.",
@@ -1018,6 +1020,7 @@ fun MainScreen(
                                 onDismiss = { success ->
                                     seedWordsLoading = false
                                     if (!success) {
+                                        seedWordsData.clear()
                                         showSeedWordsScreen = false
                                     }
                                 }

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -319,6 +319,7 @@ fun MainScreen(
     var showSeedWordsScreen by remember { mutableStateOf(false) }
     val seedWordsData = remember { SecureShareData(MAX_SEED_WORDS_LENGTH) }
     var seedWordsLoading by remember { mutableStateOf(false) }
+    var seedWordsRequestToken by remember { mutableStateOf(0) }
 
     DisposableEffect(Unit) {
         onDispose { seedWordsData.clear() }
@@ -1004,12 +1005,14 @@ fun MainScreen(
                             allAccounts.firstOrNull { it.groupPubkeyHex == key }
                         }
                         if (acct != null) {
+                            val token = ++seedWordsRequestToken
                             seedWordsLoading = true
                             seedWordsData.clear()
                             showSeedWordsScreen = true
                             accountActions.viewSeedWords(
                                 acct,
                                 onResult = { mnemonic ->
+                                    if (token != seedWordsRequestToken || !showSeedWordsScreen) return@viewSeedWords
                                     if (mnemonic != null) {
                                         if (!seedWordsData.update(mnemonic)) {
                                             Log.w("MainActivity", "Seed words exceeded MAX_SEED_WORDS_LENGTH=$MAX_SEED_WORDS_LENGTH; truncated/rejected")
@@ -1018,6 +1021,7 @@ fun MainScreen(
                                     seedWordsLoading = false
                                 },
                                 onDismiss = { success ->
+                                    if (token != seedWordsRequestToken) return@viewSeedWords
                                     seedWordsLoading = false
                                     if (!success) {
                                         seedWordsData.clear()

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -426,13 +426,17 @@ fun MainScreen(
                             .onFailure { if (it is CancellationException) throw it }
                             .getOrDefault(descriptorCount)
                     } else 0
-                    PollResult(h, s, a, k, dc)
+                    val db = runCatching { keepMobile.getActiveShareMetadata()?.didBackup }
+                        .onFailure { if (it is CancellationException) throw it }
+                        .getOrNull()
+                    PollResult(h, s, a, k, dc, db)
                 }
                 hasShare = pollResult.hasShare
                 shareInfo = pollResult.shareInfo
                 allAccounts = pollResult.allAccounts
                 activeAccountKey = pollResult.activeAccountKey
                 descriptorCount = pollResult.descriptorCount
+                activeDidBackup = pollResult.activeDidBackup
                 refreshCertificatePins()
                 profileRelays = withContext(Dispatchers.IO) { loadProfileRelays(pollResult.activeAccountKey) }
                 delay(10_000)
@@ -739,6 +743,12 @@ fun MainScreen(
                         if (success) {
                             seedWordsData.clear()
                             showSeedWordsScreen = false
+                        } else {
+                            Toast.makeText(
+                                appContext,
+                                "Failed to confirm backup. Please try again.",
+                                Toast.LENGTH_SHORT
+                            ).show()
                         }
                     }
                 }
@@ -1504,7 +1514,8 @@ private data class PollResult(
     val shareInfo: ShareInfo?,
     val allAccounts: List<AccountInfo>,
     val activeAccountKey: String?,
-    val descriptorCount: Int
+    val descriptorCount: Int,
+    val activeDidBackup: Boolean?
 )
 
 @Composable

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -426,15 +426,13 @@ fun MainScreen(
                             .onFailure { if (it is CancellationException) throw it }
                             .getOrDefault(descriptorCount)
                     } else 0
-                    val db = runCatching { keepMobile.getActiveShareMetadata()?.didBackup }.getOrNull()
-                    PollResult(h, s, a, k, dc, db)
+                    PollResult(h, s, a, k, dc)
                 }
                 hasShare = pollResult.hasShare
                 shareInfo = pollResult.shareInfo
                 allAccounts = pollResult.allAccounts
                 activeAccountKey = pollResult.activeAccountKey
                 descriptorCount = pollResult.descriptorCount
-                activeDidBackup = pollResult.activeDidBackup
                 refreshCertificatePins()
                 profileRelays = withContext(Dispatchers.IO) { loadProfileRelays(pollResult.activeAccountKey) }
                 delay(10_000)
@@ -1001,7 +999,9 @@ fun MainScreen(
                                 acct,
                                 onResult = { mnemonic ->
                                     if (mnemonic != null) {
-                                        seedWordsData.update(mnemonic)
+                                        if (!seedWordsData.update(mnemonic)) {
+                                            Log.w("MainActivity", "Seed words exceeded MAX_SEED_WORDS_LENGTH=$MAX_SEED_WORDS_LENGTH; truncated/rejected")
+                                        }
                                     }
                                     seedWordsLoading = false
                                 },
@@ -1504,8 +1504,7 @@ private data class PollResult(
     val shareInfo: ShareInfo?,
     val allAccounts: List<AccountInfo>,
     val activeAccountKey: String?,
-    val descriptorCount: Int,
-    val activeDidBackup: Boolean?
+    val descriptorCount: Int
 )
 
 @Composable

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -59,6 +59,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.crypto.Cipher
 
+private const val MAX_SEED_WORDS_LENGTH = 1024
+
 class MainActivity : FragmentActivity() {
     private var biometricHelper: BiometricHelper? = null
 
@@ -313,6 +315,10 @@ fun MainScreen(
     var showRecoverNsec by remember { mutableStateOf(false) }
     var showCreateAccountScreen by remember { mutableStateOf(false) }
     var showMnemonicRecoveryScreen by remember { mutableStateOf(false) }
+    var activeDidBackup by remember { mutableStateOf<Boolean?>(null) }
+    var showSeedWordsScreen by remember { mutableStateOf(false) }
+    val seedWordsData = remember { SecureShareData(MAX_SEED_WORDS_LENGTH) }
+    var seedWordsLoading by remember { mutableStateOf(false) }
 
     val proxyConfig = remember { runCatching { keepMobile.getProxyConfig() }.getOrNull() }
     var proxyEnabled by remember { mutableStateOf(proxyConfig?.enabled == true) }
@@ -347,6 +353,7 @@ fun MainScreen(
                 allAccounts = state.allAccounts
                 relays = state.relays
                 profileRelays = state.profileRelays
+                activeDidBackup = state.activeDidBackup
             }
         )
     }
@@ -405,7 +412,7 @@ fun MainScreen(
         }
         lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
             repeat(Int.MAX_VALUE) {
-                val (newHasShare, newShareInfo, newAccounts, newActiveKey, newDescriptorCount) = withContext(Dispatchers.IO) {
+                val pollResult = withContext(Dispatchers.IO) {
                     val h = keepMobile.hasShare()
                     val s = keepMobile.getShareInfo()
                     val a = storage.listAllShares().map { it.toAccountInfo() }
@@ -415,15 +422,17 @@ fun MainScreen(
                             .onFailure { if (it is CancellationException) throw it }
                             .getOrDefault(descriptorCount)
                     } else 0
-                    PollResult(h, s, a, k, dc)
+                    val db = runCatching { keepMobile.getActiveShare()?.didBackup }.getOrNull()
+                    PollResult(h, s, a, k, dc, db)
                 }
-                hasShare = newHasShare
-                shareInfo = newShareInfo
-                allAccounts = newAccounts
-                activeAccountKey = newActiveKey
-                descriptorCount = newDescriptorCount
+                hasShare = pollResult.hasShare
+                shareInfo = pollResult.shareInfo
+                allAccounts = pollResult.allAccounts
+                activeAccountKey = pollResult.activeAccountKey
+                descriptorCount = pollResult.descriptorCount
+                activeDidBackup = pollResult.activeDidBackup
                 refreshCertificatePins()
-                profileRelays = withContext(Dispatchers.IO) { loadProfileRelays(newActiveKey) }
+                profileRelays = withContext(Dispatchers.IO) { loadProfileRelays(pollResult.activeAccountKey) }
                 delay(10_000)
             }
         }
@@ -713,6 +722,36 @@ fun MainScreen(
         return
     }
 
+    DisposableEffect(Unit) {
+        onDispose { seedWordsData.clear() }
+    }
+
+    if (showSeedWordsScreen) {
+        val activeAccount = remember(activeAccountKey, allAccounts) {
+            activeAccountKey?.let { key -> allAccounts.firstOrNull { it.groupPubkeyHex == key } }
+        }
+        SeedWordsScreen(
+            mnemonicData = if (seedWordsLoading) null else seedWordsData,
+            didBackup = activeDidBackup == true,
+            onConfirmBackedUp = {
+                val acct = activeAccount
+                if (acct != null) {
+                    accountActions.markBackedUp(acct) { success ->
+                        if (success) {
+                            seedWordsData.clear()
+                            showSeedWordsScreen = false
+                        }
+                    }
+                }
+            },
+            onDismiss = {
+                seedWordsData.clear()
+                showSeedWordsScreen = false
+            }
+        )
+        return
+    }
+
     if (showMnemonicRecoveryScreen) {
         MnemonicRecoveryScreen(
             keepMobile = keepMobile,
@@ -944,10 +983,35 @@ fun MainScreen(
                     hasShare = hasShare,
                     shareInfo = shareInfo,
                     allAccounts = allAccounts,
+                    activeDidBackup = activeDidBackup,
                     onAccountSwitcherClick = { showAccountSwitcher = true },
                     onShareDetailsClick = { showShareDetails = true },
                     onExportClick = { showExportScreen = true },
                     onExportNcryptsecClick = { showExportNcryptsecScreen = true },
+                    onViewSeedWords = {
+                        val activeKey = activeAccountKey
+                        val acct = activeKey?.let { k -> allAccounts.firstOrNull { it.groupPubkeyHex == k } }
+                        if (acct != null) {
+                            seedWordsLoading = true
+                            seedWordsData.clear()
+                            showSeedWordsScreen = true
+                            accountActions.viewSeedWords(
+                                acct,
+                                onResult = { mnemonic ->
+                                    if (mnemonic != null) {
+                                        seedWordsData.update(mnemonic)
+                                    }
+                                    seedWordsLoading = false
+                                },
+                                onDismiss = {
+                                    seedWordsLoading = false
+                                    if (!seedWordsData.isNotBlank()) {
+                                        showSeedWordsScreen = false
+                                    }
+                                }
+                            )
+                        }
+                    },
                     onImport = { showImportScreen = true },
                     onImportNsec = { showImportNsecScreen = true },
                     onCreateAccount = { showCreateAccountScreen = true },
@@ -1269,10 +1333,12 @@ private fun AccountTab(
     hasShare: Boolean,
     shareInfo: ShareInfo?,
     allAccounts: List<AccountInfo>,
+    activeDidBackup: Boolean?,
     onAccountSwitcherClick: () -> Unit,
     onShareDetailsClick: () -> Unit,
     onExportClick: () -> Unit,
     onExportNcryptsecClick: () -> Unit,
+    onViewSeedWords: () -> Unit,
     onImport: () -> Unit,
     onImportNsec: () -> Unit,
     onCreateAccount: () -> Unit,
@@ -1289,6 +1355,11 @@ private fun AccountTab(
     ) {
         Text(text = "Keys", style = MaterialTheme.typography.headlineLarge)
         Spacer(modifier = Modifier.height(16.dp))
+
+        if (hasShare && activeDidBackup == false) {
+            BackupPromptCard(onClick = onViewSeedWords)
+            Spacer(modifier = Modifier.height(16.dp))
+        }
 
         if (allAccounts.isNotEmpty()) {
             AccountSelectorCard(
@@ -1310,6 +1381,13 @@ private fun AccountTab(
                 Column(modifier = Modifier.padding(16.dp)) {
                     Text("Key Management", style = MaterialTheme.typography.titleMedium)
                     Spacer(modifier = Modifier.height(12.dp))
+                    OutlinedButton(
+                        onClick = onViewSeedWords,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text("View Seed Words")
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
                     OutlinedButton(
                         onClick = onExportClick,
                         modifier = Modifier.fillMaxWidth()
@@ -1393,12 +1471,39 @@ private data class AccountInitial(
     val profileRelays: List<String>
 )
 
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BackupPromptCard(onClick: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        onClick = onClick,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                "Back up your seed words",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                "You haven't confirmed that you've saved your seed words. Tap to view them and back up your account.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer
+            )
+        }
+    }
+}
+
 private data class PollResult(
     val hasShare: Boolean,
     val shareInfo: ShareInfo?,
     val allAccounts: List<AccountInfo>,
     val activeAccountKey: String?,
-    val descriptorCount: Int
+    val descriptorCount: Int,
+    val activeDidBackup: Boolean?
 )
 
 @Composable

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -426,7 +426,7 @@ fun MainScreen(
                             .onFailure { if (it is CancellationException) throw it }
                             .getOrDefault(descriptorCount)
                     } else 0
-                    val db = runCatching { keepMobile.getActiveShare()?.didBackup }.getOrNull()
+                    val db = runCatching { keepMobile.getActiveShareMetadata()?.didBackup }.getOrNull()
                     PollResult(h, s, a, k, dc, db)
                 }
                 hasShare = pollResult.hasShare

--- a/app/src/main/kotlin/io/privkey/keep/QrCodeDisplay.kt
+++ b/app/src/main/kotlin/io/privkey/keep/QrCodeDisplay.kt
@@ -104,7 +104,8 @@ internal class SecureShareData(private val maxLength: Int) {
     fun isNotBlank(): Boolean = chars.isNotEmpty() && chars.any { !it.isWhitespace() }
 
     fun words(): List<String> =
-        if (chars.isEmpty()) emptyList() else String(chars).split(" ")
+        if (chars.isEmpty()) emptyList()
+        else String(chars).trim().split(Regex("\\s+")).filter { it.isNotEmpty() }
 
     fun valueUnsafe(): String = String(chars)
 

--- a/app/src/main/kotlin/io/privkey/keep/QrCodeDisplay.kt
+++ b/app/src/main/kotlin/io/privkey/keep/QrCodeDisplay.kt
@@ -109,6 +109,28 @@ internal class SecureShareData(private val maxLength: Int) {
 
     fun valueUnsafe(): String = String(chars)
 
+    // Splits the stored chars into per-word CharArrays without ever constructing a full
+    // String over the sensitive data. Returned arrays are owned by the caller and should
+    // be wiped (Arrays.fill(..., '\u0000')) as soon as they are no longer needed.
+    fun wordsAsCharArrays(): List<CharArray> {
+        if (chars.isEmpty()) return emptyList()
+        val result = mutableListOf<CharArray>()
+        var start = -1
+        for (i in chars.indices) {
+            val isWs = chars[i].isWhitespace()
+            if (!isWs && start == -1) {
+                start = i
+            } else if (isWs && start != -1) {
+                result.add(chars.copyOfRange(start, i))
+                start = -1
+            }
+        }
+        if (start != -1) {
+            result.add(chars.copyOfRange(start, chars.size))
+        }
+        return result
+    }
+
     override fun toString(): String = "<redacted>"
 }
 

--- a/app/src/main/kotlin/io/privkey/keep/SeedWordsScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/SeedWordsScreen.kt
@@ -1,0 +1,150 @@
+package io.privkey.keep
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun SeedWordsScreen(
+    mnemonicData: SecureShareData?,
+    didBackup: Boolean,
+    onConfirmBackedUp: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val context = LocalContext.current
+    var showCopyWarning by remember { mutableStateOf(false) }
+
+    DisposableEffect(context) {
+        setSecureScreen(context, true)
+        onDispose { setSecureScreen(context, false) }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .statusBarsPadding()
+            .padding(24.dp)
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Seed Words",
+            style = MaterialTheme.typography.headlineMedium
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        if (mnemonicData == null || !mnemonicData.isNotBlank()) {
+            StatusCard(
+                text = "No seed words available for this account. Seed words are only available for accounts created from a mnemonic in this app.",
+                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Button(
+                onClick = onDismiss,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Back")
+            }
+            return@Column
+        }
+
+        val words = mnemonicData.words()
+        val halfSize = words.size / 2
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            SeedWordColumn(words, 0 until halfSize, Modifier.weight(1f))
+            SeedWordColumn(words, halfSize until words.size, Modifier.weight(1f))
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedButton(
+            onClick = { showCopyWarning = true },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Copy to clipboard")
+        }
+
+        if (showCopyWarning) {
+            AlertDialog(
+                onDismissRequest = { showCopyWarning = false },
+                title = { Text("Copy seed words?") },
+                text = { Text("Your seed words will be placed on the clipboard, where other apps may be able to read them. The clipboard will be cleared after 10 seconds.") },
+                confirmButton = {
+                    TextButton(onClick = {
+                        showCopyWarning = false
+                        copySensitiveText(context, mnemonicData.valueUnsafe())
+                    }) { Text("Copy") }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showCopyWarning = false }) { Text("Cancel") }
+                }
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = "Write down these words and store them safely. Anyone with these words can access your account.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.error
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        if (!didBackup) {
+            Button(
+                onClick = onConfirmBackedUp,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("I've saved my seed words")
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            OutlinedButton(
+                onClick = onDismiss,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Back")
+            }
+        } else {
+            Button(
+                onClick = onDismiss,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Back")
+            }
+        }
+    }
+}
+
+@Composable
+private fun SeedWordColumn(words: List<String>, range: IntRange, modifier: Modifier) {
+    Column(modifier = modifier) {
+        for (i in range) {
+            OutlinedTextField(
+                value = words[i],
+                onValueChange = {},
+                readOnly = true,
+                prefix = { Text("${i + 1}. ") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true
+            )
+            if (i < range.last) {
+                Spacer(modifier = Modifier.height(4.dp))
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/io/privkey/keep/SeedWordsScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/SeedWordsScreen.kt
@@ -40,6 +40,7 @@ internal fun SeedWordsScreen(
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_STOP) {
                 mnemonicData?.clear()
+                onDismiss()
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)

--- a/app/src/main/kotlin/io/privkey/keep/SeedWordsScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/SeedWordsScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import android.app.Activity
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.password
 import androidx.compose.ui.semantics.semantics
@@ -40,13 +39,8 @@ internal fun SeedWordsScreen(
     DisposableEffect(lifecycleOwner, mnemonicData) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_STOP) {
-                // Skip wipe across configuration changes (e.g. rotation): otherwise the user
-                // would be forced to re-authenticate to re-fetch the same mnemonic mid-display.
-                val isConfigChange = (context as? Activity)?.isChangingConfigurations == true
-                if (!isConfigChange) {
-                    mnemonicData?.clear()
-                    onDismiss()
-                }
+                mnemonicData?.clear()
+                onDismiss()
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)

--- a/app/src/main/kotlin/io/privkey/keep/SeedWordsScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/SeedWordsScreen.kt
@@ -38,7 +38,7 @@ internal fun SeedWordsScreen(
 
     DisposableEffect(lifecycleOwner, mnemonicData) {
         val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_STOP || event == Lifecycle.Event.ON_PAUSE) {
+            if (event == Lifecycle.Event.ON_STOP) {
                 mnemonicData?.clear()
             }
         }
@@ -75,7 +75,7 @@ internal fun SeedWordsScreen(
             return@Column
         }
 
-        if (mnemonicData == null || !mnemonicData.isNotBlank()) {
+        if (mnemonicData?.isNotBlank() != true) {
             StatusCard(
                 text = "No seed words available for this account. Seed words are only available for accounts created from a mnemonic in this app.",
                 containerColor = MaterialTheme.colorScheme.secondaryContainer,

--- a/app/src/main/kotlin/io/privkey/keep/SeedWordsScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/SeedWordsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import android.app.Activity
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.password
 import androidx.compose.ui.semantics.semantics
@@ -39,8 +40,13 @@ internal fun SeedWordsScreen(
     DisposableEffect(lifecycleOwner, mnemonicData) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_STOP) {
-                mnemonicData?.clear()
-                onDismiss()
+                // Skip wipe across configuration changes (e.g. rotation): otherwise the user
+                // would be forced to re-authenticate to re-fetch the same mnemonic mid-display.
+                val isConfigChange = (context as? Activity)?.isChangingConfigurations == true
+                if (!isConfigChange) {
+                    mnemonicData?.clear()
+                    onDismiss()
+                }
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
@@ -166,7 +172,9 @@ private fun SeedWordColumn(words: List<CharArray>, range: IntRange, modifier: Mo
                 // Compose Text requires a String/AnnotatedString; there is no sink that
                 // accepts CharArray. This constructs a per-word String that cannot be
                 // zeroed, but the lifetime is scoped to the composition and the underlying
-                // CharArray is wiped on dispose.
+                // CharArray is wiped on dispose. Per-word BIP-39 dictionary entries in
+                // isolation (without ordering) are far lower-risk than the full mnemonic;
+                // the CharArray that preserves ordering is the one we explicitly wipe.
                 Text(
                     text = String(words[i]),
                     style = MaterialTheme.typography.bodyLarge,

--- a/app/src/main/kotlin/io/privkey/keep/SeedWordsScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/SeedWordsScreen.kt
@@ -1,29 +1,52 @@
 package io.privkey.keep
 
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.password
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 
 @Composable
 internal fun SeedWordsScreen(
     mnemonicData: SecureShareData?,
+    isLoading: Boolean,
     didBackup: Boolean,
     onConfirmBackedUp: () -> Unit,
     onDismiss: () -> Unit
 ) {
     val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
     var showCopyWarning by remember { mutableStateOf(false) }
 
     DisposableEffect(context) {
         setSecureScreen(context, true)
         onDispose { setSecureScreen(context, false) }
     }
+
+    DisposableEffect(lifecycleOwner, mnemonicData) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_STOP || event == Lifecycle.Event.ON_PAUSE) {
+                mnemonicData?.clear()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    BackHandler { onDismiss() }
 
     Column(
         modifier = Modifier
@@ -39,6 +62,18 @@ internal fun SeedWordsScreen(
         )
 
         Spacer(modifier = Modifier.height(16.dp))
+
+        if (isLoading) {
+            CircularProgressIndicator()
+            Spacer(modifier = Modifier.height(24.dp))
+            OutlinedButton(
+                onClick = onDismiss,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Back")
+            }
+            return@Column
+        }
 
         if (mnemonicData == null || !mnemonicData.isNotBlank()) {
             StatusCard(
@@ -59,7 +94,7 @@ internal fun SeedWordsScreen(
         }
 
         val words = mnemonicData.words()
-        val halfSize = words.size / 2
+        val halfSize = (words.size + 1) / 2
 
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -134,15 +169,29 @@ internal fun SeedWordsScreen(
 private fun SeedWordColumn(words: List<String>, range: IntRange, modifier: Modifier) {
     Column(modifier = modifier) {
         for (i in range) {
-            OutlinedTextField(
-                value = words[i],
-                onValueChange = {},
-                readOnly = true,
-                prefix = { Text("${i + 1}. ") },
-                modifier = Modifier.fillMaxWidth(),
-                singleLine = true
-            )
-            if (i < range.last) {
+            if (i >= words.size) break
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    .padding(horizontal = 12.dp, vertical = 10.dp)
+                    .semantics { password() },
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "${i + 1}.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.width(28.dp)
+                )
+                Text(
+                    text = words[i],
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
+            if (i < range.last && i + 1 < words.size) {
                 Spacer(modifier = Modifier.height(4.dp))
             }
         }

--- a/app/src/main/kotlin/io/privkey/keep/SeedWordsScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/SeedWordsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import java.util.Arrays
 
 @Composable
 internal fun SeedWordsScreen(
@@ -29,7 +30,6 @@ internal fun SeedWordsScreen(
 ) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
-    var showCopyWarning by remember { mutableStateOf(false) }
 
     DisposableEffect(context) {
         setSecureScreen(context, true)
@@ -94,41 +94,18 @@ internal fun SeedWordsScreen(
             return@Column
         }
 
-        val words = mnemonicData.words()
-        val halfSize = (words.size + 1) / 2
+        val wordArrays = remember(mnemonicData) { mnemonicData.wordsAsCharArrays() }
+        DisposableEffect(wordArrays) {
+            onDispose { wordArrays.forEach { Arrays.fill(it, '\u0000') } }
+        }
+        val halfSize = (wordArrays.size + 1) / 2
 
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            SeedWordColumn(words, 0 until halfSize, Modifier.weight(1f))
-            SeedWordColumn(words, halfSize until words.size, Modifier.weight(1f))
-        }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        OutlinedButton(
-            onClick = { showCopyWarning = true },
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text("Copy to clipboard")
-        }
-
-        if (showCopyWarning) {
-            AlertDialog(
-                onDismissRequest = { showCopyWarning = false },
-                title = { Text("Copy seed words?") },
-                text = { Text("Your seed words will be placed on the clipboard, where other apps may be able to read them. The clipboard will be cleared after 10 seconds.") },
-                confirmButton = {
-                    TextButton(onClick = {
-                        showCopyWarning = false
-                        copySensitiveText(context, mnemonicData.valueUnsafe())
-                    }) { Text("Copy") }
-                },
-                dismissButton = {
-                    TextButton(onClick = { showCopyWarning = false }) { Text("Cancel") }
-                }
-            )
+            SeedWordColumn(wordArrays, 0 until halfSize, Modifier.weight(1f))
+            SeedWordColumn(wordArrays, halfSize until wordArrays.size, Modifier.weight(1f))
         }
 
         Spacer(modifier = Modifier.height(16.dp))
@@ -167,7 +144,7 @@ internal fun SeedWordsScreen(
 }
 
 @Composable
-private fun SeedWordColumn(words: List<String>, range: IntRange, modifier: Modifier) {
+private fun SeedWordColumn(words: List<CharArray>, range: IntRange, modifier: Modifier) {
     Column(modifier = modifier) {
         for (i in range) {
             if (i >= words.size) break
@@ -186,8 +163,12 @@ private fun SeedWordColumn(words: List<String>, range: IntRange, modifier: Modif
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.width(28.dp)
                 )
+                // Compose Text requires a String/AnnotatedString; there is no sink that
+                // accepts CharArray. This constructs a per-word String that cannot be
+                // zeroed, but the lifetime is scoped to the composition and the underlying
+                // CharArray is wiped on dispose.
                 Text(
-                    text = words[i],
+                    text = String(words[i]),
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurface
                 )

--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
@@ -44,6 +44,7 @@ class AndroidKeystoreStorage(
         private const val KEY_SHARE_THRESHOLD = "share_threshold"
         private const val KEY_SHARE_TOTAL = "share_total"
         private const val KEY_SHARE_GROUP_PUBKEY = "share_group_pubkey"
+        private const val KEY_SHARE_DID_BACKUP = "share_did_backup"
         private const val KEY_ACTIVE_SHARE = "active_share_key"
         private const val KEY_ALL_SHARE_KEYS = "all_share_keys"
         private const val PENDING_CIPHER_TIMEOUT_MS = 60_000L
@@ -323,6 +324,7 @@ class AndroidKeystoreStorage(
             .putInt(KEY_SHARE_THRESHOLD, metadata.threshold.toInt())
             .putInt(KEY_SHARE_TOTAL, metadata.totalShares.toInt())
             .putString(KEY_SHARE_GROUP_PUBKEY, Base64.encodeToString(metadata.groupPubkey, Base64.NO_WRAP))
+            .putBoolean(KEY_SHARE_DID_BACKUP, metadata.didBackup)
             .commit()
         if (!saved) {
             throw KeepMobileException.StorageException("Failed to save share data")
@@ -380,7 +382,8 @@ class AndroidKeystoreStorage(
             identifier = identifier.toUShort(),
             threshold = threshold.toUShort(),
             totalShares = totalShares.toUShort(),
-            groupPubkey = Base64.decode(groupPubkeyB64, Base64.NO_WRAP)
+            groupPubkey = Base64.decode(groupPubkeyB64, Base64.NO_WRAP),
+            didBackup = sharePrefs.getBoolean(KEY_SHARE_DID_BACKUP, false)
         )
     } catch (e: Exception) {
         if (BuildConfig.DEBUG) Log.e(TAG, "Failed to parse stored key metadata", e)
@@ -670,6 +673,7 @@ class AndroidKeystoreStorage(
             .putInt(KEY_SHARE_THRESHOLD, metadata.threshold.toInt())
             .putInt(KEY_SHARE_TOTAL, metadata.totalShares.toInt())
             .putString(KEY_SHARE_GROUP_PUBKEY, Base64.encodeToString(metadata.groupPubkey, Base64.NO_WRAP))
+            .putBoolean(KEY_SHARE_DID_BACKUP, metadata.didBackup)
             .commit()
         if (!saved) return
 

--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
@@ -57,7 +57,7 @@ class AndroidKeystoreStorage(
         val createdAtMs: Long
     )
     private val pendingCiphers = ConcurrentHashMap<String, ArrayDeque<PendingCipherData>>()
-    private val cipherConsumedCallbacks = ConcurrentHashMap<String, ArrayDeque<() -> Unit>>()
+    private val cipherConsumedCallbacks = ConcurrentHashMap<String, ArrayDeque<(() -> Unit)?>>()
 
     private val keyStore: KeyStore = KeyStore.getInstance("AndroidKeyStore").apply {
         load(null)
@@ -208,10 +208,8 @@ class AndroidKeystoreStorage(
         )
         val queue = pendingCiphers.compute(requestId) { _, existing -> existing ?: ArrayDeque() }!!
         synchronized(queue) { queue.add(data) }
-        if (onConsumed != null) {
-            val cbQueue = cipherConsumedCallbacks.compute(requestId) { _, existing -> existing ?: ArrayDeque() }!!
-            synchronized(cbQueue) { cbQueue.add(onConsumed) }
-        }
+        val cbQueue = cipherConsumedCallbacks.compute(requestId) { _, existing -> existing ?: ArrayDeque() }!!
+        synchronized(cbQueue) { cbQueue.add(onConsumed) }
     }
 
     private fun cleanupExpiredCiphers() {

--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
@@ -57,7 +57,7 @@ class AndroidKeystoreStorage(
         val createdAtMs: Long
     )
     private val pendingCiphers = ConcurrentHashMap<String, ArrayDeque<PendingCipherData>>()
-    private val cipherConsumedCallbacks = ConcurrentHashMap<String, () -> Unit>()
+    private val cipherConsumedCallbacks = ConcurrentHashMap<String, ArrayDeque<() -> Unit>>()
 
     private val keyStore: KeyStore = KeyStore.getInstance("AndroidKeyStore").apply {
         load(null)
@@ -206,18 +206,20 @@ class AndroidKeystoreStorage(
             creatingThreadId = Thread.currentThread().id,
             createdAtMs = SystemClock.elapsedRealtime()
         )
-        pendingCiphers.compute(requestId) { _, existing ->
-            (existing ?: ArrayDeque()).apply { add(data) }
-        }
+        val queue = pendingCiphers.compute(requestId) { _, existing -> existing ?: ArrayDeque() }!!
+        synchronized(queue) { queue.add(data) }
         if (onConsumed != null) {
-            cipherConsumedCallbacks[requestId] = onConsumed
+            val cbQueue = cipherConsumedCallbacks.compute(requestId) { _, existing -> existing ?: ArrayDeque() }!!
+            synchronized(cbQueue) { cbQueue.add(onConsumed) }
         }
     }
 
     private fun cleanupExpiredCiphers() {
         val now = SystemClock.elapsedRealtime()
         val expired = pendingCiphers.entries.filter { entry ->
-            entry.value.isEmpty() || entry.value.all { now - it.createdAtMs > PENDING_CIPHER_TIMEOUT_MS }
+            synchronized(entry.value) {
+                entry.value.isEmpty() || entry.value.all { now - it.createdAtMs > PENDING_CIPHER_TIMEOUT_MS }
+            }
         }
         expired.forEach { entry ->
             pendingCiphers.remove(entry.key)
@@ -225,25 +227,63 @@ class AndroidKeystoreStorage(
         }
     }
 
+    // Drops all pending ciphers and callbacks for the given requestId.
     fun clearPendingCipher(requestId: String) {
-        cipherConsumedCallbacks.remove(requestId)
-        pendingCiphers.remove(requestId)
+        val queue = pendingCiphers[requestId]
+        if (queue != null) {
+            synchronized(queue) {
+                queue.clear()
+                pendingCiphers.remove(requestId, queue)
+            }
+        }
+        val cbQueue = cipherConsumedCallbacks[requestId]
+        if (cbQueue != null) {
+            synchronized(cbQueue) {
+                cbQueue.clear()
+                cipherConsumedCallbacks.remove(requestId, cbQueue)
+            }
+        }
     }
 
+    // Consumes pending ciphers in FIFO order. Callers MUST setPendingCipher in the
+    // same order the Rust FFI consumes them (e.g. markShareBackedUp: decrypt then encrypt).
     fun consumePendingCipher(requestId: String): Cipher? {
         val queue = pendingCiphers[requestId] ?: return null
-        val data = synchronized(queue) { if (queue.isEmpty()) null else queue.removeFirst() } ?: return null
-        if (queue.isEmpty()) {
-            pendingCiphers.remove(requestId, queue)
-            val callback = cipherConsumedCallbacks.remove(requestId)
-            val isExpired = SystemClock.elapsedRealtime() - data.createdAtMs > PENDING_CIPHER_TIMEOUT_MS
-            if (isExpired) return null
-            callback?.invoke()
-            return data.cipher
+        val cbQueue = cipherConsumedCallbacks[requestId]
+        var poppedCipher: Cipher? = null
+        var callbackToFire: (() -> Unit)? = null
+        synchronized(queue) {
+            if (queue.isEmpty()) {
+                pendingCiphers.remove(requestId, queue)
+                return null
+            }
+            val popped = queue.removeFirst()
+            val isExpired = SystemClock.elapsedRealtime() - popped.createdAtMs > PENDING_CIPHER_TIMEOUT_MS
+            if (isExpired) {
+                // Drain the whole queue on expiry: remaining entries are stale and should not be served later.
+                queue.clear()
+                pendingCiphers.remove(requestId, queue)
+                if (cbQueue != null) {
+                    synchronized(cbQueue) {
+                        cbQueue.clear()
+                        cipherConsumedCallbacks.remove(requestId, cbQueue)
+                    }
+                }
+                return null
+            }
+            poppedCipher = popped.cipher
+            if (cbQueue != null) {
+                synchronized(cbQueue) {
+                    if (cbQueue.isNotEmpty()) callbackToFire = cbQueue.removeFirst()
+                    if (cbQueue.isEmpty()) cipherConsumedCallbacks.remove(requestId, cbQueue)
+                }
+            }
+            if (queue.isEmpty()) {
+                pendingCiphers.remove(requestId, queue)
+            }
         }
-        val isExpired = SystemClock.elapsedRealtime() - data.createdAtMs > PENDING_CIPHER_TIMEOUT_MS
-        if (isExpired) return null
-        return data.cipher
+        callbackToFire?.invoke()
+        return poppedCipher
     }
 
     private val requestIdContext = ThreadLocal<String>()

--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
@@ -207,10 +207,26 @@ class AndroidKeystoreStorage(
             creatingThreadId = Thread.currentThread().id,
             createdAtMs = SystemClock.elapsedRealtime()
         )
-        val queue = pendingCiphers.compute(requestId) { _, existing -> existing ?: ArrayDeque() }!!
-        synchronized(queue) { queue.add(data) }
-        val cbQueue = cipherConsumedCallbacks.compute(requestId) { _, existing -> existing ?: ArrayDeque() }!!
-        synchronized(cbQueue) { cbQueue.add(onConsumed) }
+        while (true) {
+            val queue = pendingCiphers.compute(requestId) { _, existing -> existing ?: ArrayDeque() }!!
+            val added = synchronized(queue) {
+                if (pendingCiphers[requestId] === queue) {
+                    queue.add(data)
+                    true
+                } else false
+            }
+            if (added) break
+        }
+        while (true) {
+            val cbQueue = cipherConsumedCallbacks.compute(requestId) { _, existing -> existing ?: ArrayDeque() }!!
+            val added = synchronized(cbQueue) {
+                if (cipherConsumedCallbacks[requestId] === cbQueue) {
+                    cbQueue.add(onConsumed)
+                    true
+                } else false
+            }
+            if (added) break
+        }
     }
 
     private fun cleanupExpiredCiphers() {
@@ -383,7 +399,7 @@ class AndroidKeystoreStorage(
             threshold = threshold.toUShort(),
             totalShares = totalShares.toUShort(),
             groupPubkey = Base64.decode(groupPubkeyB64, Base64.NO_WRAP),
-            didBackup = sharePrefs.getBoolean(KEY_SHARE_DID_BACKUP, false)
+            didBackup = sharePrefs.getBoolean(KEY_SHARE_DID_BACKUP, true)
         )
     } catch (e: Exception) {
         if (BuildConfig.DEBUG) Log.e(TAG, "Failed to parse stored key metadata", e)

--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
@@ -55,10 +55,10 @@ class AndroidKeystoreStorage(
     private data class PendingCipherData(
         val cipher: Cipher,
         val creatingThreadId: Long,
-        val createdAtMs: Long
+        val createdAtMs: Long,
+        val onConsumed: (() -> Unit)?
     )
     private val pendingCiphers = ConcurrentHashMap<String, ArrayDeque<PendingCipherData>>()
-    private val cipherConsumedCallbacks = ConcurrentHashMap<String, ArrayDeque<(() -> Unit)?>>()
 
     private val keyStore: KeyStore = KeyStore.getInstance("AndroidKeyStore").apply {
         load(null)
@@ -205,23 +205,14 @@ class AndroidKeystoreStorage(
         val data = PendingCipherData(
             cipher = cipher,
             creatingThreadId = Thread.currentThread().id,
-            createdAtMs = SystemClock.elapsedRealtime()
+            createdAtMs = SystemClock.elapsedRealtime(),
+            onConsumed = onConsumed
         )
         while (true) {
             val queue = pendingCiphers.compute(requestId) { _, existing -> existing ?: ArrayDeque() }!!
             val added = synchronized(queue) {
                 if (pendingCiphers[requestId] === queue) {
                     queue.add(data)
-                    true
-                } else false
-            }
-            if (added) break
-        }
-        while (true) {
-            val cbQueue = cipherConsumedCallbacks.compute(requestId) { _, existing -> existing ?: ArrayDeque() }!!
-            val added = synchronized(cbQueue) {
-                if (cipherConsumedCallbacks[requestId] === cbQueue) {
-                    cbQueue.add(onConsumed)
                     true
                 } else false
             }
@@ -235,10 +226,8 @@ class AndroidKeystoreStorage(
             synchronized(entry.value) {
                 val stale = entry.value.isEmpty() ||
                     entry.value.all { now - it.createdAtMs > PENDING_CIPHER_TIMEOUT_MS }
-                if (stale && pendingCiphers.remove(entry.key, entry.value)) {
-                    cipherConsumedCallbacks[entry.key]?.let { cbQueue ->
-                        cipherConsumedCallbacks.remove(entry.key, cbQueue)
-                    }
+                if (stale) {
+                    pendingCiphers.remove(entry.key, entry.value)
                 }
             }
         }
@@ -246,19 +235,10 @@ class AndroidKeystoreStorage(
 
     // Drops all pending ciphers and callbacks for the given requestId.
     fun clearPendingCipher(requestId: String) {
-        val queue = pendingCiphers[requestId]
-        if (queue != null) {
-            synchronized(queue) {
-                queue.clear()
-                pendingCiphers.remove(requestId, queue)
-            }
-        }
-        val cbQueue = cipherConsumedCallbacks[requestId]
-        if (cbQueue != null) {
-            synchronized(cbQueue) {
-                cbQueue.clear()
-                cipherConsumedCallbacks.remove(requestId, cbQueue)
-            }
+        val queue = pendingCiphers[requestId] ?: return
+        synchronized(queue) {
+            queue.clear()
+            pendingCiphers.remove(requestId, queue)
         }
     }
 
@@ -266,7 +246,6 @@ class AndroidKeystoreStorage(
     // same order the Rust FFI consumes them (e.g. markShareBackedUp: decrypt then encrypt).
     fun consumePendingCipher(requestId: String): Cipher? {
         val queue = pendingCiphers[requestId] ?: return null
-        val cbQueue = cipherConsumedCallbacks[requestId]
         var poppedCipher: Cipher? = null
         var callbackToFire: (() -> Unit)? = null
         synchronized(queue) {
@@ -280,21 +259,10 @@ class AndroidKeystoreStorage(
                 // Drain the whole queue on expiry: remaining entries are stale and should not be served later.
                 queue.clear()
                 pendingCiphers.remove(requestId, queue)
-                if (cbQueue != null) {
-                    synchronized(cbQueue) {
-                        cbQueue.clear()
-                        cipherConsumedCallbacks.remove(requestId, cbQueue)
-                    }
-                }
                 return null
             }
             poppedCipher = popped.cipher
-            if (cbQueue != null) {
-                synchronized(cbQueue) {
-                    if (cbQueue.isNotEmpty()) callbackToFire = cbQueue.removeFirst()
-                    if (cbQueue.isEmpty()) cipherConsumedCallbacks.remove(requestId, cbQueue)
-                }
-            }
+            callbackToFire = popped.onConsumed
             if (queue.isEmpty()) {
                 pendingCiphers.remove(requestId, queue)
             }
@@ -399,7 +367,7 @@ class AndroidKeystoreStorage(
             threshold = threshold.toUShort(),
             totalShares = totalShares.toUShort(),
             groupPubkey = Base64.decode(groupPubkeyB64, Base64.NO_WRAP),
-            didBackup = sharePrefs.getBoolean(KEY_SHARE_DID_BACKUP, true)
+            didBackup = sharePrefs.getBoolean(KEY_SHARE_DID_BACKUP, false)
         )
     } catch (e: Exception) {
         if (BuildConfig.DEBUG) Log.e(TAG, "Failed to parse stored key metadata", e)

--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
@@ -56,7 +56,7 @@ class AndroidKeystoreStorage(
         val creatingThreadId: Long,
         val createdAtMs: Long
     )
-    private val pendingCiphers = ConcurrentHashMap<String, PendingCipherData>()
+    private val pendingCiphers = ConcurrentHashMap<String, ArrayDeque<PendingCipherData>>()
     private val cipherConsumedCallbacks = ConcurrentHashMap<String, () -> Unit>()
 
     private val keyStore: KeyStore = KeyStore.getInstance("AndroidKeyStore").apply {
@@ -206,7 +206,9 @@ class AndroidKeystoreStorage(
             creatingThreadId = Thread.currentThread().id,
             createdAtMs = SystemClock.elapsedRealtime()
         )
-        pendingCiphers[requestId] = data
+        pendingCiphers.compute(requestId) { _, existing ->
+            (existing ?: ArrayDeque()).apply { add(data) }
+        }
         if (onConsumed != null) {
             cipherConsumedCallbacks[requestId] = onConsumed
         }
@@ -214,7 +216,9 @@ class AndroidKeystoreStorage(
 
     private fun cleanupExpiredCiphers() {
         val now = SystemClock.elapsedRealtime()
-        val expired = pendingCiphers.entries.filter { now - it.value.createdAtMs > PENDING_CIPHER_TIMEOUT_MS }
+        val expired = pendingCiphers.entries.filter { entry ->
+            entry.value.isEmpty() || entry.value.all { now - it.createdAtMs > PENDING_CIPHER_TIMEOUT_MS }
+        }
         expired.forEach { entry ->
             pendingCiphers.remove(entry.key)
             cipherConsumedCallbacks.remove(entry.key)
@@ -227,11 +231,18 @@ class AndroidKeystoreStorage(
     }
 
     fun consumePendingCipher(requestId: String): Cipher? {
-        val data = pendingCiphers.remove(requestId) ?: return null
-        val callback = cipherConsumedCallbacks.remove(requestId)
+        val queue = pendingCiphers[requestId] ?: return null
+        val data = synchronized(queue) { if (queue.isEmpty()) null else queue.removeFirst() } ?: return null
+        if (queue.isEmpty()) {
+            pendingCiphers.remove(requestId, queue)
+            val callback = cipherConsumedCallbacks.remove(requestId)
+            val isExpired = SystemClock.elapsedRealtime() - data.createdAtMs > PENDING_CIPHER_TIMEOUT_MS
+            if (isExpired) return null
+            callback?.invoke()
+            return data.cipher
+        }
         val isExpired = SystemClock.elapsedRealtime() - data.createdAtMs > PENDING_CIPHER_TIMEOUT_MS
         if (isExpired) return null
-        callback?.invoke()
         return data.cipher
     }
 

--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
@@ -225,20 +225,6 @@ class AndroidKeystoreStorage(
         }
     }
 
-    // Refreshes the createdAtMs of all pending ciphers for a requestId so chained operations
-    // (e.g. markShareBackedUp: decrypt cipher enqueued, then second biometric, then FFI call)
-    // do not race the expiry timeout while waiting on user interaction.
-    fun refreshPendingCipher(requestId: String) {
-        val queue = pendingCiphers[requestId] ?: return
-        val now = SystemClock.elapsedRealtime()
-        synchronized(queue) {
-            if (pendingCiphers[requestId] !== queue) return
-            val refreshed = queue.map { it.copy(createdAtMs = now) }
-            queue.clear()
-            queue.addAll(refreshed)
-        }
-    }
-
     private fun cleanupExpiredCiphers() {
         val now = SystemClock.elapsedRealtime()
         pendingCiphers.entries.forEach { entry ->

--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
@@ -222,8 +222,10 @@ class AndroidKeystoreStorage(
             }
         }
         expired.forEach { entry ->
-            pendingCiphers.remove(entry.key)
-            cipherConsumedCallbacks.remove(entry.key)
+            pendingCiphers.remove(entry.key, entry.value)
+            cipherConsumedCallbacks[entry.key]?.let { cbQueue ->
+                cipherConsumedCallbacks.remove(entry.key, cbQueue)
+            }
         }
     }
 

--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
@@ -44,6 +44,8 @@ class AndroidKeystoreStorage(
         private const val KEY_SHARE_THRESHOLD = "share_threshold"
         private const val KEY_SHARE_TOTAL = "share_total"
         private const val KEY_SHARE_GROUP_PUBKEY = "share_group_pubkey"
+        // Non-authoritative UI cache. The Rust-side metadata via keepMobile.getActiveShareMetadata()
+        // is the source of truth; this pref exists for fast reads and must not gate sensitive UI.
         private const val KEY_SHARE_DID_BACKUP = "share_did_backup"
         private const val KEY_ACTIVE_SHARE = "active_share_key"
         private const val KEY_ALL_SHARE_KEYS = "all_share_keys"
@@ -209,6 +211,9 @@ class AndroidKeystoreStorage(
             onConsumed = onConsumed
         )
         while (true) {
+            // compute() atomically inserts a queue if absent, but a concurrent clearPendingCipher
+            // or cleanupExpiredCiphers may remove it before we take its lock. Re-check identity
+            // under the lock and retry if the map no longer points at our queue instance.
             val queue = pendingCiphers.compute(requestId) { _, existing -> existing ?: ArrayDeque() }!!
             val added = synchronized(queue) {
                 if (pendingCiphers[requestId] === queue) {
@@ -220,13 +225,27 @@ class AndroidKeystoreStorage(
         }
     }
 
+    // Refreshes the createdAtMs of all pending ciphers for a requestId so chained operations
+    // (e.g. markShareBackedUp: decrypt cipher enqueued, then second biometric, then FFI call)
+    // do not race the expiry timeout while waiting on user interaction.
+    fun refreshPendingCipher(requestId: String) {
+        val queue = pendingCiphers[requestId] ?: return
+        val now = SystemClock.elapsedRealtime()
+        synchronized(queue) {
+            if (pendingCiphers[requestId] !== queue) return
+            val refreshed = queue.map { it.copy(createdAtMs = now) }
+            queue.clear()
+            queue.addAll(refreshed)
+        }
+    }
+
     private fun cleanupExpiredCiphers() {
         val now = SystemClock.elapsedRealtime()
         pendingCiphers.entries.forEach { entry ->
             synchronized(entry.value) {
-                val stale = entry.value.isEmpty() ||
-                    entry.value.all { now - it.createdAtMs > PENDING_CIPHER_TIMEOUT_MS }
-                if (stale) {
+                // Drop only the stale entries, preserving fresh ones that may sit behind them.
+                entry.value.removeAll { now - it.createdAtMs > PENDING_CIPHER_TIMEOUT_MS }
+                if (entry.value.isEmpty()) {
                     pendingCiphers.remove(entry.key, entry.value)
                 }
             }
@@ -249,18 +268,15 @@ class AndroidKeystoreStorage(
         var poppedCipher: Cipher? = null
         var callbackToFire: (() -> Unit)? = null
         synchronized(queue) {
+            val now = SystemClock.elapsedRealtime()
+            // Strip stale entries before popping so a stale head does not mask fresh followers
+            // and stale tails do not linger past their expiry.
+            queue.removeAll { now - it.createdAtMs > PENDING_CIPHER_TIMEOUT_MS }
             if (queue.isEmpty()) {
                 pendingCiphers.remove(requestId, queue)
                 return null
             }
             val popped = queue.removeFirst()
-            val isExpired = SystemClock.elapsedRealtime() - popped.createdAtMs > PENDING_CIPHER_TIMEOUT_MS
-            if (isExpired) {
-                // Drain the whole queue on expiry: remaining entries are stale and should not be served later.
-                queue.clear()
-                pendingCiphers.remove(requestId, queue)
-                return null
-            }
             poppedCipher = popped.cipher
             callbackToFire = popped.onConsumed
             if (queue.isEmpty()) {

--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
@@ -231,15 +231,15 @@ class AndroidKeystoreStorage(
 
     private fun cleanupExpiredCiphers() {
         val now = SystemClock.elapsedRealtime()
-        val expired = pendingCiphers.entries.filter { entry ->
+        pendingCiphers.entries.forEach { entry ->
             synchronized(entry.value) {
-                entry.value.isEmpty() || entry.value.all { now - it.createdAtMs > PENDING_CIPHER_TIMEOUT_MS }
-            }
-        }
-        expired.forEach { entry ->
-            pendingCiphers.remove(entry.key, entry.value)
-            cipherConsumedCallbacks[entry.key]?.let { cbQueue ->
-                cipherConsumedCallbacks.remove(entry.key, cbQueue)
+                val stale = entry.value.isEmpty() ||
+                    entry.value.all { now - it.createdAtMs > PENDING_CIPHER_TIMEOUT_MS }
+                if (stale && pendingCiphers.remove(entry.key, entry.value)) {
+                    cipherConsumedCallbacks[entry.key]?.let { cbQueue ->
+                        cipherConsumedCallbacks.remove(entry.key, cbQueue)
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Adds seed word backup verification and retrieval flow with biometric gating, FLAG_SECURE, and sensitive-clipboard handling.

## Test Results (on-device, Pixel 7a)

Verified the full flow end-to-end after fixing two issues surfaced during testing:

1. **Backup prompt was dead on Android.** `activeDidBackup` was sourced from `getActiveShare()?.didBackup`, which requires decrypting the share blob and so always failed silently from the polling path (no cipher context). The red "Back up your seed words" card never rendered.
2. **Nsec imports incorrectly prompted for backup.** Nsec imports have no mnemonic, so the prompt was misleading and the confirm button was correctly hidden, leaving a stuck red card.

## Fixes

- Depends on privkeyio/keep#N (branch `expose-did-backup-metadata`): exposes `did_backup` on the unencrypted `ShareMetadataInfo`, adds `get_active_share_metadata()`, and marks nsec-only imports as `did_backup: true` at creation (no seed words to back up).
- Android side: persist `did_backup` in unencrypted metadata prefs, read it in `readMetadataFromPrefs`, switch both polling sites to `getActiveShareMetadata()?.didBackup`.

## Verified

- Fresh nsec import → no backup prompt (correctly suppressed).
- Fresh mnemonic-backed account → red prompt shown → tap → biometric → seed words displayed with FLAG_SECURE → confirm → two biometric prompts (cipher-queue FIFO) → screen dismisses, prompt clears.
- Build: Rust cross-compile + `assembleDebug` clean; unit tests and lint pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View Seed Words screen with secure-screen protection, lifecycle-driven clearing, and confirm/dismiss flows.
  * Biometric-gated seed retrieval and two-step biometric confirmation to mark an account as backed up.
  * Backup prompt and “View Seed Words” action added to Account UI; backup status now surfaces via polling.

* **Bug Fixes**
  * Improved seed-word parsing to handle extra whitespace and ensure per-word memory wiping.

* **Chores**
  * CI/release workflows updated to use a refreshed checkout reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->