### PR TITLE
Wire build-rust.sh into Gradle preBuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ Supported NIP-55 operations: `get_public_key`, `sign_event`, `nip04_encrypt`, `n
 
 # Building
 
-Requires Rust 1.85+, Android NDK r29, and `cargo-ndk`.
+Requires Rust 1.89+, Android NDK r29, and `cargo-ndk`.
 
 ```bash
-git clone https://github.com/privkeyio/keep ../keep
+git clone https://github.com/privkeyio/keep keep
 ./gradlew assembleDebug
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,22 +44,14 @@ Supported NIP-55 operations: `get_public_key`, `sign_event`, `nip04_encrypt`, `n
 
 # Building
 
-Requirements: Rust 1.85+, Android NDK r29, cargo-ndk. The keep workspace must be checked out alongside this repo (or point `KEEP_REPO` at it):
+Requires Rust 1.85+, Android NDK r29, and `cargo-ndk`.
 
 ```bash
 git clone https://github.com/privkeyio/keep ../keep
 ./gradlew assembleDebug
 ```
 
-Gradle invokes `build-rust.sh` automatically when Rust sources change, so you normally don't need to run it directly. APK output: `app/build/outputs/apk/debug/app-debug.apk`.
-
-To rebuild native libs and bindings out of band:
-
-```bash
-./gradlew buildRust
-# or, equivalently
-KEEP_REPO=../keep ./build-rust.sh
-```
+APK output: `app/build/outputs/apk/debug/app-debug.apk`. Gradle rebuilds the Rust libraries automatically when sources change. Set `KEEP_REPO` if the `keep` checkout lives elsewhere.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -44,23 +44,20 @@ Supported NIP-55 operations: `get_public_key`, `sign_event`, `nip04_encrypt`, `n
 
 # Building
 
+Requirements: Rust 1.85+, Android NDK r29, cargo-ndk. The keep workspace must be checked out alongside this repo (or point `KEEP_REPO` at it):
+
 ```bash
+git clone https://github.com/privkeyio/keep ../keep
 ./gradlew assembleDebug
 ```
 
-APK output: `app/build/outputs/apk/debug/app-debug.apk`
+Gradle invokes `build-rust.sh` automatically when Rust sources change, so you normally don't need to run it directly. APK output: `app/build/outputs/apk/debug/app-debug.apk`.
 
-# Development
-
-To rebuild the native libraries from source:
+To rebuild native libs and bindings out of band:
 
 ```bash
-# Requirements: Rust 1.85+, Android NDK r29, cargo-ndk
-
-# Clone keep workspace
-git clone https://github.com/privkeyio/keep ../keep
-
-# Rebuild native libs and bindings
+./gradlew buildRust
+# or, equivalently
 KEEP_REPO=../keep ./build-rust.sh
 ```
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -91,6 +91,8 @@ kotlin {
     }
 }
 
+tasks.named("preBuild") { dependsOn(rootProject.tasks.named("buildRust")) }
+
 dependencies {
     val roomVersion = "2.8.4"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,8 +4,31 @@ plugins {
     id("com.google.devtools.ksp") version "2.3.6" apply false
 }
 
+val keepRepo = file(System.getenv("KEEP_REPO") ?: "${rootDir}/keep")
+
 tasks.register<Exec>("buildRust") {
     group = "rust"
-    description = "Build Rust library for Android"
+    description = "Builds keep-mobile Rust native libraries and regenerates UniFFI Kotlin bindings."
+    workingDir = rootDir
     commandLine("bash", "build-rust.sh")
+    environment("KEEP_REPO", keepRepo.absolutePath)
+
+    inputs.file("${rootDir}/build-rust.sh").withPathSensitivity(PathSensitivity.RELATIVE)
+    if (keepRepo.exists()) {
+        inputs.dir("${keepRepo}/keep-mobile/src").withPathSensitivity(PathSensitivity.RELATIVE)
+        inputs.file("${keepRepo}/keep-mobile/Cargo.toml").withPathSensitivity(PathSensitivity.RELATIVE)
+    }
+    inputs.property("targets", System.getenv("TARGETS") ?: "")
+    outputs.dir("${rootDir}/app/src/main/jniLibs")
+    outputs.dir("${rootDir}/app/src/main/kotlin/io/privkey/keep/uniffi")
+
+    doFirst {
+        if (!keepRepo.exists()) {
+            throw GradleException(
+                "keep workspace not found at ${keepRepo.absolutePath}. " +
+                "Clone it (e.g. `git clone https://github.com/privkeyio/keep ../keep`) " +
+                "or set KEEP_REPO to its path."
+            )
+        }
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,8 +15,12 @@ tasks.register<Exec>("buildRust") {
 
     inputs.file("${rootDir}/build-rust.sh").withPathSensitivity(PathSensitivity.RELATIVE)
     if (keepRepo.exists()) {
-        inputs.dir("${keepRepo}/keep-mobile/src").withPathSensitivity(PathSensitivity.RELATIVE)
-        inputs.file("${keepRepo}/keep-mobile/Cargo.toml").withPathSensitivity(PathSensitivity.RELATIVE)
+        inputs.files(
+            fileTree(keepRepo) {
+                include("**/*.rs", "**/Cargo.toml", "**/Cargo.lock")
+                exclude("**/target/**", "**/.git/**")
+            }
+        ).withPathSensitivity(PathSensitivity.RELATIVE)
     }
     inputs.property("targets", System.getenv("TARGETS") ?: "")
     outputs.dir("${rootDir}/app/src/main/jniLibs")


### PR DESCRIPTION
## Summary
- `buildRust` Gradle task now declares inputs (Rust sources, Cargo.toml, build-rust.sh, TARGETS) and outputs (jniLibs, generated bindings), so it is incremental.
- `:app:preBuild` depends on `:buildRust`, so `./gradlew assembleDebug` rebuilds Rust only when sources change.
- Clear error if the sibling keep workspace is missing.
- README simplified: one command to build.

CI is unchanged. The explicit build-rust.sh step still runs; the subsequent Gradle invocation finds outputs up-to-date and no-ops.

## Test plan
- [x] Fresh checkout: ./gradlew assembleDebug builds Rust and APK
- [x] Second run: buildRust reports up-to-date
- [x] Missing ../keep: clear actionable error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined building documentation by removing legacy setup instructions and clarifying required toolchain versions (Rust 1.85+, Android NDK r29, cargo-ndk).

* **Chores**
  * Optimized build system to automatically compile Rust libraries as part of the standard Android build process, with automatic recompilation when source files change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->