### PR TITLE
Add export and share logs

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,16 @@
         </activity>
 
         <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
+        <provider
             android:name=".nip55.Nip55ContentProvider"
             android:authorities="io.privkey.keep.GET_PUBLIC_KEY;io.privkey.keep.SIGN_EVENT;io.privkey.keep.NIP04_ENCRYPT;io.privkey.keep.NIP04_DECRYPT;io.privkey.keep.NIP44_ENCRYPT;io.privkey.keep.NIP44_DECRYPT;io.privkey.keep.DECRYPT_ZAP_EVENT"
             android:exported="true"

--- a/app/src/main/kotlin/io/privkey/keep/ExportLogsScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ExportLogsScreen.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.unit.dp
 import io.privkey.keep.storage.AndroidKeystoreStorage
 import io.privkey.keep.uniffi.KeepMobile
 import io.privkey.keep.uniffi.SigningAuditLog
+import androidx.compose.runtime.saveable.rememberSaveable
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -47,12 +49,14 @@ fun ExportLogsScreen(
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     var state by remember { mutableStateOf<ExportLogsState>(ExportLogsState.Idle) }
+    var pendingContent by rememberSaveable { mutableStateOf<String?>(null) }
 
     val saveFileLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.CreateDocument("text/plain")
     ) { uri ->
-        val ready = state as? ExportLogsState.Ready
-        if (ready == null || uri == null) {
+        val content = pendingContent
+        pendingContent = null
+        if (content == null || uri == null) {
             if (uri == null) state = ExportLogsState.Idle
             return@rememberLauncherForActivityResult
         }
@@ -63,12 +67,14 @@ fun ExportLogsScreen(
                     val outputStream = context.contentResolver.openOutputStream(uri)
                         ?: throw java.io.IOException("openOutputStream returned null")
                     BufferedOutputStream(outputStream).use { buffered ->
-                        buffered.write(ready.content.toByteArray(Charsets.UTF_8))
+                        buffered.write(content.toByteArray(Charsets.UTF_8))
                         buffered.flush()
                     }
                 }
                 Toast.makeText(context, "Logs saved", Toast.LENGTH_SHORT).show()
                 state = ExportLogsState.Idle
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 if (BuildConfig.DEBUG) Log.e("ExportLogs", "Failed to save logs", e)
                 state = ExportLogsState.Error("Failed to save logs")
@@ -128,10 +134,13 @@ fun ExportLogsScreen(
                                             foregroundServiceEnabled = foregroundServiceEnabled
                                         )
                                     }
+                                    pendingContent = content
                                     state = ExportLogsState.Ready(content)
                                     val timestamp = LocalDateTime.now()
                                         .format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"))
                                     saveFileLauncher.launch("keep-logs-$timestamp.txt")
+                                } catch (e: CancellationException) {
+                                    throw e
                                 } catch (e: Exception) {
                                     if (BuildConfig.DEBUG) Log.e("ExportLogs", "Collection failed", e)
                                     state = ExportLogsState.Error("Failed to collect logs")

--- a/app/src/main/kotlin/io/privkey/keep/ExportLogsScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ExportLogsScreen.kt
@@ -1,5 +1,6 @@
 package io.privkey.keep
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.os.Build
 import android.util.Log
@@ -106,16 +107,21 @@ fun ExportLogsScreen(
                 }
                 val timestamp = LocalDateTime.now()
                     .format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"))
-                val fileName = "keep-logs-$timestamp.txt"
+                val saveName = "keep-logs-$timestamp.txt"
                 when (action) {
                     ExportAction.Save -> {
                         pendingContent = content
-                        saveFileLauncher.launch(fileName)
+                        saveFileLauncher.launch(saveName)
                     }
                     ExportAction.Share -> {
                         val uri = withContext(NonCancellable + Dispatchers.IO) {
                             val dir = File(context.cacheDir, "logs").apply { mkdirs() }
-                            val file = File(dir, fileName)
+                            val pruneBefore = System.currentTimeMillis() - 10 * 60 * 1000L
+                            dir.listFiles()?.forEach { old ->
+                                if (old.lastModified() < pruneBefore) old.delete()
+                            }
+                            val uniqueName = "keep-logs-$timestamp-${System.nanoTime()}.txt"
+                            val file = File(dir, uniqueName)
                             file.writeText(content, Charsets.UTF_8)
                             FileProvider.getUriForFile(
                                 context,
@@ -128,15 +134,25 @@ fun ExportLogsScreen(
                             putExtra(Intent.EXTRA_STREAM, uri)
                             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                         }
-                        context.startActivity(Intent.createChooser(sendIntent, "Share logs"))
-                        state = ExportLogsState.Idle
+                        val chooser = Intent.createChooser(sendIntent, "Share logs").apply {
+                            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        }
+                        try {
+                            context.startActivity(chooser)
+                            state = ExportLogsState.Idle
+                        } catch (e: ActivityNotFoundException) {
+                            if (BuildConfig.DEBUG) Log.e("ExportLogs", "No share target", e)
+                            state = ExportLogsState.Error("No app available to share")
+                        }
                     }
                 }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
                 if (BuildConfig.DEBUG) Log.e("ExportLogs", "Export failed", e)
-                state = ExportLogsState.Error("Failed to collect logs")
+                state = ExportLogsState.Error(
+                    if (action == ExportAction.Share) "Failed to share logs" else "Failed to collect logs"
+                )
             }
         }
     }
@@ -199,7 +215,16 @@ fun ExportLogsScreen(
                             onClick = { runExport(ExportAction.Save) },
                             enabled = !isBusy,
                             modifier = Modifier.weight(1f)
-                        ) { Text("Save to File") }
+                        ) {
+                            if (isBusy) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(16.dp),
+                                    strokeWidth = 2.dp
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                            }
+                            Text("Save to File")
+                        }
                         Button(
                             onClick = { runExport(ExportAction.Share) },
                             enabled = !isBusy,
@@ -255,8 +280,9 @@ private suspend fun buildExportContent(
         .withZone(ZoneId.systemDefault())
         .format(Instant.now())
 
-    val nip55AuditJson = permissionStore?.let { store ->
+    val nip55AuditResult = permissionStore?.let { store ->
         runCatching {
+            val totalCount = store.getAuditLogCount()
             val entries = store.getAuditLog(limit = 1000)
             val array = JSONArray()
             for (e in entries) {
@@ -268,11 +294,13 @@ private suspend fun buildExportContent(
                 obj.put("eventKind", e.eventKind ?: JSONObject.NULL)
                 obj.put("decision", e.decision)
                 obj.put("wasAutomatic", e.wasAutomatic)
+                obj.put("previousHash", e.previousHash ?: JSONObject.NULL)
+                obj.put("entryHash", e.entryHash)
                 array.put(obj)
             }
-            array.toString(2)
+            Triple(array.toString(2), entries.size, totalCount)
         }.getOrElse { e ->
-            "(export failed: ${e::class.simpleName})"
+            Triple("(export failed: ${e::class.simpleName})", 0, 0)
         }
     }
 
@@ -302,6 +330,14 @@ private suspend fun buildExportContent(
         }
         appendLine()
         appendLine("=== NIP-55 Audit Log ===")
-        appendLine(nip55AuditJson ?: "(unavailable)")
+        if (nip55AuditResult == null) {
+            appendLine("(unavailable)")
+        } else {
+            val (json, exported, total) = nip55AuditResult
+            if (total > exported) {
+                appendLine("(truncated to $exported of $total entries)")
+            }
+            appendLine(json)
+        }
     }
 }

--- a/app/src/main/kotlin/io/privkey/keep/ExportLogsScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ExportLogsScreen.kt
@@ -115,7 +115,6 @@ fun ExportLogsScreen(
                     ExportAction.Share -> {
                         val uri = withContext(NonCancellable + Dispatchers.IO) {
                             val dir = File(context.cacheDir, "logs").apply { mkdirs() }
-                            dir.listFiles()?.forEach { it.delete() }
                             val file = File(dir, fileName)
                             file.writeText(content, Charsets.UTF_8)
                             FileProvider.getUriForFile(

--- a/app/src/main/kotlin/io/privkey/keep/ExportLogsScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ExportLogsScreen.kt
@@ -18,9 +18,9 @@ import androidx.compose.ui.unit.dp
 import io.privkey.keep.storage.AndroidKeystoreStorage
 import io.privkey.keep.uniffi.KeepMobile
 import io.privkey.keep.uniffi.SigningAuditLog
-import androidx.compose.runtime.saveable.rememberSaveable
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.BufferedOutputStream
@@ -32,7 +32,7 @@ import java.time.format.DateTimeFormatter
 private sealed class ExportLogsState {
     data object Idle : ExportLogsState()
     data object Collecting : ExportLogsState()
-    data class Ready(val content: String) : ExportLogsState()
+    data object Ready : ExportLogsState()
     data object Saving : ExportLogsState()
     data class Error(val message: String) : ExportLogsState()
 }
@@ -49,7 +49,7 @@ fun ExportLogsScreen(
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     var state by remember { mutableStateOf<ExportLogsState>(ExportLogsState.Idle) }
-    var pendingContent by rememberSaveable { mutableStateOf<String?>(null) }
+    var pendingContent by remember { mutableStateOf<String?>(null) }
 
     val saveFileLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.CreateDocument("text/plain")
@@ -63,7 +63,7 @@ fun ExportLogsScreen(
         state = ExportLogsState.Saving
         scope.launch {
             try {
-                withContext(Dispatchers.IO) {
+                withContext(NonCancellable + Dispatchers.IO) {
                     val outputStream = context.contentResolver.openOutputStream(uri)
                         ?: throw java.io.IOException("openOutputStream returned null")
                     BufferedOutputStream(outputStream).use { buffered ->
@@ -77,6 +77,7 @@ fun ExportLogsScreen(
                 throw e
             } catch (e: Exception) {
                 if (BuildConfig.DEBUG) Log.e("ExportLogs", "Failed to save logs", e)
+                pendingContent = null
                 state = ExportLogsState.Error("Failed to save logs")
             }
         }
@@ -117,6 +118,17 @@ fun ExportLogsScreen(
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
 
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    Text(
+                        "Warning: audit entries include caller display names and free-text " +
+                            "reasons supplied by third-party apps. These fields may contain " +
+                            "personal information or attacker-controlled content. Review the " +
+                            "file before sharing.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+
                     Spacer(modifier = Modifier.height(16.dp))
 
                     val isBusy = state is ExportLogsState.Collecting || state is ExportLogsState.Saving
@@ -135,7 +147,7 @@ fun ExportLogsScreen(
                                         )
                                     }
                                     pendingContent = content
-                                    state = ExportLogsState.Ready(content)
+                                    state = ExportLogsState.Ready
                                     val timestamp = LocalDateTime.now()
                                         .format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"))
                                     saveFileLauncher.launch("keep-logs-$timestamp.txt")

--- a/app/src/main/kotlin/io/privkey/keep/ExportLogsScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ExportLogsScreen.kt
@@ -1,0 +1,209 @@
+package io.privkey.keep
+
+import android.os.Build
+import android.util.Log
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import io.privkey.keep.storage.AndroidKeystoreStorage
+import io.privkey.keep.uniffi.KeepMobile
+import io.privkey.keep.uniffi.SigningAuditLog
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+private sealed class ExportLogsState {
+    data object Idle : ExportLogsState()
+    data object Collecting : ExportLogsState()
+    data class Ready(val content: String) : ExportLogsState()
+    data class Error(val message: String) : ExportLogsState()
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExportLogsScreen(
+    keepMobile: KeepMobile,
+    storage: AndroidKeystoreStorage,
+    signingAuditLog: SigningAuditLog?,
+    foregroundServiceEnabled: Boolean,
+    onDismiss: () -> Unit
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var state by remember { mutableStateOf<ExportLogsState>(ExportLogsState.Idle) }
+
+    val saveFileLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.CreateDocument("text/plain")
+    ) { uri ->
+        val ready = state as? ExportLogsState.Ready
+        if (uri != null && ready != null) {
+            try {
+                val outputStream = context.contentResolver.openOutputStream(uri)
+                if (outputStream == null) {
+                    state = ExportLogsState.Error("Failed to save logs")
+                    return@rememberLauncherForActivityResult
+                }
+                outputStream.use { it.write(ready.content.toByteArray(Charsets.UTF_8)) }
+                Toast.makeText(context, "Logs saved", Toast.LENGTH_SHORT).show()
+                state = ExportLogsState.Idle
+            } catch (e: Exception) {
+                if (BuildConfig.DEBUG) Log.e("ExportLogs", "Failed to save logs", e)
+                state = ExportLogsState.Error("Failed to save logs")
+            }
+        } else if (uri == null) {
+            state = ExportLogsState.Idle
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Export & Share Logs") },
+                navigationIcon = {
+                    IconButton(onClick = onDismiss) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 16.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text("Diagnostic Logs", style = MaterialTheme.typography.titleMedium)
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        "Collects app diagnostics and audit history into a plain text file. " +
+                            "No private keys, nsec, or seed words are included.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Button(
+                        onClick = {
+                            state = ExportLogsState.Collecting
+                            scope.launch {
+                                try {
+                                    val content = withContext(Dispatchers.IO) {
+                                        buildExportContent(
+                                            keepMobile = keepMobile,
+                                            storage = storage,
+                                            signingAuditLog = signingAuditLog,
+                                            foregroundServiceEnabled = foregroundServiceEnabled
+                                        )
+                                    }
+                                    state = ExportLogsState.Ready(content)
+                                    val timestamp = LocalDateTime.now()
+                                        .format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"))
+                                    saveFileLauncher.launch("keep-logs-$timestamp.txt")
+                                } catch (e: Exception) {
+                                    if (BuildConfig.DEBUG) Log.e("ExportLogs", "Collection failed", e)
+                                    state = ExportLogsState.Error("Failed to collect logs")
+                                }
+                            }
+                        },
+                        enabled = state !is ExportLogsState.Collecting,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        if (state is ExportLogsState.Collecting) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(16.dp),
+                                strokeWidth = 2.dp,
+                                color = MaterialTheme.colorScheme.onPrimary
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                        }
+                        Text("Export Logs")
+                    }
+
+                    val errorState = state as? ExportLogsState.Error
+                    if (errorState != null) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            errorState.message,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+    }
+}
+
+private fun buildExportContent(
+    keepMobile: KeepMobile,
+    storage: AndroidKeystoreStorage,
+    signingAuditLog: SigningAuditLog?,
+    foregroundServiceEnabled: Boolean
+): String {
+    val accountCount = runCatching { storage.listAllShares().size }.getOrDefault(-1)
+    val proxyConfig = runCatching { keepMobile.getProxyConfig() }.getOrNull()
+    val torStatus = when {
+        proxyConfig == null -> "unknown"
+        proxyConfig.enabled -> "enabled (port ${proxyConfig.port})"
+        else -> "disabled"
+    }
+    val timestamp = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+        .withZone(ZoneId.systemDefault())
+        .format(Instant.now())
+
+    val header = buildString {
+        appendLine("=== Keep Diagnostics ===")
+        appendLine("Exported: $timestamp")
+        appendLine("App version: ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
+        appendLine("Build type: ${BuildConfig.BUILD_TYPE}")
+        appendLine("Android version: ${Build.VERSION.RELEASE} (SDK ${Build.VERSION.SDK_INT})")
+        appendLine("Device: ${Build.MANUFACTURER} ${Build.MODEL}")
+        appendLine("Account count: $accountCount")
+        appendLine("Foreground service: ${if (foregroundServiceEnabled) "enabled" else "disabled"}")
+        appendLine("Tor/proxy: $torStatus")
+    }
+
+    val signingSection = buildString {
+        appendLine()
+        appendLine("=== Signing Audit Log ===")
+        if (signingAuditLog == null) {
+            appendLine("(unavailable)")
+        } else {
+            try {
+                appendLine(signingAuditLog.exportJson())
+            } catch (e: Exception) {
+                appendLine("(export failed: ${e::class.simpleName})")
+            }
+        }
+    }
+
+    val auditSection = buildString {
+        appendLine()
+        appendLine("=== Audit Log ===")
+        appendLine("(not configured on this build)")
+    }
+
+    return header + signingSection + auditSection
+}

--- a/app/src/main/kotlin/io/privkey/keep/ExportLogsScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ExportLogsScreen.kt
@@ -300,6 +300,7 @@ private suspend fun buildExportContent(
             }
             Triple(array.toString(2), entries.size, totalCount)
         }.getOrElse { e ->
+            if (e is CancellationException) throw e
             Triple("(export failed: ${e::class.simpleName})", 0, 0)
         }
     }

--- a/app/src/main/kotlin/io/privkey/keep/ExportLogsScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ExportLogsScreen.kt
@@ -52,30 +52,27 @@ fun ExportLogsScreen(
         ActivityResultContracts.CreateDocument("text/plain")
     ) { uri ->
         val ready = state as? ExportLogsState.Ready
-        if (ready == null) {
+        if (ready == null || uri == null) {
             if (uri == null) state = ExportLogsState.Idle
             return@rememberLauncherForActivityResult
         }
-        if (uri == null) {
-            state = ExportLogsState.Idle
-            return@rememberLauncherForActivityResult
-        }
         state = ExportLogsState.Saving
-        try {
-            val outputStream = context.contentResolver.openOutputStream(uri)
-            if (outputStream == null) {
+        scope.launch {
+            try {
+                withContext(Dispatchers.IO) {
+                    val outputStream = context.contentResolver.openOutputStream(uri)
+                        ?: throw java.io.IOException("openOutputStream returned null")
+                    BufferedOutputStream(outputStream).use { buffered ->
+                        buffered.write(ready.content.toByteArray(Charsets.UTF_8))
+                        buffered.flush()
+                    }
+                }
+                Toast.makeText(context, "Logs saved", Toast.LENGTH_SHORT).show()
+                state = ExportLogsState.Idle
+            } catch (e: Exception) {
+                if (BuildConfig.DEBUG) Log.e("ExportLogs", "Failed to save logs", e)
                 state = ExportLogsState.Error("Failed to save logs")
-                return@rememberLauncherForActivityResult
             }
-            BufferedOutputStream(outputStream).use { buffered ->
-                buffered.write(ready.content.toByteArray(Charsets.UTF_8))
-                buffered.flush()
-            }
-            Toast.makeText(context, "Logs saved", Toast.LENGTH_SHORT).show()
-            state = ExportLogsState.Idle
-        } catch (e: Exception) {
-            if (BuildConfig.DEBUG) Log.e("ExportLogs", "Failed to save logs", e)
-            state = ExportLogsState.Error("Failed to save logs")
         }
     }
 
@@ -116,6 +113,8 @@ fun ExportLogsScreen(
 
                     Spacer(modifier = Modifier.height(16.dp))
 
+                    val isBusy = state is ExportLogsState.Collecting || state is ExportLogsState.Saving
+
                     Button(
                         onClick = {
                             state = ExportLogsState.Collecting
@@ -139,10 +138,10 @@ fun ExportLogsScreen(
                                 }
                             }
                         },
-                        enabled = state is ExportLogsState.Idle || state is ExportLogsState.Error,
+                        enabled = !isBusy && state !is ExportLogsState.Ready,
                         modifier = Modifier.fillMaxWidth()
                     ) {
-                        if (state is ExportLogsState.Collecting) {
+                        if (isBusy) {
                             CircularProgressIndicator(
                                 modifier = Modifier.size(16.dp),
                                 strokeWidth = 2.dp,
@@ -176,8 +175,7 @@ private fun buildExportContent(
     signingAuditLog: SigningAuditLog?,
     foregroundServiceEnabled: Boolean
 ): String {
-    val accountCountResult = runCatching { storage.listAllShares().size }
-    val accountCountDisplay = accountCountResult.fold(
+    val accountCountDisplay = runCatching { storage.listAllShares().size }.fold(
         onSuccess = { it.toString() },
         onFailure = { "unavailable (${it::class.simpleName})" }
     )
@@ -191,7 +189,7 @@ private fun buildExportContent(
         .withZone(ZoneId.systemDefault())
         .format(Instant.now())
 
-    val header = buildString {
+    return buildString {
         appendLine("=== Keep Diagnostics ===")
         appendLine("Exported: $timestamp")
         appendLine("App version: ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
@@ -201,9 +199,6 @@ private fun buildExportContent(
         appendLine("Account count: $accountCountDisplay")
         appendLine("Foreground service: ${if (foregroundServiceEnabled) "enabled" else "disabled"}")
         appendLine("Tor/proxy: $torStatus")
-    }
-
-    val signingSection = buildString {
         appendLine()
         appendLine("=== Signing Audit Log ===")
         if (signingAuditLog == null) {
@@ -219,6 +214,4 @@ private fun buildExportContent(
             }
         }
     }
-
-    return header + signingSection
 }

--- a/app/src/main/kotlin/io/privkey/keep/ExportLogsScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ExportLogsScreen.kt
@@ -56,10 +56,11 @@ fun ExportLogsScreen(
     ) { uri ->
         val content = pendingContent
         pendingContent = null
-        if (content == null || uri == null) {
-            if (uri == null) state = ExportLogsState.Idle
+        if (uri == null) {
+            state = ExportLogsState.Idle
             return@rememberLauncherForActivityResult
         }
+        if (content == null) return@rememberLauncherForActivityResult
         state = ExportLogsState.Saving
         scope.launch {
             try {
@@ -77,7 +78,6 @@ fun ExportLogsScreen(
                 throw e
             } catch (e: Exception) {
                 if (BuildConfig.DEBUG) Log.e("ExportLogs", "Failed to save logs", e)
-                pendingContent = null
                 state = ExportLogsState.Error("Failed to save logs")
             }
         }
@@ -126,7 +126,7 @@ fun ExportLogsScreen(
                             "personal information or attacker-controlled content. Review the " +
                             "file before sharing.",
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.error
+                        color = MaterialTheme.colorScheme.tertiary
                     )
 
                     Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/kotlin/io/privkey/keep/ExportLogsScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ExportLogsScreen.kt
@@ -21,6 +21,7 @@ import io.privkey.keep.uniffi.SigningAuditLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.BufferedOutputStream
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -30,6 +31,7 @@ private sealed class ExportLogsState {
     data object Idle : ExportLogsState()
     data object Collecting : ExportLogsState()
     data class Ready(val content: String) : ExportLogsState()
+    data object Saving : ExportLogsState()
     data class Error(val message: String) : ExportLogsState()
 }
 
@@ -50,22 +52,30 @@ fun ExportLogsScreen(
         ActivityResultContracts.CreateDocument("text/plain")
     ) { uri ->
         val ready = state as? ExportLogsState.Ready
-        if (uri != null && ready != null) {
-            try {
-                val outputStream = context.contentResolver.openOutputStream(uri)
-                if (outputStream == null) {
-                    state = ExportLogsState.Error("Failed to save logs")
-                    return@rememberLauncherForActivityResult
-                }
-                outputStream.use { it.write(ready.content.toByteArray(Charsets.UTF_8)) }
-                Toast.makeText(context, "Logs saved", Toast.LENGTH_SHORT).show()
-                state = ExportLogsState.Idle
-            } catch (e: Exception) {
-                if (BuildConfig.DEBUG) Log.e("ExportLogs", "Failed to save logs", e)
-                state = ExportLogsState.Error("Failed to save logs")
-            }
-        } else if (uri == null) {
+        if (ready == null) {
+            if (uri == null) state = ExportLogsState.Idle
+            return@rememberLauncherForActivityResult
+        }
+        if (uri == null) {
             state = ExportLogsState.Idle
+            return@rememberLauncherForActivityResult
+        }
+        state = ExportLogsState.Saving
+        try {
+            val outputStream = context.contentResolver.openOutputStream(uri)
+            if (outputStream == null) {
+                state = ExportLogsState.Error("Failed to save logs")
+                return@rememberLauncherForActivityResult
+            }
+            BufferedOutputStream(outputStream).use { buffered ->
+                buffered.write(ready.content.toByteArray(Charsets.UTF_8))
+                buffered.flush()
+            }
+            Toast.makeText(context, "Logs saved", Toast.LENGTH_SHORT).show()
+            state = ExportLogsState.Idle
+        } catch (e: Exception) {
+            if (BuildConfig.DEBUG) Log.e("ExportLogs", "Failed to save logs", e)
+            state = ExportLogsState.Error("Failed to save logs")
         }
     }
 
@@ -94,8 +104,12 @@ fun ExportLogsScreen(
                     Text("Diagnostic Logs", style = MaterialTheme.typography.titleMedium)
                     Spacer(modifier = Modifier.height(4.dp))
                     Text(
-                        "Collects app diagnostics and audit history into a plain text file. " +
-                            "No private keys, nsec, or seed words are included.",
+                        "Collects app diagnostics into a plain text file. Includes: device " +
+                            "manufacturer/model, Android version, app version and build type, " +
+                            "account count, foreground service and Tor/proxy configuration, and " +
+                            "signing audit history (caller package names, caller display names, " +
+                            "event kinds, and free-text reasons). Does not include private keys, " +
+                            "nsec, or seed words.",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
@@ -125,7 +139,7 @@ fun ExportLogsScreen(
                                 }
                             }
                         },
-                        enabled = state !is ExportLogsState.Collecting,
+                        enabled = state is ExportLogsState.Idle || state is ExportLogsState.Error,
                         modifier = Modifier.fillMaxWidth()
                     ) {
                         if (state is ExportLogsState.Collecting) {
@@ -162,7 +176,11 @@ private fun buildExportContent(
     signingAuditLog: SigningAuditLog?,
     foregroundServiceEnabled: Boolean
 ): String {
-    val accountCount = runCatching { storage.listAllShares().size }.getOrDefault(-1)
+    val accountCountResult = runCatching { storage.listAllShares().size }
+    val accountCountDisplay = accountCountResult.fold(
+        onSuccess = { it.toString() },
+        onFailure = { "unavailable (${it::class.simpleName})" }
+    )
     val proxyConfig = runCatching { keepMobile.getProxyConfig() }.getOrNull()
     val torStatus = when {
         proxyConfig == null -> "unknown"
@@ -180,7 +198,7 @@ private fun buildExportContent(
         appendLine("Build type: ${BuildConfig.BUILD_TYPE}")
         appendLine("Android version: ${Build.VERSION.RELEASE} (SDK ${Build.VERSION.SDK_INT})")
         appendLine("Device: ${Build.MANUFACTURER} ${Build.MODEL}")
-        appendLine("Account count: $accountCount")
+        appendLine("Account count: $accountCountDisplay")
         appendLine("Foreground service: ${if (foregroundServiceEnabled) "enabled" else "disabled"}")
         appendLine("Tor/proxy: $torStatus")
     }
@@ -194,16 +212,13 @@ private fun buildExportContent(
             try {
                 appendLine(signingAuditLog.exportJson())
             } catch (e: Exception) {
-                appendLine("(export failed: ${e::class.simpleName})")
+                val sanitized = e.message
+                    ?.replace(Regex("[\\r\\n\\t]"), " ")
+                    ?.take(200)
+                appendLine("(export failed: ${e::class.simpleName}${if (sanitized.isNullOrBlank()) "" else ": $sanitized"})")
             }
         }
     }
 
-    val auditSection = buildString {
-        appendLine()
-        appendLine("=== Audit Log ===")
-        appendLine("(not configured on this build)")
-    }
-
-    return header + signingSection + auditSection
+    return header + signingSection
 }

--- a/app/src/main/kotlin/io/privkey/keep/ExportLogsScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ExportLogsScreen.kt
@@ -1,5 +1,6 @@
 package io.privkey.keep
 
+import android.content.Intent
 import android.os.Build
 import android.util.Log
 import android.widget.Toast
@@ -15,6 +16,8 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.core.content.FileProvider
+import io.privkey.keep.nip55.PermissionStore
 import io.privkey.keep.storage.AndroidKeystoreStorage
 import io.privkey.keep.uniffi.KeepMobile
 import io.privkey.keep.uniffi.SigningAuditLog
@@ -23,7 +26,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
 import java.io.BufferedOutputStream
+import java.io.File
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -32,10 +38,11 @@ import java.time.format.DateTimeFormatter
 private sealed class ExportLogsState {
     data object Idle : ExportLogsState()
     data object Collecting : ExportLogsState()
-    data object Ready : ExportLogsState()
     data object Saving : ExportLogsState()
     data class Error(val message: String) : ExportLogsState()
 }
+
+private enum class ExportAction { Save, Share }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -43,6 +50,7 @@ fun ExportLogsScreen(
     keepMobile: KeepMobile,
     storage: AndroidKeystoreStorage,
     signingAuditLog: SigningAuditLog?,
+    permissionStore: PermissionStore?,
     foregroundServiceEnabled: Boolean,
     onDismiss: () -> Unit
 ) {
@@ -83,6 +91,57 @@ fun ExportLogsScreen(
         }
     }
 
+    fun runExport(action: ExportAction) {
+        state = ExportLogsState.Collecting
+        scope.launch {
+            try {
+                val content = withContext(Dispatchers.IO) {
+                    buildExportContent(
+                        keepMobile = keepMobile,
+                        storage = storage,
+                        signingAuditLog = signingAuditLog,
+                        permissionStore = permissionStore,
+                        foregroundServiceEnabled = foregroundServiceEnabled
+                    )
+                }
+                val timestamp = LocalDateTime.now()
+                    .format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"))
+                val fileName = "keep-logs-$timestamp.txt"
+                when (action) {
+                    ExportAction.Save -> {
+                        pendingContent = content
+                        saveFileLauncher.launch(fileName)
+                    }
+                    ExportAction.Share -> {
+                        val uri = withContext(NonCancellable + Dispatchers.IO) {
+                            val dir = File(context.cacheDir, "logs").apply { mkdirs() }
+                            dir.listFiles()?.forEach { it.delete() }
+                            val file = File(dir, fileName)
+                            file.writeText(content, Charsets.UTF_8)
+                            FileProvider.getUriForFile(
+                                context,
+                                "${context.packageName}.fileprovider",
+                                file
+                            )
+                        }
+                        val sendIntent = Intent(Intent.ACTION_SEND).apply {
+                            type = "text/plain"
+                            putExtra(Intent.EXTRA_STREAM, uri)
+                            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        }
+                        context.startActivity(Intent.createChooser(sendIntent, "Share logs"))
+                        state = ExportLogsState.Idle
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                if (BuildConfig.DEBUG) Log.e("ExportLogs", "Export failed", e)
+                state = ExportLogsState.Error("Failed to collect logs")
+            }
+        }
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -110,10 +169,10 @@ fun ExportLogsScreen(
                     Text(
                         "Collects app diagnostics into a plain text file. Includes: device " +
                             "manufacturer/model, Android version, app version and build type, " +
-                            "account count, foreground service and Tor/proxy configuration, and " +
+                            "account count, foreground service and Tor/proxy configuration, " +
                             "signing audit history (caller package names, caller display names, " +
-                            "event kinds, and free-text reasons). Does not include private keys, " +
-                            "nsec, or seed words.",
+                            "event kinds, and free-text reasons), and NIP-55 permission audit " +
+                            "history. Does not include private keys, nsec, or seed words.",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
@@ -133,44 +192,30 @@ fun ExportLogsScreen(
 
                     val isBusy = state is ExportLogsState.Collecting || state is ExportLogsState.Saving
 
-                    Button(
-                        onClick = {
-                            state = ExportLogsState.Collecting
-                            scope.launch {
-                                try {
-                                    val content = withContext(Dispatchers.IO) {
-                                        buildExportContent(
-                                            keepMobile = keepMobile,
-                                            storage = storage,
-                                            signingAuditLog = signingAuditLog,
-                                            foregroundServiceEnabled = foregroundServiceEnabled
-                                        )
-                                    }
-                                    pendingContent = content
-                                    state = ExportLogsState.Ready
-                                    val timestamp = LocalDateTime.now()
-                                        .format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"))
-                                    saveFileLauncher.launch("keep-logs-$timestamp.txt")
-                                } catch (e: CancellationException) {
-                                    throw e
-                                } catch (e: Exception) {
-                                    if (BuildConfig.DEBUG) Log.e("ExportLogs", "Collection failed", e)
-                                    state = ExportLogsState.Error("Failed to collect logs")
-                                }
-                            }
-                        },
-                        enabled = !isBusy && state !is ExportLogsState.Ready,
-                        modifier = Modifier.fillMaxWidth()
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        if (isBusy) {
-                            CircularProgressIndicator(
-                                modifier = Modifier.size(16.dp),
-                                strokeWidth = 2.dp,
-                                color = MaterialTheme.colorScheme.onPrimary
-                            )
-                            Spacer(modifier = Modifier.width(8.dp))
+                        OutlinedButton(
+                            onClick = { runExport(ExportAction.Save) },
+                            enabled = !isBusy,
+                            modifier = Modifier.weight(1f)
+                        ) { Text("Save to File") }
+                        Button(
+                            onClick = { runExport(ExportAction.Share) },
+                            enabled = !isBusy,
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            if (isBusy) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(16.dp),
+                                    strokeWidth = 2.dp,
+                                    color = MaterialTheme.colorScheme.onPrimary
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                            }
+                            Text("Share")
                         }
-                        Text("Export Logs")
                     }
 
                     val errorState = state as? ExportLogsState.Error
@@ -190,10 +235,11 @@ fun ExportLogsScreen(
     }
 }
 
-private fun buildExportContent(
+private suspend fun buildExportContent(
     keepMobile: KeepMobile,
     storage: AndroidKeystoreStorage,
     signingAuditLog: SigningAuditLog?,
+    permissionStore: PermissionStore?,
     foregroundServiceEnabled: Boolean
 ): String {
     val accountCountDisplay = runCatching { storage.listAllShares().size }.fold(
@@ -209,6 +255,27 @@ private fun buildExportContent(
     val timestamp = DateTimeFormatter.ISO_OFFSET_DATE_TIME
         .withZone(ZoneId.systemDefault())
         .format(Instant.now())
+
+    val nip55AuditJson = permissionStore?.let { store ->
+        runCatching {
+            val entries = store.getAuditLog(limit = 1000)
+            val array = JSONArray()
+            for (e in entries) {
+                val obj = JSONObject()
+                obj.put("id", e.id)
+                obj.put("timestamp", e.timestamp)
+                obj.put("callerPackage", e.callerPackage)
+                obj.put("requestType", e.requestType)
+                obj.put("eventKind", e.eventKind ?: JSONObject.NULL)
+                obj.put("decision", e.decision)
+                obj.put("wasAutomatic", e.wasAutomatic)
+                array.put(obj)
+            }
+            array.toString(2)
+        }.getOrElse { e ->
+            "(export failed: ${e::class.simpleName})"
+        }
+    }
 
     return buildString {
         appendLine("=== Keep Diagnostics ===")
@@ -234,5 +301,8 @@ private fun buildExportContent(
                 appendLine("(export failed: ${e::class.simpleName}${if (sanitized.isNullOrBlank()) "" else ": $sanitized"})")
             }
         }
+        appendLine()
+        appendLine("=== NIP-55 Audit Log ===")
+        appendLine(nip55AuditJson ?: "(unavailable)")
     }
 }

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -511,6 +511,7 @@ fun MainScreen(
             keepMobile = keepMobile,
             storage = storage,
             signingAuditLog = signingAuditLog,
+            permissionStore = permissionStore,
             foregroundServiceEnabled = foregroundServiceEnabled,
             onDismiss = { showExportLogs = false }
         )

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -311,6 +311,7 @@ fun MainScreen(
     var certificatePins by remember { mutableStateOf(keepMobile.getCertificatePinsCompat()) }
     var profileRelays by remember { mutableStateOf(emptyList<String>()) }
     var showSecuritySettings by remember { mutableStateOf(false) }
+    var showExportLogs by remember { mutableStateOf(false) }
     var showBackupRestore by remember { mutableStateOf(false) }
     var showRecoverNsec by remember { mutableStateOf(false) }
     var showCreateAccountScreen by remember { mutableStateOf(false) }
@@ -496,7 +497,19 @@ fun MainScreen(
             biometricAvailable = biometricAvailable,
             killSwitchEnabled = killSwitchEnabled,
             onKillSwitchToggle = handleKillSwitchToggle,
+            onExportLogs = { showExportLogs = true },
             onDismiss = { showSecuritySettings = false }
+        )
+        return
+    }
+
+    if (showExportLogs) {
+        ExportLogsScreen(
+            keepMobile = keepMobile,
+            storage = storage,
+            signingAuditLog = signingAuditLog,
+            foregroundServiceEnabled = foregroundServiceEnabled,
+            onDismiss = { showExportLogs = false }
         )
         return
     }

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -497,7 +497,10 @@ fun MainScreen(
             biometricAvailable = biometricAvailable,
             killSwitchEnabled = killSwitchEnabled,
             onKillSwitchToggle = handleKillSwitchToggle,
-            onExportLogs = { showExportLogs = true },
+            onExportLogs = {
+                showSecuritySettings = false
+                showExportLogs = true
+            },
             onDismiss = { showSecuritySettings = false }
         )
         return

--- a/app/src/main/kotlin/io/privkey/keep/SecuritySettingsScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/SecuritySettingsScreen.kt
@@ -25,6 +25,7 @@ fun SecuritySettingsScreen(
     biometricAvailable: Boolean,
     killSwitchEnabled: Boolean,
     onKillSwitchToggle: (Boolean) -> Unit,
+    onExportLogs: () -> Unit,
     onDismiss: () -> Unit
 ) {
     val context = LocalContext.current
@@ -76,6 +77,8 @@ fun SecuritySettingsScreen(
                 onToggle = onBiometricLockOnLaunchChanged,
                 biometricAvailable = biometricAvailable
             )
+
+            ExportLogsCard(onClick = onExportLogs)
 
             Spacer(modifier = Modifier.height(16.dp))
         }

--- a/app/src/main/kotlin/io/privkey/keep/SettingsCards.kt
+++ b/app/src/main/kotlin/io/privkey/keep/SettingsCards.kt
@@ -321,6 +321,28 @@ fun TorOrbotCard(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
+fun ExportLogsCard(onClick: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth(), onClick = onClick) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text("Export & Share Logs", style = MaterialTheme.typography.titleMedium)
+                Text(
+                    "Save diagnostics and audit history to a file",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Text("Export", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
 fun BackupSettingsCard(onClick: () -> Unit) {
     Card(modifier = Modifier.fillMaxWidth(), onClick = onClick) {
         Row(

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="shared_logs" path="logs/" />
+</paths>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Export & Share Logs" option added to Security Settings to save or share diagnostic and audit history as a plain-text, timestamped file.
  * New Export Logs screen collects app/device/metadata, account counts, proxy status, signing and permission audit sections; shows progress, success toast, and clear error messages.
  * Sharing uses a secure file URI and system chooser to send collected logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->