### PR TITLE
Add bit-for-bit APK reproducibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,13 @@ jobs:
       - name: Verify toolchain version pins are consistent
         run: ./scripts/check-toolchain-pins.sh
 
+      - name: Derive SOURCE_DATE_EPOCH
+        run: |
+          SDE="$(ANDROID_REPO="$GITHUB_WORKSPACE" KEEP_REPO="$GITHUB_WORKSPACE/keep" \
+            ./scripts/derive-sde.sh)"
+          echo "SOURCE_DATE_EPOCH=$SDE" >> "$GITHUB_ENV"
+          echo "Using SOURCE_DATE_EPOCH=$SDE"
+
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -89,6 +96,7 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          SOURCE_DATE_EPOCH: ${{ env.SOURCE_DATE_EPOCH }}
 
       - name: Verify APK is signed
         run: |

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,6 +25,13 @@ android {
         }
     }
 
+    // Reproducible builds: strip non-reproducible Play dependency metadata blob
+    // (contains signing timestamps) from APK and bundle outputs.
+    dependenciesInfo {
+        includeInApk = false
+        includeInBundle = false
+    }
+
     signingConfigs {
         create("release") {
             val ksFile = System.getenv("KEYSTORE_FILE")
@@ -75,6 +82,7 @@ android {
                 "/lib/mips/**",
                 "/lib/mips64/**",
             )
+            useLegacyPackaging = false
         }
     }
 

--- a/build-rust.sh
+++ b/build-rust.sh
@@ -2,9 +2,57 @@
 set -euo pipefail
 
 KEEP_REPO="${KEEP_REPO:-./keep}"
+if [ ! -d "$KEEP_REPO" ]; then
+    echo "error: KEEP_REPO path does not exist: $KEEP_REPO" >&2
+    exit 1
+fi
+KEEP_REPO="$(cd "$KEEP_REPO" && pwd)"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RUST_PROJECT="$KEEP_REPO/keep-mobile"
 JNILIBS_DIR="$SCRIPT_DIR/app/src/main/jniLibs"
+
+# Reproducible-build environment. Callers may override SOURCE_DATE_EPOCH.
+export LC_ALL=C
+export TZ=UTC
+umask 022
+
+SOURCE_DATE_EPOCH="$(ANDROID_REPO="$SCRIPT_DIR" KEEP_REPO="$KEEP_REPO" \
+    "$SCRIPT_DIR/scripts/derive-sde.sh")"
+if [[ ! "$SOURCE_DATE_EPOCH" =~ ^[0-9]+$ ]]; then
+    echo "error: derived SOURCE_DATE_EPOCH='$SOURCE_DATE_EPOCH' is not a non-negative integer." >&2
+    exit 1
+fi
+export SOURCE_DATE_EPOCH
+echo "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH"
+
+# Strip absolute paths from rustc debuginfo so two builders with different
+# CARGO_HOME / workspace locations produce byte-identical .so files.
+CARGO_HOME_DIR="${CARGO_HOME:-$HOME/.cargo}"
+REMAP_FLAGS=(
+    "--remap-path-prefix=$RUST_PROJECT=/build/keep-mobile"
+    "--remap-path-prefix=$KEEP_REPO=/build"
+    "--remap-path-prefix=$CARGO_HOME_DIR/registry=/cargo/registry"
+    "--remap-path-prefix=$CARGO_HOME_DIR/git=/cargo/git"
+    "--remap-path-prefix=$CARGO_HOME_DIR=/cargo"
+)
+# Use CARGO_ENCODED_RUSTFLAGS with 0x1f (ASCII unit separator) between flags so
+# whitespace in paths (e.g., $HOME containing spaces) can't split a flag mid-arg.
+ALL_FLAGS=()
+if [ -n "${CARGO_ENCODED_RUSTFLAGS:-}" ]; then
+    # Preserve pre-encoded flags verbatim as a single pre-joined segment.
+    ALL_FLAGS+=("$CARGO_ENCODED_RUSTFLAGS")
+elif [ -n "${RUSTFLAGS:-}" ]; then
+    # Best-effort preservation of a pre-set RUSTFLAGS: split on whitespace.
+    # Callers with spaces in RUSTFLAGS values should set CARGO_ENCODED_RUSTFLAGS.
+    # shellcheck disable=SC2206
+    ALL_FLAGS+=($RUSTFLAGS)
+    unset RUSTFLAGS
+fi
+ALL_FLAGS+=("${REMAP_FLAGS[@]}")
+# Join with 0x1f.
+printf -v CARGO_ENCODED_RUSTFLAGS '%s\x1f' "${ALL_FLAGS[@]}"
+CARGO_ENCODED_RUSTFLAGS="${CARGO_ENCODED_RUSTFLAGS%$'\x1f'}"
+export CARGO_ENCODED_RUSTFLAGS
 
 # Pinned toolchain versions. Keep in sync with CI workflows and rust-toolchain.toml.
 EXPECTED_RUST="1.89.0"
@@ -96,7 +144,7 @@ done
 
 rm -f "$JNILIBS_DIR"/*/libredb-*.so
 
-BINDING_LIB=$(find "$JNILIBS_DIR" -name "libkeep_mobile.so" | head -1)
+BINDING_LIB=$(find "$JNILIBS_DIR" -name "libkeep_mobile.so" | LC_ALL=C sort | head -1)
 echo "Generating Kotlin bindings from $BINDING_LIB..."
 cargo run --bin uniffi-bindgen generate \
     --library "$BINDING_LIB" \

--- a/build-rust.sh
+++ b/build-rust.sh
@@ -42,11 +42,11 @@ if [ -n "${CARGO_ENCODED_RUSTFLAGS:-}" ]; then
     # Preserve pre-encoded flags verbatim as a single pre-joined segment.
     ALL_FLAGS+=("$CARGO_ENCODED_RUSTFLAGS")
 elif [ -n "${RUSTFLAGS:-}" ]; then
-    # Best-effort preservation of a pre-set RUSTFLAGS: split on whitespace.
-    # Callers with spaces in RUSTFLAGS values should set CARGO_ENCODED_RUSTFLAGS.
-    # shellcheck disable=SC2206
-    ALL_FLAGS+=($RUSTFLAGS)
-    unset RUSTFLAGS
+    echo "error: RUSTFLAGS is set but CARGO_ENCODED_RUSTFLAGS is not." >&2
+    echo "Word-splitting RUSTFLAGS would silently corrupt flags containing spaces." >&2
+    echo "Fix: re-encode your flags into CARGO_ENCODED_RUSTFLAGS using 0x1f (ASCII unit" >&2
+    echo "separator) between flags, then unset RUSTFLAGS before invoking this script." >&2
+    exit 1
 fi
 ALL_FLAGS+=("${REMAP_FLAGS[@]}")
 # Join with 0x1f.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -129,6 +129,9 @@ tasks.register<Exec>("buildRust") {
     workingDir = rootDir
     commandLine("bash", "build-rust.sh")
     environment("KEEP_REPO", keepRepo.absolutePath)
+    System.getenv("SOURCE_DATE_EPOCH")?.takeIf { it.isNotBlank() }?.let {
+        environment("SOURCE_DATE_EPOCH", it)
+    }
 
     inputs.file("${rootDir}/build-rust.sh").withPathSensitivity(PathSensitivity.RELATIVE)
     if (keepRepo.exists()) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,28 @@ gradle.taskGraph.whenReady {
             "(or install via Android Studio SDK Manager)."
         )
     }
+
+    val releaseTaskPattern = Regex("(^|:)(assemble|bundle|package)[A-Z0-9_].*[Rr]elease([A-Z0-9_].*)?$")
+    val buildingRelease = allTasks.any { task ->
+        releaseTaskPattern.containsMatchIn(task.path)
+    }
+    if (buildingRelease) {
+        val sde = System.getenv("SOURCE_DATE_EPOCH")
+        if (sde.isNullOrBlank()) {
+            throw GradleException(
+                "SOURCE_DATE_EPOCH is not set. Release builds require it to be set in the " +
+                "Gradle JVM environment so AGP's packaging and signing use a deterministic " +
+                "timestamp. Fix: export SOURCE_DATE_EPOCH=\"\$(./scripts/derive-sde.sh)\" " +
+                "before invoking Gradle."
+            )
+        }
+        if (!sde.matches(Regex("^[0-9]+$"))) {
+            throw GradleException(
+                "SOURCE_DATE_EPOCH='$sde' is not a non-negative integer. " +
+                "Fix: export SOURCE_DATE_EPOCH=\"\$(./scripts/derive-sde.sh)\"."
+            )
+        }
+    }
 }
 
 val keepRepo = file(System.getenv("KEEP_REPO") ?: "${rootDir}/keep")
@@ -129,8 +151,14 @@ tasks.register<Exec>("buildRust") {
     workingDir = rootDir
     commandLine("bash", "build-rust.sh")
     environment("KEEP_REPO", keepRepo.absolutePath)
-    System.getenv("SOURCE_DATE_EPOCH")?.takeIf { it.isNotBlank() }?.let {
-        environment("SOURCE_DATE_EPOCH", it)
+    System.getenv("SOURCE_DATE_EPOCH")?.takeIf { it.isNotBlank() }?.let { sde ->
+        if (!sde.matches(Regex("^[0-9]+$"))) {
+            throw GradleException(
+                "SOURCE_DATE_EPOCH='$sde' is not a non-negative integer. " +
+                "Fix: export SOURCE_DATE_EPOCH=\"\$(./scripts/derive-sde.sh)\"."
+            )
+        }
+        environment("SOURCE_DATE_EPOCH", sde)
     }
 
     inputs.file("${rootDir}/build-rust.sh").withPathSensitivity(PathSensitivity.RELATIVE)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,16 @@ plugins {
 val expectedJavaMajor = 17
 val expectedNdkVersion = "29.0.14206865"
 
+fun validateSourceDateEpoch(sde: String): String {
+    if (!sde.matches(Regex("^[0-9]+$"))) {
+        throw GradleException(
+            "SOURCE_DATE_EPOCH='$sde' is not a non-negative integer. " +
+            "Fix: export SOURCE_DATE_EPOCH=\"\$(./scripts/derive-sde.sh)\"."
+        )
+    }
+    return sde
+}
+
 fun resolveAndroidSdkDir(): String? {
     System.getenv("ANDROID_HOME")?.trim()?.takeIf { it.isNotBlank() }?.let { return it }
     System.getenv("ANDROID_SDK_ROOT")?.trim()?.takeIf { it.isNotBlank() }?.let { return it }
@@ -57,7 +67,7 @@ gradle.taskGraph.whenReady {
         )
     }
 
-    val releaseTaskPattern = Regex("(^|:)(assemble|bundle|package)[A-Z0-9_].*[Rr]elease([A-Z0-9_].*)?$")
+    val releaseTaskPattern = Regex("(^|:)(assemble|bundle|package)([A-Z0-9_].*)?Release([A-Z0-9_].*)?$")
     val buildingRelease = allTasks.any { task ->
         releaseTaskPattern.containsMatchIn(task.path)
     }
@@ -71,12 +81,7 @@ gradle.taskGraph.whenReady {
                 "before invoking Gradle."
             )
         }
-        if (!sde.matches(Regex("^[0-9]+$"))) {
-            throw GradleException(
-                "SOURCE_DATE_EPOCH='$sde' is not a non-negative integer. " +
-                "Fix: export SOURCE_DATE_EPOCH=\"\$(./scripts/derive-sde.sh)\"."
-            )
-        }
+        validateSourceDateEpoch(sde)
     }
 }
 
@@ -152,13 +157,7 @@ tasks.register<Exec>("buildRust") {
     commandLine("bash", "build-rust.sh")
     environment("KEEP_REPO", keepRepo.absolutePath)
     System.getenv("SOURCE_DATE_EPOCH")?.takeIf { it.isNotBlank() }?.let { sde ->
-        if (!sde.matches(Regex("^[0-9]+$"))) {
-            throw GradleException(
-                "SOURCE_DATE_EPOCH='$sde' is not a non-negative integer. " +
-                "Fix: export SOURCE_DATE_EPOCH=\"\$(./scripts/derive-sde.sh)\"."
-            )
-        }
-        environment("SOURCE_DATE_EPOCH", sde)
+        environment("SOURCE_DATE_EPOCH", validateSourceDateEpoch(sde))
     }
 
     inputs.file("${rootDir}/build-rust.sh").withPathSensitivity(PathSensitivity.RELATIVE)

--- a/docs/REPRODUCIBLE_BUILDS.md
+++ b/docs/REPRODUCIBLE_BUILDS.md
@@ -1,0 +1,106 @@
+# Reproducible Builds
+
+Two independent builders with matching toolchains and source commits must
+produce byte-identical release APKs. This document lists the required
+environment and the verification procedure.
+
+## Required toolchain
+
+Pinned and enforced by `scripts/check-toolchain-pins.sh`:
+
+| Component     | Version           |
+|---------------|-------------------|
+| Rust          | 1.89.0            |
+| cargo-ndk     | 4.1.2             |
+| Android NDK   | 29.0.14206865     |
+| Android build-tools | 36.0.0      |
+| JDK           | 17 (Temurin, verified with 17.0.13+11) |
+| AGP           | 9.1.0             |
+| Kotlin        | 2.3.20            |
+
+The `keep` sibling repository must be checked out at the exact commit
+referenced by `.github/workflows/release.yml` (`ref:` under the
+`Checkout keep repo` step).
+
+## Required environment
+
+| Variable              | Value                                         |
+|-----------------------|-----------------------------------------------|
+| `SOURCE_DATE_EPOCH`   | commit timestamp (see below)                  |
+| `LC_ALL`              | `C` (set by `build-rust.sh`)                  |
+| `TZ`                  | `UTC` (set by `build-rust.sh`)                |
+| `umask`               | `022` (set by `build-rust.sh`)                |
+| Filesystem            | case-sensitive (ext4, APFS case-sensitive)    |
+
+`SOURCE_DATE_EPOCH` is derived by `scripts/derive-sde.sh` (called by both
+`build-rust.sh` and `.github/workflows/release.yml`) as the later of the
+HEAD commit times of this repository and the `keep` workspace. Override
+by exporting it explicitly.
+
+**Local `./gradlew assembleRelease` callers must export
+`SOURCE_DATE_EPOCH` in the shell before invoking Gradle.** AGP's
+packaging and signing steps read it from the Gradle process environment;
+`build.gradle.kts` only forwards it into the `buildRust` `Exec`
+subprocess, so an unset shell variable will produce a non-reproducible
+APK even if the Rust build was reproducible. Easiest recipe:
+
+```bash
+export SOURCE_DATE_EPOCH="$(./scripts/derive-sde.sh)"
+```
+
+### JDK minor version
+
+The JDK minor version is a known reproducibility variable. Release
+builds are verified against Temurin 17.0.13+11; other 17.x builds may
+produce byte-identical output but are not guaranteed to.
+
+### `umask` scope
+
+`umask 022` in `build-rust.sh` only affects files the script itself
+writes (cargo-ndk outputs, generated bindings). Gradle's APK packager
+normalizes entry modes inside the APK independently, so this setting is
+belt-and-suspenders rather than load-bearing for APK reproducibility.
+
+## Local verification
+
+```bash
+# clean state
+./gradlew clean
+rm -rf app/src/main/jniLibs app/src/main/kotlin/io/privkey/keep/uniffi
+
+# build 1
+KEEP_REPO=../keep ./build-rust.sh
+ANDROID_HOME=/usr/lib/android-sdk ./gradlew assembleRelease
+cp app/build/outputs/apk/release/app-release*.apk /tmp/build1.apk
+
+# clean and re-build
+./gradlew clean
+rm -rf app/src/main/jniLibs app/src/main/kotlin/io/privkey/keep/uniffi
+KEEP_REPO=../keep ./build-rust.sh
+ANDROID_HOME=/usr/lib/android-sdk ./gradlew assembleRelease
+cp app/build/outputs/apk/release/app-release*.apk /tmp/build2.apk
+
+sha256sum /tmp/build1.apk /tmp/build2.apk
+diffoscope /tmp/build1.apk /tmp/build2.apk
+```
+
+## Sources of non-determinism addressed
+
+1. **Build timestamps** — `SOURCE_DATE_EPOCH` derived from the latest
+   commit of the two source repos, propagated to `cargo`, AGP, and the
+   APK signing path.
+2. **Absolute paths in Rust debuginfo** — `build-rust.sh` injects
+   `--remap-path-prefix` for the `keep` workspace, `CARGO_HOME`, and the
+   cargo registry.
+3. **Play dependency metadata** — `android.dependenciesInfo
+   { includeInApk = false; includeInBundle = false }` strips the
+   encrypted Play Store metadata blob (contains a signing timestamp).
+4. **Native lib packaging** — `jniLibs.useLegacyPackaging = false`
+   ensures uncompressed, page-aligned, deterministic entries.
+5. **Locale/timezone ordering** — `LC_ALL=C TZ=UTC umask 022` set
+   before any file I/O or archive creation.
+
+## Known residual differences
+
+None currently documented. If a verifier finds a diff, attach the
+`diffoscope` output to an issue.

--- a/docs/REPRODUCIBLE_BUILDS.md
+++ b/docs/REPRODUCIBLE_BUILDS.md
@@ -42,9 +42,12 @@ by exporting it explicitly.
 packaging and signing steps read it from the Gradle process environment;
 `build.gradle.kts` only forwards it into the `buildRust` `Exec`
 subprocess, so an unset shell variable will produce a non-reproducible
-APK even if the Rust build was reproducible. Easiest recipe:
+APK even if the Rust build was reproducible. Easiest recipe (the
+example assumes the `keep` checkout is at `./keep`; set `KEEP_REPO` if
+it lives elsewhere):
 
 ```bash
+export KEEP_REPO=../keep
 export SOURCE_DATE_EPOCH="$(./scripts/derive-sde.sh)"
 ```
 
@@ -64,19 +67,22 @@ belt-and-suspenders rather than load-bearing for APK reproducibility.
 ## Local verification
 
 ```bash
+export KEEP_REPO=../keep
+export SOURCE_DATE_EPOCH="$(./scripts/derive-sde.sh)"
+
 # clean state
 ./gradlew clean
 rm -rf app/src/main/jniLibs app/src/main/kotlin/io/privkey/keep/uniffi
 
 # build 1
-KEEP_REPO=../keep ./build-rust.sh
+./build-rust.sh
 ANDROID_HOME=/usr/lib/android-sdk ./gradlew assembleRelease
 cp app/build/outputs/apk/release/app-release*.apk /tmp/build1.apk
 
 # clean and re-build
 ./gradlew clean
 rm -rf app/src/main/jniLibs app/src/main/kotlin/io/privkey/keep/uniffi
-KEEP_REPO=../keep ./build-rust.sh
+./build-rust.sh
 ANDROID_HOME=/usr/lib/android-sdk ./gradlew assembleRelease
 cp app/build/outputs/apk/release/app-release*.apk /tmp/build2.apk
 

--- a/scripts/derive-sde.sh
+++ b/scripts/derive-sde.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Prints SOURCE_DATE_EPOCH on stdout as the later of the two repo HEAD commit
+# times (keep-android and the keep workspace). Respects a pre-set
+# SOURCE_DATE_EPOCH by echoing it unchanged. Exits non-zero on failure.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ANDROID_REPO="${ANDROID_REPO:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+KEEP_REPO="${KEEP_REPO:-$ANDROID_REPO/keep}"
+
+if [ -n "${SOURCE_DATE_EPOCH:-}" ]; then
+    if [[ ! "$SOURCE_DATE_EPOCH" =~ ^[0-9]+$ ]]; then
+        echo "error: SOURCE_DATE_EPOCH='$SOURCE_DATE_EPOCH' is not a non-negative integer." >&2
+        exit 1
+    fi
+    printf '%s\n' "$SOURCE_DATE_EPOCH"
+    exit 0
+fi
+
+ANDROID_EPOCH=""
+KEEP_EPOCH=""
+if git -C "$ANDROID_REPO" rev-parse --git-dir >/dev/null 2>&1; then
+    ANDROID_EPOCH=$(git -C "$ANDROID_REPO" log -1 --pretty=%ct 2>/dev/null || true)
+fi
+if [ -d "$KEEP_REPO" ] && git -C "$KEEP_REPO" rev-parse --git-dir >/dev/null 2>&1; then
+    KEEP_EPOCH=$(git -C "$KEEP_REPO" log -1 --pretty=%ct 2>/dev/null || true)
+fi
+
+for name in ANDROID_EPOCH KEEP_EPOCH; do
+    val="${!name}"
+    if [ -n "$val" ] && [[ ! "$val" =~ ^[0-9]+$ ]]; then
+        echo "error: $name='$val' is not a non-negative integer." >&2
+        exit 1
+    fi
+done
+
+if [ -n "$ANDROID_EPOCH" ] && [ -n "$KEEP_EPOCH" ]; then
+    if [ "$ANDROID_EPOCH" -gt "$KEEP_EPOCH" ]; then
+        printf '%s\n' "$ANDROID_EPOCH"
+    else
+        printf '%s\n' "$KEEP_EPOCH"
+    fi
+elif [ -n "$ANDROID_EPOCH" ]; then
+    printf '%s\n' "$ANDROID_EPOCH"
+elif [ -n "$KEEP_EPOCH" ]; then
+    printf '%s\n' "$KEEP_EPOCH"
+else
+    echo "error: SOURCE_DATE_EPOCH unset and neither repo has git history to derive it." >&2
+    exit 1
+fi

--- a/scripts/derive-sde.sh
+++ b/scripts/derive-sde.sh
@@ -22,8 +22,17 @@ KEEP_EPOCH=""
 if git -C "$ANDROID_REPO" rev-parse --git-dir >/dev/null 2>&1; then
     ANDROID_EPOCH=$(git -C "$ANDROID_REPO" log -1 --pretty=%ct 2>/dev/null || true)
 fi
-if [ -d "$KEEP_REPO" ] && git -C "$KEEP_REPO" rev-parse --git-dir >/dev/null 2>&1; then
+if [ -d "$KEEP_REPO" ]; then
+    if ! git -C "$KEEP_REPO" rev-parse --git-dir >/dev/null 2>&1; then
+        echo "error: KEEP_REPO='$KEEP_REPO' exists but is not a git repository." >&2
+        echo "Fix: clone keep as a git repo, or set SOURCE_DATE_EPOCH explicitly." >&2
+        exit 1
+    fi
     KEEP_EPOCH=$(git -C "$KEEP_REPO" log -1 --pretty=%ct 2>/dev/null || true)
+    if [ -z "$KEEP_EPOCH" ]; then
+        echo "error: failed to read HEAD commit time from KEEP_REPO='$KEEP_REPO'." >&2
+        exit 1
+    fi
 fi
 
 for name in ANDROID_EPOCH KEEP_EPOCH; do

--- a/scripts/derive-sde.sh
+++ b/scripts/derive-sde.sh
@@ -21,6 +21,10 @@ ANDROID_EPOCH=""
 KEEP_EPOCH=""
 if git -C "$ANDROID_REPO" rev-parse --git-dir >/dev/null 2>&1; then
     ANDROID_EPOCH=$(git -C "$ANDROID_REPO" log -1 --pretty=%ct 2>/dev/null || true)
+    if [ -z "$ANDROID_EPOCH" ]; then
+        echo "error: failed to read HEAD commit time from ANDROID_REPO='$ANDROID_REPO'." >&2
+        exit 1
+    fi
 fi
 if [ -d "$KEEP_REPO" ]; then
     if ! git -C "$KEEP_REPO" rev-parse --git-dir >/dev/null 2>&1; then

--- a/scripts/derive-sde.sh
+++ b/scripts/derive-sde.sh
@@ -47,17 +47,12 @@ for name in ANDROID_EPOCH KEEP_EPOCH; do
     fi
 done
 
-if [ -n "$ANDROID_EPOCH" ] && [ -n "$KEEP_EPOCH" ]; then
-    if [ "$ANDROID_EPOCH" -gt "$KEEP_EPOCH" ]; then
-        printf '%s\n' "$ANDROID_EPOCH"
-    else
-        printf '%s\n' "$KEEP_EPOCH"
-    fi
-elif [ -n "$ANDROID_EPOCH" ]; then
-    printf '%s\n' "$ANDROID_EPOCH"
-elif [ -n "$KEEP_EPOCH" ]; then
-    printf '%s\n' "$KEEP_EPOCH"
-else
+if [ -z "$ANDROID_EPOCH" ] && [ -z "$KEEP_EPOCH" ]; then
     echo "error: SOURCE_DATE_EPOCH unset and neither repo has git history to derive it." >&2
     exit 1
+fi
+if [ "${ANDROID_EPOCH:-0}" -gt "${KEEP_EPOCH:-0}" ]; then
+    printf '%s\n' "$ANDROID_EPOCH"
+else
+    printf '%s\n' "$KEEP_EPOCH"
 fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release APKs are now reproducible, enabling independent verification that binaries match the source.

* **Bug Fixes / Packaging**
  * Removed embedded Play dependency metadata and disabled legacy JNI packaging to produce cleaner, more deterministic artifacts.

* **Chores**
  * Build infrastructure tightened to enforce deterministic builds and fail fast when required environment settings are missing.

* **Documentation**
  * Added a reproducible builds guide with verification steps and required toolchain/environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->