### PR TITLE
Add automated reproducibility check workflow

### DIFF
--- a/.github/workflows/reproducibility.yml
+++ b/.github/workflows/reproducibility.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           SDE="$(ANDROID_REPO="$GITHUB_WORKSPACE" KEEP_REPO="$GITHUB_WORKSPACE/keep" \
             ./scripts/derive-sde.sh)"
+          [[ "$SDE" =~ ^[0-9]+$ ]] || { echo "invalid SOURCE_DATE_EPOCH: $SDE" >&2; exit 1; }
           echo "SOURCE_DATE_EPOCH=$SDE" >> "$GITHUB_ENV"
           echo "Using SOURCE_DATE_EPOCH=$SDE"
 
@@ -71,6 +72,7 @@ jobs:
         with:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
 
+      # Throwaway keystore for determinism verification only - never replace with real signing key.
       - name: Generate workflow-local release keystore
         run: |
           KEYSTORE_OUT="${{ runner.temp }}/repro.keystore"
@@ -83,14 +85,12 @@ jobs:
             -keyalg RSA -keysize 4096 -validity 36500 \
             -dname "CN=keep-reproducibility, O=CI, C=US"
           echo "KEYSTORE_FILE=$KEYSTORE_OUT" >> "$GITHUB_ENV"
-          echo "KEYSTORE_PASSWORD=reproducible" >> "$GITHUB_ENV"
           echo "KEY_ALIAS=repro" >> "$GITHUB_ENV"
-          echo "KEY_PASSWORD=reproducible" >> "$GITHUB_ENV"
 
       - name: Build APK (run 1)
         run: |
           ./gradlew clean --no-daemon
-          rm -rf app/src/main/jniLibs app/src/main/kotlin/io/privkey/keep/uniffi
+          rm -rf app/src/main/jniLibs app/src/main/kotlin/io/privkey/keep/uniffi keep/keep-mobile/target
           ./build-rust.sh
           ./gradlew assembleRelease --no-daemon
           mkdir -p "${{ runner.temp }}/apks"
@@ -100,11 +100,13 @@ jobs:
           ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/${{ env.NDK_VERSION }}
           AWS_LC_SYS_CMAKE_BUILDER: "1"
           SOURCE_DATE_EPOCH: ${{ env.SOURCE_DATE_EPOCH }}
+          KEYSTORE_PASSWORD: reproducible
+          KEY_PASSWORD: reproducible
 
       - name: Build APK (run 2)
         run: |
           ./gradlew clean --no-daemon
-          rm -rf app/src/main/jniLibs app/src/main/kotlin/io/privkey/keep/uniffi
+          rm -rf app/src/main/jniLibs app/src/main/kotlin/io/privkey/keep/uniffi keep/keep-mobile/target
           ./build-rust.sh
           ./gradlew assembleRelease --no-daemon
           cp app/build/outputs/apk/release/app-release.apk "${{ runner.temp }}/apks/build2.apk"
@@ -113,6 +115,8 @@ jobs:
           ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/${{ env.NDK_VERSION }}
           AWS_LC_SYS_CMAKE_BUILDER: "1"
           SOURCE_DATE_EPOCH: ${{ env.SOURCE_DATE_EPOCH }}
+          KEYSTORE_PASSWORD: reproducible
+          KEY_PASSWORD: reproducible
 
       - name: Compare APK checksums
         id: compare

--- a/.github/workflows/reproducibility.yml
+++ b/.github/workflows/reproducibility.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1'
+  push:
+    tags:
+      - "v*"
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 

--- a/.github/workflows/reproducibility.yml
+++ b/.github/workflows/reproducibility.yml
@@ -53,9 +53,6 @@ jobs:
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
 
       - name: Install Android NDK and build-tools
-        env:
-          NDK_VERSION: ${{ env.NDK_VERSION }}
-          BUILD_TOOLS_VERSION: ${{ env.BUILD_TOOLS_VERSION }}
         run: sdkmanager --install "ndk;$NDK_VERSION" "build-tools;$BUILD_TOOLS_VERSION"
 
       - name: Install Rust

--- a/.github/workflows/reproducibility.yml
+++ b/.github/workflows/reproducibility.yml
@@ -1,0 +1,147 @@
+name: Reproducibility
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+permissions: {}
+
+env:
+  ANDROID_HOME: /usr/local/lib/android/sdk
+  NDK_VERSION: "29.0.14206865"
+  CARGO_NDK_VERSION: "4.1.2"
+  RUST_VERSION: "1.89.0"
+  BUILD_TOOLS_VERSION: "36.0.0"
+
+jobs:
+  verify:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'reproducibility')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup keep checkout
+        uses: ./.github/actions/setup-keep
+
+      - name: Verify toolchain version pins are consistent
+        run: ./scripts/check-toolchain-pins.sh
+
+      - name: Derive SOURCE_DATE_EPOCH
+        run: |
+          SDE="$(ANDROID_REPO="$GITHUB_WORKSPACE" KEEP_REPO="$GITHUB_WORKSPACE/keep" \
+            ./scripts/derive-sde.sh)"
+          echo "SOURCE_DATE_EPOCH=$SDE" >> "$GITHUB_ENV"
+          echo "Using SOURCE_DATE_EPOCH=$SDE"
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
+
+      - name: Install Android NDK and build-tools
+        run: sdkmanager --install "ndk;${{ env.NDK_VERSION }}" "build-tools;${{ env.BUILD_TOOLS_VERSION }}"
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          targets: aarch64-linux-android,x86_64-linux-android
+
+      - name: Install cargo-ndk
+        uses: taiki-e/install-action@cf39a74df4a72510be4e5b63348d61067f11e64a # v2
+        with:
+          tool: cargo-ndk@${{ env.CARGO_NDK_VERSION }}
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+
+      - name: Generate workflow-local release keystore
+        run: |
+          KEYSTORE_OUT="${{ runner.temp }}/repro.keystore"
+          keytool -genkeypair -v \
+            -keystore "$KEYSTORE_OUT" \
+            -storetype PKCS12 \
+            -storepass reproducible \
+            -keypass reproducible \
+            -alias repro \
+            -keyalg RSA -keysize 4096 -validity 36500 \
+            -dname "CN=keep-reproducibility, O=CI, C=US"
+          echo "KEYSTORE_FILE=$KEYSTORE_OUT" >> "$GITHUB_ENV"
+          echo "KEYSTORE_PASSWORD=reproducible" >> "$GITHUB_ENV"
+          echo "KEY_ALIAS=repro" >> "$GITHUB_ENV"
+          echo "KEY_PASSWORD=reproducible" >> "$GITHUB_ENV"
+
+      - name: Build APK (run 1)
+        run: |
+          ./gradlew clean --no-daemon
+          rm -rf app/src/main/jniLibs app/src/main/kotlin/io/privkey/keep/uniffi
+          ./build-rust.sh
+          ./gradlew assembleRelease --no-daemon
+          mkdir -p "${{ runner.temp }}/apks"
+          cp app/build/outputs/apk/release/app-release*.apk "${{ runner.temp }}/apks/build1.apk"
+        env:
+          KEEP_REPO: ${{ github.workspace }}/keep
+          ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/${{ env.NDK_VERSION }}
+          AWS_LC_SYS_CMAKE_BUILDER: "1"
+          SOURCE_DATE_EPOCH: ${{ env.SOURCE_DATE_EPOCH }}
+
+      - name: Build APK (run 2)
+        run: |
+          ./gradlew clean --no-daemon
+          rm -rf app/src/main/jniLibs app/src/main/kotlin/io/privkey/keep/uniffi
+          ./build-rust.sh
+          ./gradlew assembleRelease --no-daemon
+          cp app/build/outputs/apk/release/app-release*.apk "${{ runner.temp }}/apks/build2.apk"
+        env:
+          KEEP_REPO: ${{ github.workspace }}/keep
+          ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/${{ env.NDK_VERSION }}
+          AWS_LC_SYS_CMAKE_BUILDER: "1"
+          SOURCE_DATE_EPOCH: ${{ env.SOURCE_DATE_EPOCH }}
+
+      - name: Compare APK checksums
+        id: compare
+        run: |
+          cd "${{ runner.temp }}/apks"
+          sha256sum build1.apk build2.apk | tee checksums.txt
+          H1=$(sha256sum build1.apk | awk '{print $1}')
+          H2=$(sha256sum build2.apk | awk '{print $1}')
+          if [ "$H1" != "$H2" ]; then
+            echo "mismatch=true" >> "$GITHUB_OUTPUT"
+            echo "::error::APK reproducibility check failed: $H1 != $H2"
+            exit 1
+          fi
+          echo "APKs are bit-for-bit identical: $H1"
+
+      - name: Install diffoscope
+        if: failure() && steps.compare.outputs.mismatch == 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends diffoscope
+
+      - name: Run diffoscope
+        if: failure() && steps.compare.outputs.mismatch == 'true'
+        run: |
+          cd "${{ runner.temp }}/apks"
+          diffoscope --html diffoscope.html --text diffoscope.txt build1.apk build2.apk || true
+
+      - name: Upload diffoscope report
+        if: failure() && steps.compare.outputs.mismatch == 'true'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: diffoscope-report
+          path: |
+            ${{ runner.temp }}/apks/diffoscope.html
+            ${{ runner.temp }}/apks/diffoscope.txt
+            ${{ runner.temp }}/apks/checksums.txt
+            ${{ runner.temp }}/apks/build1.apk
+            ${{ runner.temp }}/apks/build2.apk

--- a/.github/workflows/reproducibility.yml
+++ b/.github/workflows/reproducibility.yml
@@ -9,6 +9,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   ANDROID_HOME: /usr/local/lib/android/sdk
   NDK_VERSION: "29.0.14206865"
@@ -49,7 +53,10 @@ jobs:
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
 
       - name: Install Android NDK and build-tools
-        run: sdkmanager --install "ndk;${{ env.NDK_VERSION }}" "build-tools;${{ env.BUILD_TOOLS_VERSION }}"
+        env:
+          NDK_VERSION: ${{ env.NDK_VERSION }}
+          BUILD_TOOLS_VERSION: ${{ env.BUILD_TOOLS_VERSION }}
+        run: sdkmanager --install "ndk;$NDK_VERSION" "build-tools;$BUILD_TOOLS_VERSION"
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
@@ -64,6 +71,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
 
       - name: Generate workflow-local release keystore
         run: |
@@ -88,7 +97,7 @@ jobs:
           ./build-rust.sh
           ./gradlew assembleRelease --no-daemon
           mkdir -p "${{ runner.temp }}/apks"
-          cp app/build/outputs/apk/release/app-release*.apk "${{ runner.temp }}/apks/build1.apk"
+          cp app/build/outputs/apk/release/app-release.apk "${{ runner.temp }}/apks/build1.apk"
         env:
           KEEP_REPO: ${{ github.workspace }}/keep
           ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/${{ env.NDK_VERSION }}
@@ -101,7 +110,7 @@ jobs:
           rm -rf app/src/main/jniLibs app/src/main/kotlin/io/privkey/keep/uniffi
           ./build-rust.sh
           ./gradlew assembleRelease --no-daemon
-          cp app/build/outputs/apk/release/app-release*.apk "${{ runner.temp }}/apks/build2.apk"
+          cp app/build/outputs/apk/release/app-release.apk "${{ runner.temp }}/apks/build2.apk"
         env:
           KEEP_REPO: ${{ github.workspace }}/keep
           ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/${{ env.NDK_VERSION }}

--- a/docs/REPRODUCIBLE_BUILDS.md
+++ b/docs/REPRODUCIBLE_BUILDS.md
@@ -110,3 +110,27 @@ diffoscope /tmp/build1.apk /tmp/build2.apk
 
 None currently documented. If a verifier finds a diff, attach the
 `diffoscope` output to an issue.
+
+## Automated CI enforcement
+
+`.github/workflows/reproducibility.yml` guards against regressions by
+building `assembleRelease` twice on the same runner and comparing the
+output APKs with `sha256sum`. The workflow:
+
+- Runs on `workflow_dispatch`, a weekly `schedule` (Mondays 06:00 UTC),
+  and on pull requests carrying the `reproducibility` label. It is
+  deliberately excluded from the default PR path because running two
+  release builds is expensive.
+- Pins the same toolchain as `release.yml` (Rust, cargo-ndk, NDK,
+  build-tools, JDK 17 Temurin) and derives `SOURCE_DATE_EPOCH` via
+  `scripts/derive-sde.sh`.
+- Generates a workflow-local PKCS12 keystore with `keytool` and exports
+  `KEYSTORE_FILE` / `KEYSTORE_PASSWORD` / `KEY_ALIAS` / `KEY_PASSWORD`
+  so the release signing path is exercised without production secrets.
+  The same keystore is reused for both builds within the job.
+- Between the two builds it runs `./gradlew clean` and removes
+  `app/src/main/jniLibs` plus the generated `uniffi` Kotlin bindings,
+  then re-invokes `./build-rust.sh` and `./gradlew assembleRelease`.
+- On mismatch it installs `diffoscope`, generates HTML + text reports,
+  and uploads them along with both APKs as the `diffoscope-report`
+  workflow artifact. The job fails so the regression is visible.

--- a/docs/REPRODUCIBLE_BUILDS.md
+++ b/docs/REPRODUCIBLE_BUILDS.md
@@ -129,7 +129,8 @@ output APKs with `sha256sum`. The workflow:
   so the release signing path is exercised without production secrets.
   The same keystore is reused for both builds within the job.
 - Between the two builds it runs `./gradlew clean` and removes
-  `app/src/main/jniLibs` plus the generated `uniffi` Kotlin bindings,
+  `app/src/main/jniLibs`, the generated `uniffi` Kotlin bindings, and
+  `keep/keep-mobile/target` so run 2 exercises a cold Rust rebuild,
   then re-invokes `./build-rust.sh` and `./gradlew assembleRelease`.
 - On mismatch it installs `diffoscope`, generates HTML + text reports,
   and uploads them along with both APKs as the `diffoscope-report`

--- a/docs/REPRODUCIBLE_BUILDS.md
+++ b/docs/REPRODUCIBLE_BUILDS.md
@@ -118,9 +118,9 @@ building `assembleRelease` twice on the same runner and comparing the
 output APKs with `sha256sum`. The workflow:
 
 - Runs on `workflow_dispatch`, a weekly `schedule` (Mondays 06:00 UTC),
-  and on pull requests carrying the `reproducibility` label. It is
-  deliberately excluded from the default PR path because running two
-  release builds is expensive.
+  on `v*` tag pushes so every release is verified, and on pull requests
+  carrying the `reproducibility` label. It is deliberately excluded from
+  the default PR path because running two release builds is expensive.
 - Pins the same toolchain as `release.yml` (Rust, cargo-ndk, NDK,
   build-tools, JDK 17 Temurin) and derives `SOURCE_DATE_EPOCH` via
   `scripts/derive-sde.sh`.

--- a/scripts/check-toolchain-pins.sh
+++ b/scripts/check-toolchain-pins.sh
@@ -31,10 +31,11 @@ extract() {
 BUILD_RUST="$ROOT/build-rust.sh"
 CI_YML="$ROOT/.github/workflows/ci.yml"
 RELEASE_YML="$ROOT/.github/workflows/release.yml"
+REPRO_YML="$ROOT/.github/workflows/reproducibility.yml"
 GRADLE_KTS="$ROOT/build.gradle.kts"
 TOOLCHAIN_TOML="$ROOT/keep/rust-toolchain.toml"
 
-for f in "$BUILD_RUST" "$CI_YML" "$RELEASE_YML" "$GRADLE_KTS"; do
+for f in "$BUILD_RUST" "$CI_YML" "$RELEASE_YML" "$REPRO_YML" "$GRADLE_KTS"; do
     [ -f "$f" ] || fail "missing file: $f"
 done
 
@@ -48,6 +49,12 @@ CI_CARGO_NDK=$(extract "$CI_YML" '^[[:space:]]+CARGO_NDK_VERSION: "([0-9]+\.[0-9
 REL_RUST=$(extract "$RELEASE_YML" '^[[:space:]]+RUST_VERSION: "([0-9]+\.[0-9]+\.[0-9]+)"')
 REL_NDK=$(extract "$RELEASE_YML" '^[[:space:]]+NDK_VERSION: "([0-9.]+)"')
 REL_CARGO_NDK=$(extract "$RELEASE_YML" '^[[:space:]]+CARGO_NDK_VERSION: "([0-9]+\.[0-9]+\.[0-9]+)"')
+REL_BUILD_TOOLS=$(extract "$RELEASE_YML" '^[[:space:]]+BUILD_TOOLS_VERSION: "([0-9.]+)"')
+
+REPRO_RUST=$(extract "$REPRO_YML" '^[[:space:]]+RUST_VERSION: "([0-9]+\.[0-9]+\.[0-9]+)"')
+REPRO_NDK=$(extract "$REPRO_YML" '^[[:space:]]+NDK_VERSION: "([0-9.]+)"')
+REPRO_CARGO_NDK=$(extract "$REPRO_YML" '^[[:space:]]+CARGO_NDK_VERSION: "([0-9]+\.[0-9]+\.[0-9]+)"')
+REPRO_BUILD_TOOLS=$(extract "$REPRO_YML" '^[[:space:]]+BUILD_TOOLS_VERSION: "([0-9.]+)"')
 
 GRADLE_NDK=$(extract "$GRADLE_KTS" 'expectedNdkVersion = "([0-9.]+)"')
 GRADLE_JDK=$(extract "$GRADLE_KTS" 'expectedJavaMajor = ([0-9]+)')
@@ -65,6 +72,7 @@ extract_unique() {
 
 CI_JDK=$(extract_unique "$CI_YML" "^[[:space:]]+java-version: '([0-9]+)'")
 REL_JDK=$(extract_unique "$RELEASE_YML" "^[[:space:]]+java-version: '([0-9]+)'")
+REPRO_JDK=$(extract_unique "$REPRO_YML" "^[[:space:]]+java-version: '([0-9]+)'")
 
 check_equal() {
     local name="$1"
@@ -79,10 +87,11 @@ check_equal() {
     echo "ok: $name = $first"
 }
 
-check_equal "rust version"        "$BR_RUST"       "$CI_RUST"       "$REL_RUST"
-check_equal "cargo-ndk version"   "$BR_CARGO_NDK"  "$CI_CARGO_NDK"  "$REL_CARGO_NDK"
-check_equal "ndk version"         "$CI_NDK"        "$REL_NDK"       "$GRADLE_NDK"
-check_equal "jdk major version"   "$GRADLE_JDK"    "$CI_JDK"        "$REL_JDK"
+check_equal "rust version"        "$BR_RUST"       "$CI_RUST"       "$REL_RUST"       "$REPRO_RUST"
+check_equal "cargo-ndk version"   "$BR_CARGO_NDK"  "$CI_CARGO_NDK"  "$REL_CARGO_NDK"  "$REPRO_CARGO_NDK"
+check_equal "ndk version"         "$CI_NDK"        "$REL_NDK"       "$GRADLE_NDK"     "$REPRO_NDK"
+check_equal "jdk major version"   "$GRADLE_JDK"    "$CI_JDK"        "$REL_JDK"        "$REPRO_JDK"
+check_equal "build-tools version" "$REL_BUILD_TOOLS" "$REPRO_BUILD_TOOLS"
 
 if [ -f "$TOOLCHAIN_TOML" ]; then
     TOML_CHANNEL=$(sed -nE 's/^channel *= *"([^"]+)".*/\1/p' "$TOOLCHAIN_TOML" | head -1)

--- a/scripts/check-toolchain-pins.sh
+++ b/scripts/check-toolchain-pins.sh
@@ -48,7 +48,7 @@ BR_RUST=$(extract "$BUILD_RUST" 'EXPECTED_RUST="([0-9]+\.[0-9]+\.[0-9]+)"')
 BR_CARGO_NDK=$(extract "$BUILD_RUST" 'CARGO_NDK_VERSION="([0-9]+\.[0-9]+\.[0-9]+)"')
 
 SEMVER='[0-9]+\.[0-9]+\.[0-9]+'
-NDK_VER='[0-9.]+'
+NDK_VER='[0-9]+(\.[0-9]+)*'
 
 CI_RUST=$(yaml_env "$CI_YML" RUST_VERSION "$SEMVER")
 CI_NDK=$(yaml_env "$CI_YML" NDK_VERSION "$NDK_VER")

--- a/scripts/check-toolchain-pins.sh
+++ b/scripts/check-toolchain-pins.sh
@@ -39,22 +39,30 @@ for f in "$BUILD_RUST" "$CI_YML" "$RELEASE_YML" "$REPRO_YML" "$GRADLE_KTS"; do
     [ -f "$f" ] || fail "missing file: $f"
 done
 
+yaml_env() {
+    # yaml_env <file> <KEY> <value-regex>
+    extract "$1" "^[[:space:]]+$2: \"($3)\""
+}
+
 BR_RUST=$(extract "$BUILD_RUST" 'EXPECTED_RUST="([0-9]+\.[0-9]+\.[0-9]+)"')
 BR_CARGO_NDK=$(extract "$BUILD_RUST" 'CARGO_NDK_VERSION="([0-9]+\.[0-9]+\.[0-9]+)"')
 
-CI_RUST=$(extract "$CI_YML" '^[[:space:]]+RUST_VERSION: "([0-9]+\.[0-9]+\.[0-9]+)"')
-CI_NDK=$(extract "$CI_YML" '^[[:space:]]+NDK_VERSION: "([0-9.]+)"')
-CI_CARGO_NDK=$(extract "$CI_YML" '^[[:space:]]+CARGO_NDK_VERSION: "([0-9]+\.[0-9]+\.[0-9]+)"')
+SEMVER='[0-9]+\.[0-9]+\.[0-9]+'
+NDK_VER='[0-9.]+'
 
-REL_RUST=$(extract "$RELEASE_YML" '^[[:space:]]+RUST_VERSION: "([0-9]+\.[0-9]+\.[0-9]+)"')
-REL_NDK=$(extract "$RELEASE_YML" '^[[:space:]]+NDK_VERSION: "([0-9.]+)"')
-REL_CARGO_NDK=$(extract "$RELEASE_YML" '^[[:space:]]+CARGO_NDK_VERSION: "([0-9]+\.[0-9]+\.[0-9]+)"')
-REL_BUILD_TOOLS=$(extract "$RELEASE_YML" '^[[:space:]]+BUILD_TOOLS_VERSION: "([0-9.]+)"')
+CI_RUST=$(yaml_env "$CI_YML" RUST_VERSION "$SEMVER")
+CI_NDK=$(yaml_env "$CI_YML" NDK_VERSION "$NDK_VER")
+CI_CARGO_NDK=$(yaml_env "$CI_YML" CARGO_NDK_VERSION "$SEMVER")
 
-REPRO_RUST=$(extract "$REPRO_YML" '^[[:space:]]+RUST_VERSION: "([0-9]+\.[0-9]+\.[0-9]+)"')
-REPRO_NDK=$(extract "$REPRO_YML" '^[[:space:]]+NDK_VERSION: "([0-9.]+)"')
-REPRO_CARGO_NDK=$(extract "$REPRO_YML" '^[[:space:]]+CARGO_NDK_VERSION: "([0-9]+\.[0-9]+\.[0-9]+)"')
-REPRO_BUILD_TOOLS=$(extract "$REPRO_YML" '^[[:space:]]+BUILD_TOOLS_VERSION: "([0-9.]+)"')
+REL_RUST=$(yaml_env "$RELEASE_YML" RUST_VERSION "$SEMVER")
+REL_NDK=$(yaml_env "$RELEASE_YML" NDK_VERSION "$NDK_VER")
+REL_CARGO_NDK=$(yaml_env "$RELEASE_YML" CARGO_NDK_VERSION "$SEMVER")
+REL_BUILD_TOOLS=$(yaml_env "$RELEASE_YML" BUILD_TOOLS_VERSION "$NDK_VER")
+
+REPRO_RUST=$(yaml_env "$REPRO_YML" RUST_VERSION "$SEMVER")
+REPRO_NDK=$(yaml_env "$REPRO_YML" NDK_VERSION "$NDK_VER")
+REPRO_CARGO_NDK=$(yaml_env "$REPRO_YML" CARGO_NDK_VERSION "$SEMVER")
+REPRO_BUILD_TOOLS=$(yaml_env "$REPRO_YML" BUILD_TOOLS_VERSION "$NDK_VER")
 
 GRADLE_NDK=$(extract "$GRADLE_KTS" 'expectedNdkVersion = "([0-9.]+)"')
 GRADLE_JDK=$(extract "$GRADLE_KTS" 'expectedJavaMajor = ([0-9]+)')


### PR DESCRIPTION
Adds a CI workflow that builds the release APK twice and verifies bit-for-bit reproducibility. Extends toolchain pin consistency check to cover the new workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated reproducibility verification workflow that builds the release APK twice, compares checksums, and uploads diff reports on mismatch.

* **Documentation**
  * Documented the CI reproducible-build enforcement process, triggers, deterministic-build steps, and artifact/report handling.

* **Chores**
  * Expanded toolchain/version pin validation to include the new reproducibility workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->