### PR TITLE
Enforce exact toolchain versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ env:
   ANDROID_HOME: /usr/local/lib/android/sdk
   NDK_VERSION: "29.0.14206865"
   CARGO_NDK_VERSION: "4.1.2"
+  RUST_VERSION: "1.89.0"
 
 jobs:
   build:
@@ -40,8 +41,20 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Verify toolchain version pins are consistent
+        run: ./scripts/check-toolchain-pins.sh
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
+
       - name: Install Android NDK
-        run: $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install "ndk;${{ env.NDK_VERSION }}"
+        run: sdkmanager --install "ndk;${{ env.NDK_VERSION }}"
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          targets: aarch64-linux-android
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
@@ -92,8 +105,20 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Verify toolchain version pins are consistent
+        run: ./scripts/check-toolchain-pins.sh
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
+
       - name: Install Android NDK
-        run: $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install "ndk;${{ env.NDK_VERSION }}"
+        run: sdkmanager --install "ndk;${{ env.NDK_VERSION }}"
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          targets: x86_64-linux-android
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ concurrency:
 env:
   ANDROID_HOME: /usr/local/lib/android/sdk
   NDK_VERSION: "29.0.14206865"
+  CARGO_NDK_VERSION: "4.1.2"
 
 jobs:
   build:
@@ -46,7 +47,7 @@ jobs:
       - name: Install cargo-ndk
         uses: taiki-e/install-action@cf39a74df4a72510be4e5b63348d61067f11e64a # v2
         with:
-          tool: cargo-ndk
+          tool: cargo-ndk@${{ env.CARGO_NDK_VERSION }}
 
       - name: Build native libraries
         run: ./build-rust.sh
@@ -94,7 +95,7 @@ jobs:
       - name: Install cargo-ndk
         uses: taiki-e/install-action@cf39a74df4a72510be4e5b63348d61067f11e64a # v2
         with:
-          tool: cargo-ndk
+          tool: cargo-ndk@${{ env.CARGO_NDK_VERSION }}
 
       - name: Build native libraries
         run: ./build-rust.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 env:
   ANDROID_HOME: /usr/local/lib/android/sdk
   NDK_VERSION: "29.0.14206865"
@@ -18,6 +20,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
 
     steps:
@@ -59,6 +63,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
 
       - name: Build, test, and lint
         run: ./gradlew assembleDebug testDebugUnitTest lintDebug --no-daemon
@@ -66,6 +72,8 @@ jobs:
   instrumented-tests:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
+    permissions:
+      contents: read
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
 
     steps:
@@ -107,6 +115,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
 
       - name: Enable KVM
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,20 @@ on:
     tags:
       - "v*"
 
+permissions: {}
+
+env:
+  NDK_VERSION: "29.0.14206865"
+  CARGO_NDK_VERSION: "4.1.2"
+  RUST_VERSION: "1.89.0"
+  BUILD_TOOLS_VERSION: "36.0.0"
+
 jobs:
   build:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -28,24 +39,24 @@ jobs:
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
 
       - name: Install Android NDK
-        run: sdkmanager --install "ndk;29.0.14206865"
+        run: sdkmanager --install "ndk;${{ env.NDK_VERSION }}"
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: "1.89.0"
+          toolchain: ${{ env.RUST_VERSION }}
           targets: aarch64-linux-android,x86_64-linux-android
 
       - name: Install cargo-ndk
         uses: taiki-e/install-action@cf39a74df4a72510be4e5b63348d61067f11e64a # v2
         with:
-          tool: cargo-ndk@4.1.2
+          tool: cargo-ndk@${{ env.CARGO_NDK_VERSION }}
 
       - name: Build native libraries
         run: ./build-rust.sh
         env:
           KEEP_REPO: ${{ github.workspace }}/keep
-          ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/29.0.14206865
+          ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/${{ env.NDK_VERSION }}
           AWS_LC_SYS_CMAKE_BUILDER: "1"
 
       - name: Setup Gradle
@@ -54,7 +65,17 @@ jobs:
       - name: Decode keystore
         env:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
-        run: echo "$KEYSTORE_BASE64" | base64 -d > ${{ runner.temp }}/release.keystore
+        run: |
+          if [ -z "$KEYSTORE_BASE64" ]; then
+            echo "error: KEYSTORE_BASE64 secret is empty." >&2
+            exit 1
+          fi
+          KEYSTORE_OUT="${{ runner.temp }}/release.keystore"
+          printf '%s' "$KEYSTORE_BASE64" | base64 -d > "$KEYSTORE_OUT"
+          if [ ! -s "$KEYSTORE_OUT" ]; then
+            echo "error: decoded keystore is empty; check KEYSTORE_BASE64 encoding." >&2
+            exit 1
+          fi
 
       - name: Build APK
         run: ./gradlew assembleRelease --no-daemon
@@ -65,7 +86,7 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
       - name: Verify APK is signed
-        run: $ANDROID_HOME/build-tools/$(ls $ANDROID_HOME/build-tools/ | tail -1)/apksigner verify --print-certs app/build/outputs/apk/release/app-release.apk
+        run: $ANDROID_HOME/build-tools/${{ env.BUILD_TOOLS_VERSION }}/apksigner verify --print-certs app/build/outputs/apk/release/app-release.apk
 
       - name: Rename APK
         run: mv app/build/outputs/apk/release/app-release.apk "keep-android-${{ github.ref_name }}.apk"
@@ -78,6 +99,7 @@ jobs:
   release:
     needs: [build]
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ jobs:
           ref: 81a820f6b29b8d10025bf4c7e7bdd9f986b01378
           path: keep
 
+      - name: Verify toolchain version pins are consistent
+        run: ./scripts/check-toolchain-pins.sh
+
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -75,6 +78,11 @@ jobs:
           printf '%s' "$KEYSTORE_BASE64" | base64 -d > "$KEYSTORE_OUT"
           if [ ! -s "$KEYSTORE_OUT" ]; then
             echo "error: decoded keystore is empty; check KEYSTORE_BASE64 encoding." >&2
+            exit 1
+          fi
+          if ! KEYSTORE_PASSWORD="${{ secrets.KEYSTORE_PASSWORD }}" \
+              keytool -list -keystore "$KEYSTORE_OUT" -storepass:env KEYSTORE_PASSWORD >/dev/null; then
+            echo "error: keystore failed to load (corrupt base64 or wrong password)." >&2
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,8 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
       - name: Verify APK is signed
-        run: $ANDROID_HOME/build-tools/${{ env.BUILD_TOOLS_VERSION }}/apksigner verify --print-certs app/build/outputs/apk/release/app-release.apk
+        run: |
+          "$ANDROID_HOME/build-tools/${{ env.BUILD_TOOLS_VERSION }}/apksigner" verify --print-certs app/build/outputs/apk/release/app-release.apk
 
       - name: Rename APK
         run: mv app/build/outputs/apk/release/app-release.apk "keep-android-${{ github.ref_name }}.apk"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
 
-      - name: Install Android NDK
-        run: sdkmanager --install "ndk;${{ env.NDK_VERSION }}"
+      - name: Install Android NDK and build-tools
+        run: sdkmanager --install "ndk;${{ env.NDK_VERSION }}" "build-tools;${{ env.BUILD_TOOLS_VERSION }}"
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,13 +33,13 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: "1.85.0"
+          toolchain: "1.89.0"
           targets: aarch64-linux-android,x86_64-linux-android
 
       - name: Install cargo-ndk
         uses: taiki-e/install-action@cf39a74df4a72510be4e5b63348d61067f11e64a # v2
         with:
-          tool: cargo-ndk
+          tool: cargo-ndk@4.1.2
 
       - name: Build native libraries
         run: ./build-rust.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions: {}
 
 env:
+  ANDROID_HOME: /usr/local/lib/android/sdk
   NDK_VERSION: "29.0.14206865"
   CARGO_NDK_VERSION: "4.1.2"
   RUST_VERSION: "1.89.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,12 @@ Supported NIP-55 operations: `get_public_key`, `sign_event`, `nip04_encrypt`, `n
 
 # Building
 
-Requires Rust 1.89+, Android NDK r29, and `cargo-ndk`.
+Exact toolchain versions are required. The build fails fast on any mismatch.
+
+- Rust `1.89.0` (pinned in `keep/rust-toolchain.toml`, auto-selected by rustup)
+- Android NDK `29.0.14206865` (install via `sdkmanager "ndk;29.0.14206865"`)
+- `cargo-ndk` `4.1.2`: `cargo install --locked cargo-ndk --version 4.1.2`
+- JDK 17
 
 ```bash
 git clone https://github.com/privkeyio/keep keep
@@ -52,6 +57,8 @@ git clone https://github.com/privkeyio/keep keep
 ```
 
 APK output: `app/build/outputs/apk/debug/app-debug.apk`. Gradle rebuilds the Rust libraries automatically when sources change. Set `KEEP_REPO` if the `keep` checkout lives elsewhere.
+
+Run `scripts/check-toolchain-pins.sh` to verify pinned versions are consistent across build scripts and CI workflows.
 
 # Contributing
 

--- a/build-rust.sh
+++ b/build-rust.sh
@@ -39,7 +39,16 @@ if [ "$TOOLCHAIN_CHANNEL" != "$EXPECTED_RUST" ]; then
     exit 1
 fi
 
-ACTUAL_RUST=$(cd "$RUST_PROJECT" && rustc --version | awk '{print $2}')
+ACTUAL_RUST=$(cd "$RUST_PROJECT" && set -o pipefail && rustc --version | awk '{print $2}')
+if [ -z "$ACTUAL_RUST" ]; then
+    echo "error: failed to determine rustc version (empty output from 'rustc --version')." >&2
+    echo "Fix: ensure rustup/rustc is installed and on PATH." >&2
+    exit 1
+fi
+if [[ ! "$ACTUAL_RUST" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "error: rustc version '$ACTUAL_RUST' is not a valid semver version." >&2
+    exit 1
+fi
 if [ "$ACTUAL_RUST" != "$EXPECTED_RUST" ]; then
     echo "error: rustc version mismatch" >&2
     echo "  expected: $EXPECTED_RUST" >&2
@@ -54,7 +63,7 @@ if ! command -v cargo-ndk >/dev/null 2>&1; then
     exit 1
 fi
 VERSION_OUTPUT="$(cargo ndk --version 2>/dev/null || true)"
-ACTUAL_CARGO_NDK="$(echo "$VERSION_OUTPUT" | grep -E '^cargo-ndk ' | awk '{print $2}' || true)"
+ACTUAL_CARGO_NDK="$(echo "$VERSION_OUTPUT" | sed -nE 's/^cargo-ndk[[:space:]]+v?([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' | head -1 || true)"
 if [ "$ACTUAL_CARGO_NDK" != "$CARGO_NDK_VERSION" ]; then
     echo "error: cargo-ndk version mismatch" >&2
     echo "  expected: $CARGO_NDK_VERSION" >&2

--- a/build-rust.sh
+++ b/build-rust.sh
@@ -39,7 +39,7 @@ if [ "$TOOLCHAIN_CHANNEL" != "$EXPECTED_RUST" ]; then
     exit 1
 fi
 
-ACTUAL_RUST=$(cd "$RUST_PROJECT" && set -o pipefail && rustc --version | awk '{print $2}')
+ACTUAL_RUST=$(cd "$RUST_PROJECT" && rustc --version | awk '{print $2}')
 if [ -z "$ACTUAL_RUST" ]; then
     echo "error: failed to determine rustc version (empty output from 'rustc --version')." >&2
     echo "Fix: ensure rustup/rustc is installed and on PATH." >&2
@@ -63,7 +63,7 @@ if ! command -v cargo-ndk >/dev/null 2>&1; then
     exit 1
 fi
 VERSION_OUTPUT="$(cargo ndk --version 2>/dev/null || true)"
-ACTUAL_CARGO_NDK="$(echo "$VERSION_OUTPUT" | sed -nE 's/^cargo-ndk[[:space:]]+v?([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' | head -1 || true)"
+ACTUAL_CARGO_NDK="$(sed -nE 's/^cargo-ndk[[:space:]]+v?([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' <<<"$VERSION_OUTPUT" | head -1)"
 if [ "$ACTUAL_CARGO_NDK" != "$CARGO_NDK_VERSION" ]; then
     echo "error: cargo-ndk version mismatch" >&2
     echo "  expected: $CARGO_NDK_VERSION" >&2

--- a/build-rust.sh
+++ b/build-rust.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 KEEP_REPO="${KEEP_REPO:-./keep}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -7,7 +7,13 @@ RUST_PROJECT="$KEEP_REPO/keep-mobile"
 JNILIBS_DIR="$SCRIPT_DIR/app/src/main/jniLibs"
 
 # Pinned toolchain versions. Keep in sync with CI workflows and rust-toolchain.toml.
+EXPECTED_RUST="1.89.0"
 CARGO_NDK_VERSION="4.1.2"
+
+if [[ ! "$EXPECTED_RUST" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "error: EXPECTED_RUST ($EXPECTED_RUST) is not a valid semver version." >&2
+    exit 1
+fi
 
 if [ ! -d "$RUST_PROJECT" ]; then
     echo "error: keep-mobile not found at $RUST_PROJECT" >&2
@@ -20,16 +26,23 @@ if [ ! -f "$TOOLCHAIN_FILE" ]; then
     echo "error: $TOOLCHAIN_FILE not found; cannot determine pinned Rust version." >&2
     exit 1
 fi
-EXPECTED_RUST=$(sed -n 's/^channel *= *"\([^"]*\)".*/\1/p' "$TOOLCHAIN_FILE" | head -1)
-if [ -z "$EXPECTED_RUST" ]; then
+TOOLCHAIN_CHANNEL=$(sed -n 's/^channel *= *"\([^"]*\)".*/\1/p' "$TOOLCHAIN_FILE" | head -1)
+if [ -z "$TOOLCHAIN_CHANNEL" ]; then
     echo "error: could not parse channel from $TOOLCHAIN_FILE" >&2
+    exit 1
+fi
+if [ "$TOOLCHAIN_CHANNEL" != "$EXPECTED_RUST" ]; then
+    echo "error: rust-toolchain.toml channel does not match pinned EXPECTED_RUST" >&2
+    echo "  pinned (build-rust.sh): $EXPECTED_RUST" >&2
+    echo "  channel ($TOOLCHAIN_FILE): $TOOLCHAIN_CHANNEL" >&2
+    echo "Fix: update both to the same version after reviewing the keep repo SHA pin." >&2
     exit 1
 fi
 
 ACTUAL_RUST=$(cd "$RUST_PROJECT" && rustc --version | awk '{print $2}')
 if [ "$ACTUAL_RUST" != "$EXPECTED_RUST" ]; then
     echo "error: rustc version mismatch" >&2
-    echo "  expected: $EXPECTED_RUST (from $TOOLCHAIN_FILE)" >&2
+    echo "  expected: $EXPECTED_RUST" >&2
     echo "  actual:   $ACTUAL_RUST" >&2
     echo "Fix: run 'rustup install $EXPECTED_RUST' (rustup should auto-select via rust-toolchain.toml)." >&2
     exit 1
@@ -40,7 +53,12 @@ if ! command -v cargo-ndk >/dev/null 2>&1; then
     echo "Fix: cargo install --locked cargo-ndk --version $CARGO_NDK_VERSION" >&2
     exit 1
 fi
-ACTUAL_CARGO_NDK=$(cargo ndk --version | awk '{print $2}')
+ACTUAL_CARGO_NDK=$(cargo ndk --version 2>&1 | awk '{print $2}')
+if [ -z "$ACTUAL_CARGO_NDK" ]; then
+    echo "error: could not parse 'cargo ndk --version' output." >&2
+    echo "Fix: reinstall cargo-ndk: cargo install --locked cargo-ndk --version $CARGO_NDK_VERSION --force" >&2
+    exit 1
+fi
 if [ "$ACTUAL_CARGO_NDK" != "$CARGO_NDK_VERSION" ]; then
     echo "error: cargo-ndk version mismatch" >&2
     echo "  expected: $CARGO_NDK_VERSION" >&2
@@ -51,7 +69,7 @@ fi
 
 echo "Building keep-mobile for Android..."
 
-if [ -n "$TARGETS" ]; then
+if [ -n "${TARGETS:-}" ]; then
     IFS=',' read -ra TARGETS <<< "$TARGETS"
 else
     TARGETS=(
@@ -68,7 +86,7 @@ done
 
 for target in "${TARGETS[@]}"; do
     echo "Building for $target..."
-    cargo ndk -t "$target" -P 33 -o "$JNILIBS_DIR" build --release
+    cargo ndk -t "$target" -P 33 -o "$JNILIBS_DIR" build --release --locked
 done
 
 rm -f "$JNILIBS_DIR"/*/libredb-*.so

--- a/build-rust.sh
+++ b/build-rust.sh
@@ -6,6 +6,49 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RUST_PROJECT="$KEEP_REPO/keep-mobile"
 JNILIBS_DIR="$SCRIPT_DIR/app/src/main/jniLibs"
 
+# Pinned toolchain versions. Keep in sync with CI workflows and rust-toolchain.toml.
+CARGO_NDK_VERSION="4.1.2"
+
+if [ ! -d "$RUST_PROJECT" ]; then
+    echo "error: keep-mobile not found at $RUST_PROJECT" >&2
+    echo "Set KEEP_REPO to the path of your local keep checkout." >&2
+    exit 1
+fi
+
+TOOLCHAIN_FILE="$KEEP_REPO/rust-toolchain.toml"
+if [ ! -f "$TOOLCHAIN_FILE" ]; then
+    echo "error: $TOOLCHAIN_FILE not found; cannot determine pinned Rust version." >&2
+    exit 1
+fi
+EXPECTED_RUST=$(sed -n 's/^channel *= *"\([^"]*\)".*/\1/p' "$TOOLCHAIN_FILE" | head -1)
+if [ -z "$EXPECTED_RUST" ]; then
+    echo "error: could not parse channel from $TOOLCHAIN_FILE" >&2
+    exit 1
+fi
+
+ACTUAL_RUST=$(cd "$RUST_PROJECT" && rustc --version | awk '{print $2}')
+if [ "$ACTUAL_RUST" != "$EXPECTED_RUST" ]; then
+    echo "error: rustc version mismatch" >&2
+    echo "  expected: $EXPECTED_RUST (from $TOOLCHAIN_FILE)" >&2
+    echo "  actual:   $ACTUAL_RUST" >&2
+    echo "Fix: run 'rustup install $EXPECTED_RUST' (rustup should auto-select via rust-toolchain.toml)." >&2
+    exit 1
+fi
+
+if ! command -v cargo-ndk >/dev/null 2>&1; then
+    echo "error: cargo-ndk not installed." >&2
+    echo "Fix: cargo install --locked cargo-ndk --version $CARGO_NDK_VERSION" >&2
+    exit 1
+fi
+ACTUAL_CARGO_NDK=$(cargo ndk --version | awk '{print $2}')
+if [ "$ACTUAL_CARGO_NDK" != "$CARGO_NDK_VERSION" ]; then
+    echo "error: cargo-ndk version mismatch" >&2
+    echo "  expected: $CARGO_NDK_VERSION" >&2
+    echo "  actual:   $ACTUAL_CARGO_NDK" >&2
+    echo "Fix: cargo install --locked cargo-ndk --version $CARGO_NDK_VERSION --force" >&2
+    exit 1
+fi
+
 echo "Building keep-mobile for Android..."
 
 if [ -n "$TARGETS" ]; then

--- a/build-rust.sh
+++ b/build-rust.sh
@@ -53,16 +53,11 @@ if ! command -v cargo-ndk >/dev/null 2>&1; then
     echo "Fix: cargo install --locked cargo-ndk --version $CARGO_NDK_VERSION" >&2
     exit 1
 fi
-ACTUAL_CARGO_NDK=$(cargo ndk --version 2>&1 | awk '{print $2}')
-if [ -z "$ACTUAL_CARGO_NDK" ]; then
-    echo "error: could not parse 'cargo ndk --version' output." >&2
-    echo "Fix: reinstall cargo-ndk: cargo install --locked cargo-ndk --version $CARGO_NDK_VERSION --force" >&2
-    exit 1
-fi
+ACTUAL_CARGO_NDK=$(cargo ndk --version | grep -E '^cargo-ndk ' | awk '{print $2}')
 if [ "$ACTUAL_CARGO_NDK" != "$CARGO_NDK_VERSION" ]; then
     echo "error: cargo-ndk version mismatch" >&2
     echo "  expected: $CARGO_NDK_VERSION" >&2
-    echo "  actual:   $ACTUAL_CARGO_NDK" >&2
+    echo "  actual:   ${ACTUAL_CARGO_NDK:-<unparseable>}" >&2
     echo "Fix: cargo install --locked cargo-ndk --version $CARGO_NDK_VERSION --force" >&2
     exit 1
 fi

--- a/build-rust.sh
+++ b/build-rust.sh
@@ -53,7 +53,8 @@ if ! command -v cargo-ndk >/dev/null 2>&1; then
     echo "Fix: cargo install --locked cargo-ndk --version $CARGO_NDK_VERSION" >&2
     exit 1
 fi
-ACTUAL_CARGO_NDK=$(cargo ndk --version | grep -E '^cargo-ndk ' | awk '{print $2}')
+VERSION_OUTPUT="$(cargo ndk --version 2>/dev/null || true)"
+ACTUAL_CARGO_NDK="$(echo "$VERSION_OUTPUT" | grep -E '^cargo-ndk ' | awk '{print $2}' || true)"
 if [ "$ACTUAL_CARGO_NDK" != "$CARGO_NDK_VERSION" ]; then
     echo "error: cargo-ndk version mismatch" >&2
     echo "  expected: $CARGO_NDK_VERSION" >&2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,8 +17,8 @@ if (runningJavaVersion.majorVersion.toInt() != expectedJavaMajor) {
 val expectedNdkVersion = "29.0.14206865"
 
 fun resolveAndroidSdkDir(): String? {
-    System.getenv("ANDROID_HOME")?.let { return it }
-    System.getenv("ANDROID_SDK_ROOT")?.let { return it }
+    System.getenv("ANDROID_HOME")?.trim()?.takeIf { it.isNotBlank() }?.let { return it }
+    System.getenv("ANDROID_SDK_ROOT")?.trim()?.takeIf { it.isNotBlank() }?.let { return it }
     val localProps = file("${rootDir}/local.properties")
     if (localProps.exists()) {
         val props = java.util.Properties()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,32 @@ plugins {
     id("com.google.devtools.ksp") version "2.3.6" apply false
 }
 
+val expectedJavaMajor = 17
+val runningJavaVersion = JavaVersion.current()
+if (!runningJavaVersion.isCompatibleWith(JavaVersion.VERSION_17) ||
+    runningJavaVersion.majorVersion.toInt() != expectedJavaMajor) {
+    throw GradleException(
+        "JDK $expectedJavaMajor is required but Gradle is running on ${System.getProperty("java.version")} " +
+        "(java.home=${System.getProperty("java.home")}). " +
+        "Fix: set JAVA_HOME to a JDK $expectedJavaMajor install (e.g. Temurin 17) and re-run."
+    )
+}
+
+val expectedNdkVersion = "29.0.14206865"
+val androidHome = System.getenv("ANDROID_HOME")
+    ?: System.getenv("ANDROID_SDK_ROOT")
+    ?: file("${System.getProperty("user.home")}/Android/Sdk").takeIf { it.exists() }?.absolutePath
+if (androidHome != null) {
+    val ndkDir = file("$androidHome/ndk/$expectedNdkVersion")
+    if (!ndkDir.exists()) {
+        throw GradleException(
+            "Android NDK $expectedNdkVersion not found at ${ndkDir.absolutePath}. " +
+            "Fix: sdkmanager --install \"ndk;$expectedNdkVersion\" " +
+            "(or install via Android Studio SDK Manager)."
+        )
+    }
+}
+
 val keepRepo = file(System.getenv("KEEP_REPO") ?: "${rootDir}/keep")
 
 tasks.register<Exec>("buildRust") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,15 +5,6 @@ plugins {
 }
 
 val expectedJavaMajor = 17
-val runningJavaVersion = JavaVersion.current()
-if (runningJavaVersion.majorVersion.toInt() != expectedJavaMajor) {
-    throw GradleException(
-        "JDK $expectedJavaMajor is required but Gradle is running on ${System.getProperty("java.version")} " +
-        "(java.home=${System.getProperty("java.home")}). " +
-        "Fix: set JAVA_HOME to a JDK $expectedJavaMajor install (e.g. Temurin 17) and re-run."
-    )
-}
-
 val expectedNdkVersion = "29.0.14206865"
 
 fun resolveAndroidSdkDir(): String? {
@@ -29,14 +20,27 @@ fun resolveAndroidSdkDir(): String? {
 }
 
 gradle.taskGraph.whenReady {
+    val buildTaskPatterns = listOf(
+        Regex("(^|:)(assemble|bundle|compile|lint|connectedCheck|buildRust)[A-Z0-9_].*"),
+        Regex("(^|:)(assemble|bundle|compile|lint|buildRust)$"),
+        Regex("(^|:)(test|check)[A-Z0-9_].*"),
+        Regex("(^|:)(test|check)$"),
+        Regex("(^|:).*AndroidTest([A-Z0-9_].*)?$"),
+        Regex("(^|:).*UnitTest([A-Z0-9_].*)?$")
+    )
     val needsAndroidBuild = allTasks.any { task ->
-        val path = task.path.lowercase()
-        path.contains("assemble") || path.contains("bundle") ||
-            path.contains("compile") || path.contains("androidtest") ||
-            path.contains("buildrust") || path.contains("lint") ||
-            path.contains("test") && !path.endsWith(":tasks")
+        buildTaskPatterns.any { it.containsMatchIn(task.path) }
     }
     if (!needsAndroidBuild) return@whenReady
+
+    val runningJavaVersion = JavaVersion.current()
+    if (runningJavaVersion.majorVersion.toInt() != expectedJavaMajor) {
+        throw GradleException(
+            "JDK $expectedJavaMajor is required but Gradle is running on ${System.getProperty("java.version")} " +
+            "(java.home=${System.getProperty("java.home")}). " +
+            "Fix: set JAVA_HOME to a JDK $expectedJavaMajor install (e.g. Temurin 17) and re-run."
+        )
+    }
 
     val androidHome = resolveAndroidSdkDir()
     if (androidHome == null) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,7 @@ plugins {
 
 val expectedJavaMajor = 17
 val runningJavaVersion = JavaVersion.current()
-if (!runningJavaVersion.isCompatibleWith(JavaVersion.VERSION_17) ||
-    runningJavaVersion.majorVersion.toInt() != expectedJavaMajor) {
+if (runningJavaVersion.majorVersion.toInt() != expectedJavaMajor) {
     throw GradleException(
         "JDK $expectedJavaMajor is required but Gradle is running on ${System.getProperty("java.version")} " +
         "(java.home=${System.getProperty("java.home")}). " +
@@ -16,10 +15,38 @@ if (!runningJavaVersion.isCompatibleWith(JavaVersion.VERSION_17) ||
 }
 
 val expectedNdkVersion = "29.0.14206865"
-val androidHome = System.getenv("ANDROID_HOME")
-    ?: System.getenv("ANDROID_SDK_ROOT")
-    ?: file("${System.getProperty("user.home")}/Android/Sdk").takeIf { it.exists() }?.absolutePath
-if (androidHome != null) {
+
+fun resolveAndroidSdkDir(): String? {
+    System.getenv("ANDROID_HOME")?.let { return it }
+    System.getenv("ANDROID_SDK_ROOT")?.let { return it }
+    val localProps = file("${rootDir}/local.properties")
+    if (localProps.exists()) {
+        val props = java.util.Properties()
+        localProps.inputStream().use { props.load(it) }
+        props.getProperty("sdk.dir")?.takeIf { it.isNotBlank() }?.let { return it }
+    }
+    return file("${System.getProperty("user.home")}/Android/Sdk").takeIf { it.exists() }?.absolutePath
+}
+
+gradle.taskGraph.whenReady {
+    val needsAndroidBuild = allTasks.any { task ->
+        val path = task.path.lowercase()
+        path.contains("assemble") || path.contains("bundle") ||
+            path.contains("compile") || path.contains("androidtest") ||
+            path.contains("buildrust") || path.contains("lint") ||
+            path.contains("test") && !path.endsWith(":tasks")
+    }
+    if (!needsAndroidBuild) return@whenReady
+
+    val androidHome = resolveAndroidSdkDir()
+    if (androidHome == null) {
+        logger.warn(
+            "Android SDK not found (ANDROID_HOME, ANDROID_SDK_ROOT, local.properties sdk.dir, " +
+            "and ~/Android/Sdk all unset/missing). Skipping NDK $expectedNdkVersion check; " +
+            "Android build tasks will likely fail."
+        )
+        return@whenReady
+    }
     val ndkDir = file("$androidHome/ndk/$expectedNdkVersion")
     if (!ndkDir.exists()) {
         throw GradleException(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,12 +21,9 @@ fun resolveAndroidSdkDir(): String? {
 
 gradle.taskGraph.whenReady {
     val buildTaskPatterns = listOf(
-        Regex("(^|:)(assemble|bundle|compile|lint|connectedCheck|buildRust)[A-Z0-9_].*"),
-        Regex("(^|:)(assemble|bundle|compile|lint|buildRust)$"),
-        Regex("(^|:)(test|check)[A-Z0-9_].*"),
-        Regex("(^|:)(test|check)$"),
-        Regex("(^|:).*AndroidTest([A-Z0-9_].*)?$"),
-        Regex("(^|:).*UnitTest([A-Z0-9_].*)?$")
+        Regex("(^|:)(assemble|bundle|compile|lint|buildRust|test|check)([A-Z0-9_].*)?$"),
+        Regex("(^|:)connectedCheck[A-Z0-9_].*"),
+        Regex("(^|:).*(AndroidTest|UnitTest)([A-Z0-9_].*)?$")
     )
     val needsAndroidBuild = allTasks.any { task ->
         buildTaskPatterns.any { it.containsMatchIn(task.path) }

--- a/scripts/check-toolchain-pins.sh
+++ b/scripts/check-toolchain-pins.sh
@@ -40,13 +40,13 @@ done
 BR_RUST=$(extract "$BUILD_RUST" 'EXPECTED_RUST="([0-9]+\.[0-9]+\.[0-9]+)"')
 BR_CARGO_NDK=$(extract "$BUILD_RUST" 'CARGO_NDK_VERSION="([0-9]+\.[0-9]+\.[0-9]+)"')
 
-CI_RUST=$(extract "$CI_YML" 'RUST_VERSION: "([0-9]+\.[0-9]+\.[0-9]+)"')
-CI_NDK=$(extract "$CI_YML" 'NDK_VERSION: "([0-9.]+)"')
-CI_CARGO_NDK=$(extract "$CI_YML" 'CARGO_NDK_VERSION: "([0-9]+\.[0-9]+\.[0-9]+)"')
+CI_RUST=$(extract "$CI_YML" '^[[:space:]]+RUST_VERSION: "([0-9]+\.[0-9]+\.[0-9]+)"')
+CI_NDK=$(extract "$CI_YML" '^[[:space:]]+NDK_VERSION: "([0-9.]+)"')
+CI_CARGO_NDK=$(extract "$CI_YML" '^[[:space:]]+CARGO_NDK_VERSION: "([0-9]+\.[0-9]+\.[0-9]+)"')
 
-REL_RUST=$(extract "$RELEASE_YML" 'RUST_VERSION: "([0-9]+\.[0-9]+\.[0-9]+)"')
-REL_NDK=$(extract "$RELEASE_YML" 'NDK_VERSION: "([0-9.]+)"')
-REL_CARGO_NDK=$(extract "$RELEASE_YML" 'CARGO_NDK_VERSION: "([0-9]+\.[0-9]+\.[0-9]+)"')
+REL_RUST=$(extract "$RELEASE_YML" '^[[:space:]]+RUST_VERSION: "([0-9]+\.[0-9]+\.[0-9]+)"')
+REL_NDK=$(extract "$RELEASE_YML" '^[[:space:]]+NDK_VERSION: "([0-9.]+)"')
+REL_CARGO_NDK=$(extract "$RELEASE_YML" '^[[:space:]]+CARGO_NDK_VERSION: "([0-9]+\.[0-9]+\.[0-9]+)"')
 
 GRADLE_NDK=$(extract "$GRADLE_KTS" 'expectedNdkVersion = "([0-9.]+)"')
 

--- a/scripts/check-toolchain-pins.sh
+++ b/scripts/check-toolchain-pins.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 #   .github/workflows/release.yml (RUST_VERSION, NDK_VERSION, CARGO_NDK_VERSION)
 #   keep/rust-toolchain.toml (channel, if present)
 #   build.gradle.kts         (expectedNdkVersion, expectedJavaMajor)
+#   .github/workflows/*.yml  (java-version in actions/setup-java steps)
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -49,6 +50,21 @@ REL_NDK=$(extract "$RELEASE_YML" '^[[:space:]]+NDK_VERSION: "([0-9.]+)"')
 REL_CARGO_NDK=$(extract "$RELEASE_YML" '^[[:space:]]+CARGO_NDK_VERSION: "([0-9]+\.[0-9]+\.[0-9]+)"')
 
 GRADLE_NDK=$(extract "$GRADLE_KTS" 'expectedNdkVersion = "([0-9.]+)"')
+GRADLE_JDK=$(extract "$GRADLE_KTS" 'expectedJavaMajor = ([0-9]+)')
+
+extract_unique() {
+    # extract_unique <file> <regex with one capture group>: all matches must be equal
+    local file="$1"
+    local regex="$2"
+    local vals
+    vals=$(sed -nE "s/.*${regex}.*/\1/p" "$file" | sort -u)
+    [ -n "$vals" ] || fail "could not extract /$regex/ from $file"
+    [ "$(echo "$vals" | wc -l)" -eq 1 ] || fail "inconsistent values for /$regex/ within $file: $vals"
+    echo "$vals"
+}
+
+CI_JDK=$(extract_unique "$CI_YML" "^[[:space:]]+java-version: '([0-9]+)'")
+REL_JDK=$(extract_unique "$RELEASE_YML" "^[[:space:]]+java-version: '([0-9]+)'")
 
 check_equal() {
     local name="$1"
@@ -66,6 +82,7 @@ check_equal() {
 check_equal "rust version"        "$BR_RUST"       "$CI_RUST"       "$REL_RUST"
 check_equal "cargo-ndk version"   "$BR_CARGO_NDK"  "$CI_CARGO_NDK"  "$REL_CARGO_NDK"
 check_equal "ndk version"         "$CI_NDK"        "$REL_NDK"       "$GRADLE_NDK"
+check_equal "jdk major version"   "$GRADLE_JDK"    "$CI_JDK"        "$REL_JDK"
 
 if [ -f "$TOOLCHAIN_TOML" ]; then
     TOML_CHANNEL=$(sed -nE 's/^channel *= *"([^"]+)".*/\1/p' "$TOOLCHAIN_TOML" | head -1)

--- a/scripts/check-toolchain-pins.sh
+++ b/scripts/check-toolchain-pins.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -euo pipefail
+
+# Verifies that pinned toolchain versions are consistent across all files.
+# Sources of truth checked:
+#   build-rust.sh            (EXPECTED_RUST, CARGO_NDK_VERSION)
+#   .github/workflows/ci.yml (RUST_VERSION, NDK_VERSION, CARGO_NDK_VERSION)
+#   .github/workflows/release.yml (RUST_VERSION, NDK_VERSION, CARGO_NDK_VERSION)
+#   keep/rust-toolchain.toml (channel, if present)
+#   build.gradle.kts         (expectedNdkVersion, expectedJavaMajor)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+fail() {
+    echo "error: $*" >&2
+    exit 1
+}
+
+extract() {
+    # extract <file> <regex with one capture group>
+    local file="$1"
+    local regex="$2"
+    local val
+    val=$(sed -nE "s/.*${regex}.*/\1/p" "$file" | head -1)
+    [ -n "$val" ] || fail "could not extract /$regex/ from $file"
+    echo "$val"
+}
+
+BUILD_RUST="$ROOT/build-rust.sh"
+CI_YML="$ROOT/.github/workflows/ci.yml"
+RELEASE_YML="$ROOT/.github/workflows/release.yml"
+GRADLE_KTS="$ROOT/build.gradle.kts"
+TOOLCHAIN_TOML="$ROOT/keep/rust-toolchain.toml"
+
+for f in "$BUILD_RUST" "$CI_YML" "$RELEASE_YML" "$GRADLE_KTS"; do
+    [ -f "$f" ] || fail "missing file: $f"
+done
+
+BR_RUST=$(extract "$BUILD_RUST" 'EXPECTED_RUST="([0-9]+\.[0-9]+\.[0-9]+)"')
+BR_CARGO_NDK=$(extract "$BUILD_RUST" 'CARGO_NDK_VERSION="([0-9]+\.[0-9]+\.[0-9]+)"')
+
+CI_RUST=$(extract "$CI_YML" 'RUST_VERSION: "([0-9]+\.[0-9]+\.[0-9]+)"')
+CI_NDK=$(extract "$CI_YML" 'NDK_VERSION: "([0-9.]+)"')
+CI_CARGO_NDK=$(extract "$CI_YML" 'CARGO_NDK_VERSION: "([0-9]+\.[0-9]+\.[0-9]+)"')
+
+REL_RUST=$(extract "$RELEASE_YML" 'RUST_VERSION: "([0-9]+\.[0-9]+\.[0-9]+)"')
+REL_NDK=$(extract "$RELEASE_YML" 'NDK_VERSION: "([0-9.]+)"')
+REL_CARGO_NDK=$(extract "$RELEASE_YML" 'CARGO_NDK_VERSION: "([0-9]+\.[0-9]+\.[0-9]+)"')
+
+GRADLE_NDK=$(extract "$GRADLE_KTS" 'expectedNdkVersion = "([0-9.]+)"')
+
+check_equal() {
+    local name="$1"
+    shift
+    local first="$1"
+    shift
+    for v in "$@"; do
+        if [ "$v" != "$first" ]; then
+            fail "$name mismatch: $first vs $v (values: $first $*)"
+        fi
+    done
+    echo "ok: $name = $first"
+}
+
+check_equal "rust version"        "$BR_RUST"       "$CI_RUST"       "$REL_RUST"
+check_equal "cargo-ndk version"   "$BR_CARGO_NDK"  "$CI_CARGO_NDK"  "$REL_CARGO_NDK"
+check_equal "ndk version"         "$CI_NDK"        "$REL_NDK"       "$GRADLE_NDK"
+
+if [ -f "$TOOLCHAIN_TOML" ]; then
+    TOML_CHANNEL=$(sed -nE 's/^channel *= *"([^"]+)".*/\1/p' "$TOOLCHAIN_TOML" | head -1)
+    [ -n "$TOML_CHANNEL" ] || fail "could not parse channel from $TOOLCHAIN_TOML"
+    check_equal "rust-toolchain.toml channel" "$BR_RUST" "$TOML_CHANNEL"
+else
+    echo "note: $TOOLCHAIN_TOML not present; skipping channel check."
+fi
+
+echo "all toolchain pins consistent."


### PR DESCRIPTION
Pin Rust 1.89.0, NDK 29.0.14206865, cargo-ndk 4.1.2, JDK 17, build-tools 36.0.0 across local builds and CI. Harden workflow permissions, keystore decode, and Gradle toolchain checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Restricted CI workflow token permissions, added job timeouts, and made Gradle cache writes conditional for safer CI.
  * Pinned toolchain versions (Rust, cargo-ndk, Android NDK, build-tools, JDK) and made APK signing deterministic.
  * Added many fail-fast build validations for JVM, Rust toolchain, cargo-ndk, Android SDK/NDK presence, and install commands.

* **Documentation**
  * Updated build instructions with exact pinned versions and guidance to verify toolchain pins.

* **Chores (scripts)**
  * Added a script to verify consistency of pinned toolchain versions across the repo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->