### PR TITLE
Add reproducible build recipe with pinned, verified toolchain

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Keep build context lean and reproducible. Notably:
+#   - exclude any sibling ./keep clone (Dockerfile.reproducible always clones
+#     keep at the pinned SHA itself).
+#   - exclude host-built artifacts so they cannot leak into the container.
+# .git/ is intentionally NOT excluded — scripts/derive-sde.sh needs it.
+
+keep/
+
+app/build/
+build/
+.gradle/
+
+app/src/main/jniLibs/
+app/src/main/kotlin/io/privkey/keep/uniffi/
+
+local.properties
+*.keystore
+*.jks
+
+.idea/
+*.iml
+out/

--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -50,8 +50,12 @@ ARG KEY_ALIAS
 ARG KEY_PASSWORD
 
 # Pinned toolchain versions. Cross-validated by scripts/check-toolchain-pins.sh.
+# JDK_MAJOR must match the major of JDK_VERSION (first dot-component). It is
+# split out because ENV/install paths should stay stable across patch bumps of
+# JDK_VERSION (e.g. 17.0.13+11 -> 17.0.14+5 requires no path change).
 ARG DEBIAN_SNAPSHOT=20250601T000000Z
 ARG JDK_VERSION=17.0.13+11
+ARG JDK_MAJOR=17
 ARG ANDROID_CMDLINE_TOOLS_VERSION=11076708
 ARG ANDROID_BUILD_TOOLS_VERSION=36.0.0
 ARG ANDROID_PLATFORM=android-36
@@ -67,10 +71,10 @@ ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-} \
     ANDROID_HOME=/opt/android-sdk \
     ANDROID_SDK_ROOT=/opt/android-sdk \
     ANDROID_NDK_HOME=/opt/android-sdk/ndk/${ANDROID_NDK_VERSION} \
-    JAVA_HOME=/opt/jdk-17 \
+    JAVA_HOME=/opt/jdk-${JDK_MAJOR} \
     CARGO_HOME=/opt/cargo \
     RUSTUP_HOME=/opt/rustup \
-    PATH=/opt/cargo/bin:/opt/jdk-17/bin:/opt/android-sdk/cmdline-tools/latest/bin:/opt/android-sdk/platform-tools:/opt/android-sdk/build-tools/${ANDROID_BUILD_TOOLS_VERSION}:${PATH}
+    PATH=/opt/cargo/bin:/opt/jdk-${JDK_MAJOR}/bin:/opt/android-sdk/cmdline-tools/latest/bin:/opt/android-sdk/platform-tools:/opt/android-sdk/build-tools/${ANDROID_BUILD_TOOLS_VERSION}:${PATH}
 
 # SHA-256 checksums for bootstrap downloads. Updating any version above also
 # requires refreshing the matching hash here. Sources:
@@ -125,19 +129,23 @@ RUN printf 'deb [check-valid-until=no] https://snapshot.debian.org/archive/debia
         file \
     && rm -rf /var/lib/apt/lists/*
 
-# Temurin JDK 17. Pinned by version and SHA-256 (per arch).
-RUN mkdir -p /opt/jdk-17 \
+# Temurin JDK. Pinned by version and SHA-256 (per arch). The Adoptium archive
+# filename encodes the version with '+' replaced by '_', so compute that form
+# with POSIX tr instead of a bash-only ${var/+/_} expansion (Dockerfile RUN
+# runs under /bin/sh, which on Debian is dash and rejects bash substitutions).
+RUN mkdir -p "/opt/jdk-${JDK_MAJOR}" \
     && ARCH="$(uname -m)" \
     && case "$ARCH" in \
          x86_64)  JDK_ARCH=x64;     JDK_SHA256="${JDK_X64_SHA256}"     ;; \
          aarch64) JDK_ARCH=aarch64; JDK_SHA256="${JDK_AARCH64_SHA256}" ;; \
          *) echo "unsupported arch: $ARCH" >&2; exit 1 ;; \
        esac \
+    && JDK_VERSION_FILE="$(echo "${JDK_VERSION}" | tr '+' '_')" \
     && curl --proto '=https' --tlsv1.2 -fsSL \
-        "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-${JDK_VERSION}/OpenJDK17U-jdk_${JDK_ARCH}_linux_hotspot_${JDK_VERSION/+/_}.tar.gz" \
+        "https://github.com/adoptium/temurin${JDK_MAJOR}-binaries/releases/download/jdk-${JDK_VERSION}/OpenJDK${JDK_MAJOR}U-jdk_${JDK_ARCH}_linux_hotspot_${JDK_VERSION_FILE}.tar.gz" \
         -o /tmp/jdk.tar.gz \
     && echo "${JDK_SHA256}  /tmp/jdk.tar.gz" | sha256sum -c - \
-    && tar -xzf /tmp/jdk.tar.gz -C /opt/jdk-17 --strip-components=1 \
+    && tar -xzf /tmp/jdk.tar.gz -C "/opt/jdk-${JDK_MAJOR}" --strip-components=1 \
     && rm /tmp/jdk.tar.gz \
     && java -version
 
@@ -216,7 +224,7 @@ RUN ARCH="$(uname -m)" \
 # malicious cargo/Gradle dependency cannot tamper with the toolchain layers.
 RUN useradd --create-home --uid 1000 --shell /bin/bash builder \
     && mkdir -p /build /out \
-    && chown -R builder:builder /opt/jdk-17 /opt/android-sdk /opt/cargo /opt/rustup /build /out
+    && chown -R builder:builder "/opt/jdk-${JDK_MAJOR}" /opt/android-sdk /opt/cargo /opt/rustup /build /out
 USER builder
 
 WORKDIR /build
@@ -311,7 +319,13 @@ RUN set -eux; \
     ./gradlew assembleRelease --no-daemon; \
     mkdir -p /out; \
     cp app/build/outputs/apk/release/app-release.apk /out/app-release.apk; \
-    sha256sum /out/app-release.apk
+    echo "SHA256 of signed APK (depends on signing key; differs per build when"; \
+    echo "using the throwaway keystore, since the RSA key is regenerated):"; \
+    sha256sum /out/app-release.apk; \
+    echo ""; \
+    echo "For reproducibility verification, compare APKs with diffoscope"; \
+    echo "(see REPRODUCIBLE_BUILDS.md § 5.2). A matching signed-APK sha256 is"; \
+    echo "only expected when the same KEYSTORE_FILE/PASSWORD/ALIAS is reused."
 
 # Export stage: extract just the APK using BuildKit's local output.
 #   docker build --output type=local,dest=out -f Dockerfile.reproducible .

--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -34,6 +34,7 @@ FROM --platform=linux/amd64 debian@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0
 ARG DEBIAN_FRONTEND=noninteractive
 ARG SOURCE_DATE_EPOCH
 ARG KEEP_SHA
+ARG KEEP_REMOTE=https://github.com/privkeyio/keep.git
 
 # Optional keystore overrides. When KEYSTORE_FILE points at an existing file
 # inside the build context (e.g. a path copied in, or `/run/secrets/...`
@@ -86,6 +87,10 @@ ARG RUSTUP_INIT_X64_SHA256=20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c0
 ARG RUSTUP_INIT_AARCH64_SHA256=e3853c5a252fca15252d07cb23a1bdd9377a8c6f3efa01531109281ae47f841c
 ARG ANDROID_NDK_URL_BASENAME=android-ndk-r29-linux.zip
 ARG ANDROID_NDK_SHA256=4abbbcdc842f3d4879206e9695d52709603e52dd68d3c1fff04b3b5e7a308ecf
+# cargo-ndk published .crate tarball from static.crates.io. Refresh this when
+# bumping CARGO_NDK_VERSION by running:
+#   curl -fsSL https://static.crates.io/crates/cargo-ndk/cargo-ndk-<ver>.crate | sha256sum
+ARG CARGO_NDK_SHA256=903cc87cda6ab7a2ff82a74065e1c2ae5baa869546b32eb4aacabcc6ed5a670f
 
 # System packages required to bootstrap the SDK and Rust builds.
 #
@@ -195,7 +200,14 @@ RUN ARCH="$(uname -m)" \
         --no-modify-path \
     && rm /tmp/rustup-init \
     && rustup target add aarch64-linux-android x86_64-linux-android \
-    && cargo install --locked cargo-ndk --version "${CARGO_NDK_VERSION}" \
+    && curl --proto '=https' --tlsv1.2 -fsSL \
+        "https://static.crates.io/crates/cargo-ndk/cargo-ndk-${CARGO_NDK_VERSION}.crate" \
+        -o /tmp/cargo-ndk.crate \
+    && echo "${CARGO_NDK_SHA256}  /tmp/cargo-ndk.crate" | sha256sum -c - \
+    && mkdir -p /tmp/cargo-ndk-src \
+    && tar -xzf /tmp/cargo-ndk.crate -C /tmp/cargo-ndk-src --strip-components=1 \
+    && cargo install --locked --path /tmp/cargo-ndk-src \
+    && rm -rf /tmp/cargo-ndk.crate /tmp/cargo-ndk-src \
     && rustc --version \
     && cargo ndk --version
 
@@ -219,13 +231,23 @@ COPY --chown=builder:builder . /build/keep-android
 # does NOT verify who authored that commit. Reproducers should verify the
 # keep-android release tag's GPG/SSH signature out of band (see
 # REPRODUCIBLE_BUILDS.md § 2).
+#
+# The symlink below (/build/keep-android/keep -> /build/keep) exists because
+# several tools fall back to "${rootDir}/keep" or "$ANDROID_REPO/keep" when
+# KEEP_REPO is not set in their process env: derive-sde.sh (invoked below
+# before KEEP_REPO is exported) and build.gradle.kts' verifyKeepVersion in
+# code paths that read keep/rust-toolchain.toml or resolve the Gradle
+# default. KEEP_REPO=/build/keep is still set as the authoritative value for
+# build-rust.sh and the Gradle assembleRelease invocation.
 RUN if [ -z "$KEEP_SHA" ]; then \
         KEEP_SHA="$(tr -d '[:space:]' < /build/keep-android/keep.version)"; \
     fi \
     && echo "$KEEP_SHA" | grep -Eq '^[0-9a-f]{40}$' \
         || { echo "KEEP_SHA must be a 40-char lowercase hex SHA, got: '$KEEP_SHA'" >&2; exit 1; } \
-    && echo "Pinned keep SHA: $KEEP_SHA" \
-    && git clone https://github.com/privkeyio/keep.git /build/keep \
+    && echo "${KEEP_REMOTE}" | grep -Eq '^https?://' \
+        || { echo "KEEP_REMOTE must be an http(s) URL, got: '${KEEP_REMOTE}'" >&2; exit 1; } \
+    && echo "Pinned keep SHA: $KEEP_SHA (from ${KEEP_REMOTE})" \
+    && git clone "${KEEP_REMOTE}" /build/keep \
     && git -C /build/keep checkout "$KEEP_SHA" \
     && actual="$(git -C /build/keep rev-parse HEAD)" \
     && [ "$actual" = "$KEEP_SHA" ] || { echo "keep checkout drift: $actual != $KEEP_SHA" >&2; exit 1; } \

--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -1,0 +1,213 @@
+# SPDX-FileCopyrightText: © 2026 PrivKey LLC
+# SPDX-License-Identifier: MIT
+#
+# Reproducible Android build container for keep-android.
+#
+# Usage (see REPRODUCIBLE_BUILDS.md for the full recipe):
+#
+#   export KEEP_SHA="$(tr -d '[:space:]' < keep.version)"
+#   export SOURCE_DATE_EPOCH="$(./scripts/derive-sde.sh)"
+#   DOCKER_BUILDKIT=1 docker build \
+#       --build-arg KEEP_SHA="$KEEP_SHA" \
+#       --build-arg SOURCE_DATE_EPOCH="$SOURCE_DATE_EPOCH" \
+#       --output type=local,dest=out \
+#       -f Dockerfile.reproducible .
+#
+# Output: ./out/app-release.apk  (unsigned; sign with your own key or compare
+# against the published APK with diffoscope — the payload is reproducible,
+# only the signing block necessarily differs).
+
+# Pinned base: Debian 12 (bookworm), slim variant. Digest pin keeps the base
+# layer byte-identical across rebuilds. Refresh the digest when upgrading via
+# `docker pull debian:bookworm-slim && docker inspect --format='{{index .RepoDigests 0}}' debian:bookworm-slim`.
+FROM debian@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d AS builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG SOURCE_DATE_EPOCH
+ARG KEEP_SHA
+
+ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-0} \
+    LC_ALL=C \
+    TZ=UTC \
+    LANG=C.UTF-8 \
+    ANDROID_HOME=/opt/android-sdk \
+    ANDROID_SDK_ROOT=/opt/android-sdk \
+    ANDROID_NDK_HOME=/opt/android-sdk/ndk/29.0.14206865 \
+    JAVA_HOME=/opt/jdk-17 \
+    CARGO_HOME=/opt/cargo \
+    RUSTUP_HOME=/opt/rustup \
+    PATH=/opt/cargo/bin:/opt/jdk-17/bin:/opt/android-sdk/cmdline-tools/latest/bin:/opt/android-sdk/platform-tools:/opt/android-sdk/build-tools/36.0.0:${PATH}
+
+# Pinned toolchain versions. Cross-validated by scripts/check-toolchain-pins.sh.
+ARG JDK_VERSION=17.0.13+11
+ARG ANDROID_CMDLINE_TOOLS_VERSION=11076708
+ARG ANDROID_BUILD_TOOLS_VERSION=36.0.0
+ARG ANDROID_PLATFORM=android-36
+ARG ANDROID_NDK_VERSION=29.0.14206865
+ARG RUST_VERSION=1.89.0
+ARG RUSTUP_VERSION=1.28.2
+ARG CARGO_NDK_VERSION=4.1.2
+
+# SHA-256 checksums for bootstrap downloads. Updating any version above also
+# requires refreshing the matching hash here. Sources:
+#   JDK: Adoptium publishes .sha256.txt alongside each release artifact.
+#   cmdline-tools: sha256sum of the dl.google.com archive.
+#   rustup-init: https://static.rust-lang.org/rustup/archive/<ver>/<target>/rustup-init.sha256
+ARG JDK_X64_SHA256=8682892fc02965930b9022c066fa164dd6f458ef4a5dc262016aa28333b30f49
+ARG JDK_AARCH64_SHA256=0c17fa4f14c0d2cc9e9334f996fccdddc5da4459d768f3105c7ff0283c47bf62
+ARG ANDROID_CMDLINE_TOOLS_SHA256=2d2d50857e4eb553af5a6dc3ad507a17adf43d115264b1afc116f95c92e5e258
+ARG RUSTUP_INIT_X64_SHA256=20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c
+ARG RUSTUP_INIT_AARCH64_SHA256=e3853c5a252fca15252d07cb23a1bdd9377a8c6f3efa01531109281ae47f841c
+
+# System packages required to bootstrap the SDK and Rust builds.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        unzip \
+        zip \
+        git \
+        bash \
+        coreutils \
+        tar \
+        xz-utils \
+        pkg-config \
+        cmake \
+        make \
+        gcc \
+        g++ \
+        libc6-dev \
+        file \
+    && rm -rf /var/lib/apt/lists/*
+
+# Temurin JDK 17. Pinned by version and SHA-256 (per arch).
+RUN mkdir -p /opt/jdk-17 \
+    && ARCH="$(uname -m)" \
+    && case "$ARCH" in \
+         x86_64)  JDK_ARCH=x64;     JDK_SHA256="${JDK_X64_SHA256}"     ;; \
+         aarch64) JDK_ARCH=aarch64; JDK_SHA256="${JDK_AARCH64_SHA256}" ;; \
+         *) echo "unsupported arch: $ARCH" >&2; exit 1 ;; \
+       esac \
+    && curl --proto '=https' --tlsv1.2 -fsSL \
+        "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-${JDK_VERSION}/OpenJDK17U-jdk_${JDK_ARCH}_linux_hotspot_${JDK_VERSION/+/_}.tar.gz" \
+        -o /tmp/jdk.tar.gz \
+    && echo "${JDK_SHA256}  /tmp/jdk.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/jdk.tar.gz -C /opt/jdk-17 --strip-components=1 \
+    && rm /tmp/jdk.tar.gz \
+    && java -version
+
+# Android cmdline-tools + platform-tools + build-tools + platform + NDK (all pinned).
+RUN mkdir -p "${ANDROID_HOME}/cmdline-tools" \
+    && curl --proto '=https' --tlsv1.2 -fsSL \
+        "https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_CMDLINE_TOOLS_VERSION}_latest.zip" \
+        -o /tmp/cmdline-tools.zip \
+    && echo "${ANDROID_CMDLINE_TOOLS_SHA256}  /tmp/cmdline-tools.zip" | sha256sum -c - \
+    && unzip -q /tmp/cmdline-tools.zip -d "${ANDROID_HOME}/cmdline-tools" \
+    && mv "${ANDROID_HOME}/cmdline-tools/cmdline-tools" "${ANDROID_HOME}/cmdline-tools/latest" \
+    && rm /tmp/cmdline-tools.zip \
+    && yes | sdkmanager --licenses >/dev/null \
+    && sdkmanager --install \
+        "platform-tools" \
+        "platforms;${ANDROID_PLATFORM}" \
+        "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" \
+        "ndk;${ANDROID_NDK_VERSION}"
+
+# Rust + Android targets + cargo-ndk (all pinned, --locked). rustup-init is
+# fetched as a pinned binary (by version and SHA-256), not via `curl | sh`, so
+# a compromise of sh.rustup.rs cannot inject a backdoored bootstrap.
+RUN ARCH="$(uname -m)" \
+    && case "$ARCH" in \
+         x86_64)  RUSTUP_TARGET=x86_64-unknown-linux-gnu;  RUSTUP_SHA256="${RUSTUP_INIT_X64_SHA256}"     ;; \
+         aarch64) RUSTUP_TARGET=aarch64-unknown-linux-gnu; RUSTUP_SHA256="${RUSTUP_INIT_AARCH64_SHA256}" ;; \
+         *) echo "unsupported arch: $ARCH" >&2; exit 1 ;; \
+       esac \
+    && curl --proto '=https' --tlsv1.2 -fsSL \
+        "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUSTUP_TARGET}/rustup-init" \
+        -o /tmp/rustup-init \
+    && echo "${RUSTUP_SHA256}  /tmp/rustup-init" | sha256sum -c - \
+    && chmod +x /tmp/rustup-init \
+    && /tmp/rustup-init -y \
+        --default-toolchain "${RUST_VERSION}" \
+        --profile minimal \
+        --no-modify-path \
+    && rm /tmp/rustup-init \
+    && rustup target add aarch64-linux-android x86_64-linux-android \
+    && cargo install --locked cargo-ndk --version "${CARGO_NDK_VERSION}" \
+    && rustc --version \
+    && cargo ndk --version
+
+# Drop privileges. All build steps from here run as a non-root user so that a
+# malicious cargo/Gradle dependency cannot tamper with the toolchain layers.
+RUN useradd --create-home --uid 1000 --shell /bin/bash builder \
+    && mkdir -p /build /out \
+    && chown -R builder:builder /opt/jdk-17 /opt/android-sdk /opt/cargo /opt/rustup /build /out
+USER builder
+
+WORKDIR /build
+
+# Bring the keep-android sources in. The host caller is responsible for
+# running this Dockerfile from a clean keep-android checkout at the release
+# tag. The shipped `.dockerignore` excludes a sibling ./keep and build
+# outputs so we always clone keep at the pinned SHA below.
+COPY --chown=builder:builder . /build/keep-android
+
+# Clone keep at the pinned SHA and verify.
+# Trust note: pinning by SHA defeats post-hoc tampering of the `keep` repo but
+# does NOT verify who authored that commit. Reproducers should verify the
+# keep-android release tag's GPG/SSH signature out of band (see
+# REPRODUCIBLE_BUILDS.md § 2).
+RUN if [ -z "$KEEP_SHA" ]; then \
+        KEEP_SHA="$(tr -d '[:space:]' < /build/keep-android/keep.version)"; \
+    fi \
+    && echo "$KEEP_SHA" | grep -Eq '^[0-9a-f]{40}$' \
+        || { echo "KEEP_SHA must be a 40-char lowercase hex SHA, got: '$KEEP_SHA'" >&2; exit 1; } \
+    && echo "Pinned keep SHA: $KEEP_SHA" \
+    && git clone https://github.com/privkeyio/keep.git /build/keep \
+    && git -C /build/keep checkout "$KEEP_SHA" \
+    && actual="$(git -C /build/keep rev-parse HEAD)" \
+    && [ "$actual" = "$KEEP_SHA" ] || { echo "keep checkout drift: $actual != $KEEP_SHA" >&2; exit 1; } \
+    && rm -rf /build/keep-android/keep \
+    && ln -s /build/keep /build/keep-android/keep
+
+# Build. SOURCE_DATE_EPOCH is passed through to both the Rust build (via
+# build-rust.sh) and Gradle's packaging/signing.
+WORKDIR /build/keep-android
+RUN set -eux; \
+    if [ -z "${SOURCE_DATE_EPOCH}" ] || [ "${SOURCE_DATE_EPOCH}" = "0" ]; then \
+        export SOURCE_DATE_EPOCH="$(./scripts/derive-sde.sh)"; \
+    fi; \
+    echo "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH"; \
+    export KEEP_REPO=/build/keep; \
+    export AWS_LC_SYS_CMAKE_BUILDER=1; \
+    ./scripts/check-toolchain-pins.sh; \
+    ./build-rust.sh; \
+    # ========================================================================
+    # THROWAWAY KEYSTORE — DO NOT SHIP APKS SIGNED WITH THIS KEY.
+    # ------------------------------------------------------------------------
+    # Generated per build for local reproducibility verification only. The
+    # resulting APK's payload is reproducible; only the signing block varies.
+    # Android installs are pinned to signing identity — accidentally shipping
+    # an APK signed with this publicly-known key means anyone can sign updates
+    # for your app. To match the official release bytes, mount a real keystore
+    # via --secret and pass KEYSTORE_FILE/PASSWORD/KEY_ALIAS/KEY_PASSWORD.
+    # ========================================================================
+    keytool -genkeypair -v \
+        -keystore /tmp/throwaway.keystore \
+        -storetype PKCS12 \
+        -storepass THROWAWAY_DO_NOT_SHIP \
+        -keypass THROWAWAY_DO_NOT_SHIP \
+        -alias THROWAWAY-DO-NOT-SHIP \
+        -keyalg RSA -keysize 4096 -validity 36500 \
+        -dname "CN=keep-reproducibility-THROWAWAY-DO-NOT-SHIP, O=local, C=US"; \
+    KEYSTORE_FILE=/tmp/throwaway.keystore \
+    KEYSTORE_PASSWORD=THROWAWAY_DO_NOT_SHIP \
+    KEY_ALIAS=THROWAWAY-DO-NOT-SHIP \
+    KEY_PASSWORD=THROWAWAY_DO_NOT_SHIP \
+    ./gradlew assembleRelease --no-daemon; \
+    mkdir -p /out; \
+    cp app/build/outputs/apk/release/app-release.apk /out/app-release.apk; \
+    sha256sum /out/app-release.apk
+
+# Export stage: extract just the APK using BuildKit's local output.
+#   docker build --output type=local,dest=out -f Dockerfile.reproducible .
+FROM scratch AS export
+COPY --from=builder /out/app-release.apk /app-release.apk

--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -20,7 +20,16 @@
 # Pinned base: Debian 12 (bookworm), slim variant. Digest pin keeps the base
 # layer byte-identical across rebuilds. Refresh the digest when upgrading via
 # `docker pull debian:bookworm-slim && docker inspect --format='{{index .RepoDigests 0}}' debian:bookworm-slim`.
-FROM debian@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d AS builder
+#
+# Build host: linux/amd64 is the canonical reproducibility platform. The
+# digest above is a multi-arch manifest index, but AWS_LC_SYS_CMAKE_BUILDER=1
+# compiles native aws-lc artifacts with the host gcc/cmake, so a different
+# host architecture would produce non-identical .so bytes even with matching
+# toolchain versions. `--platform=linux/amd64` pins the resolved image to
+# amd64 regardless of the host (BuildKit will emulate via QEMU on other
+# hosts). The aarch64 branches below remain for future platform expansion
+# but are currently unreachable under this pin.
+FROM --platform=linux/amd64 debian@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG SOURCE_DATE_EPOCH
@@ -67,11 +76,16 @@ ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-0} \
 #   JDK: Adoptium publishes .sha256.txt alongside each release artifact.
 #   cmdline-tools: sha256sum of the dl.google.com archive.
 #   rustup-init: https://static.rust-lang.org/rustup/archive/<ver>/<target>/rustup-init.sha256
+#   NDK: compute sha256sum of android-ndk-r<N>-linux.zip after downloading;
+#        Google's repository2-3.xml only publishes sha1, so we re-pin to sha256
+#        here and check both for defense-in-depth.
 ARG JDK_X64_SHA256=8682892fc02965930b9022c066fa164dd6f458ef4a5dc262016aa28333b30f49
 ARG JDK_AARCH64_SHA256=0c17fa4f14c0d2cc9e9334f996fccdddc5da4459d768f3105c7ff0283c47bf62
 ARG ANDROID_CMDLINE_TOOLS_SHA256=2d2d50857e4eb553af5a6dc3ad507a17adf43d115264b1afc116f95c92e5e258
 ARG RUSTUP_INIT_X64_SHA256=20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c
 ARG RUSTUP_INIT_AARCH64_SHA256=e3853c5a252fca15252d07cb23a1bdd9377a8c6f3efa01531109281ae47f841c
+ARG ANDROID_NDK_URL_BASENAME=android-ndk-r29-linux.zip
+ARG ANDROID_NDK_SHA256=4abbbcdc842f3d4879206e9695d52709603e52dd68d3c1fff04b3b5e7a308ecf
 
 # System packages required to bootstrap the SDK and Rust builds.
 #
@@ -122,7 +136,12 @@ RUN mkdir -p /opt/jdk-17 \
     && rm /tmp/jdk.tar.gz \
     && java -version
 
-# Android cmdline-tools + platform-tools + build-tools + platform + NDK (all pinned).
+# Android cmdline-tools + platform-tools + build-tools + platform. The NDK is
+# installed separately below with an explicit SHA-256 pin (biggest supply-chain
+# surface; see ANDROID_NDK_SHA256). platform-tools / platforms / build-tools
+# are still fetched via sdkmanager from dl.google.com over TLS — the gap is
+# documented in REPRODUCIBLE_BUILDS.md and mitigated by the base image and NDK
+# pins, which are the layers that materially affect APK bytes.
 RUN mkdir -p "${ANDROID_HOME}/cmdline-tools" \
     && curl --proto '=https' --tlsv1.2 -fsSL \
         "https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_CMDLINE_TOOLS_VERSION}_latest.zip" \
@@ -135,8 +154,26 @@ RUN mkdir -p "${ANDROID_HOME}/cmdline-tools" \
     && sdkmanager --install \
         "platform-tools" \
         "platforms;${ANDROID_PLATFORM}" \
-        "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" \
-        "ndk;${ANDROID_NDK_VERSION}"
+        "build-tools;${ANDROID_BUILD_TOOLS_VERSION}"
+
+# Android NDK. Pinned by SHA-256 (primary) and SHA-1 (defense-in-depth; the
+# SHA-1 is what Google publishes in repository2-3.xml). The NDK is downloaded
+# directly from dl.google.com rather than via sdkmanager so a compromised
+# sdkmanager cannot substitute a different NDK tree; the zip's sha256 is
+# verified before extraction. The extracted path must match
+# ${ANDROID_NDK_HOME} so Gradle's NDK probing resolves it.
+RUN mkdir -p "${ANDROID_HOME}/ndk" \
+    && curl --proto '=https' --tlsv1.2 -fsSL \
+        "https://dl.google.com/android/repository/${ANDROID_NDK_URL_BASENAME}" \
+        -o /tmp/ndk.zip \
+    && echo "${ANDROID_NDK_SHA256}  /tmp/ndk.zip" | sha256sum -c - \
+    && unzip -q /tmp/ndk.zip -d /tmp/ndk-extract \
+    && NDK_INNER_DIR="$(find /tmp/ndk-extract -mindepth 1 -maxdepth 1 -type d | head -1)" \
+    && [ -n "$NDK_INNER_DIR" ] || { echo "NDK archive layout unexpected" >&2; exit 1; } \
+    && mv "$NDK_INNER_DIR" "${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}" \
+    && rm -rf /tmp/ndk.zip /tmp/ndk-extract \
+    && [ -x "${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}/ndk-build" ] \
+        || { echo "NDK install layout invalid at ${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}" >&2; exit 1; }
 
 # Rust + Android targets + cargo-ndk (all pinned, --locked). rustup-init is
 # fetched as a pinned binary (by version and SHA-256), not via `curl | sh`, so

--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -161,20 +161,21 @@ RUN mkdir -p "${ANDROID_HOME}/cmdline-tools" \
         "platforms;${ANDROID_PLATFORM}" \
         "build-tools;${ANDROID_BUILD_TOOLS_VERSION}"
 
-# Android NDK. Pinned by SHA-256 (primary) and SHA-1 (defense-in-depth; the
-# SHA-1 is what Google publishes in repository2-3.xml). The NDK is downloaded
-# directly from dl.google.com rather than via sdkmanager so a compromised
-# sdkmanager cannot substitute a different NDK tree; the zip's sha256 is
-# verified before extraction. The extracted path must match
-# ${ANDROID_NDK_HOME} so Gradle's NDK probing resolves it.
+# Android NDK. Pinned by SHA-256 and downloaded directly from dl.google.com
+# rather than via sdkmanager, so a compromised sdkmanager cannot substitute a
+# different NDK tree; the zip's sha256 is verified before extraction. The
+# extracted path must match ${ANDROID_NDK_HOME} so Gradle's NDK probing
+# resolves it.
 RUN mkdir -p "${ANDROID_HOME}/ndk" \
     && curl --proto '=https' --tlsv1.2 -fsSL \
         "https://dl.google.com/android/repository/${ANDROID_NDK_URL_BASENAME}" \
         -o /tmp/ndk.zip \
     && echo "${ANDROID_NDK_SHA256}  /tmp/ndk.zip" | sha256sum -c - \
     && unzip -q /tmp/ndk.zip -d /tmp/ndk-extract \
-    && NDK_INNER_DIR="$(find /tmp/ndk-extract -mindepth 1 -maxdepth 1 -type d | head -1)" \
-    && [ -n "$NDK_INNER_DIR" ] || { echo "NDK archive layout unexpected" >&2; exit 1; } \
+    && NDK_DIR_COUNT="$(find /tmp/ndk-extract -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')" \
+    && [ "$NDK_DIR_COUNT" = "1" ] \
+        || { echo "NDK archive layout unexpected (expected 1 top-level dir, got $NDK_DIR_COUNT):" >&2; find /tmp/ndk-extract -mindepth 1 -maxdepth 1 >&2; exit 1; } \
+    && NDK_INNER_DIR="$(find /tmp/ndk-extract -mindepth 1 -maxdepth 1 -type d)" \
     && mv "$NDK_INNER_DIR" "${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}" \
     && rm -rf /tmp/ndk.zip /tmp/ndk-extract \
     && [ -x "${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}/ndk-build" ] \
@@ -244,8 +245,8 @@ RUN if [ -z "$KEEP_SHA" ]; then \
     fi \
     && echo "$KEEP_SHA" | grep -Eq '^[0-9a-f]{40}$' \
         || { echo "KEEP_SHA must be a 40-char lowercase hex SHA, got: '$KEEP_SHA'" >&2; exit 1; } \
-    && echo "${KEEP_REMOTE}" | grep -Eq '^https?://' \
-        || { echo "KEEP_REMOTE must be an http(s) URL, got: '${KEEP_REMOTE}'" >&2; exit 1; } \
+    && echo "${KEEP_REMOTE}" | grep -Eq '^https://[^[:space:]]+$' \
+        || { echo "KEEP_REMOTE must be an https URL, got: '${KEEP_REMOTE}'" >&2; exit 1; } \
     && echo "Pinned keep SHA: $KEEP_SHA (from ${KEEP_REMOTE})" \
     && git clone "${KEEP_REMOTE}" /build/keep \
     && git -C /build/keep checkout "$KEEP_SHA" \
@@ -297,6 +298,14 @@ RUN set -eux; \
         KEY_PASSWORD=THROWAWAY_DO_NOT_SHIP; \
     else \
         echo "Using caller-provided KEYSTORE_FILE=$KEYSTORE_FILE"; \
+        missing=""; \
+        [ -n "$KEYSTORE_PASSWORD" ] || missing="$missing KEYSTORE_PASSWORD"; \
+        [ -n "$KEY_ALIAS" ]         || missing="$missing KEY_ALIAS"; \
+        [ -n "$KEY_PASSWORD" ]      || missing="$missing KEY_PASSWORD"; \
+        if [ -n "$missing" ]; then \
+            echo "KEYSTORE_FILE set but missing required var(s):$missing" >&2; \
+            exit 1; \
+        fi; \
     fi; \
     export KEYSTORE_FILE KEYSTORE_PASSWORD KEY_ALIAS KEY_PASSWORD; \
     ./gradlew assembleRelease --no-daemon; \

--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -26,6 +26,19 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG SOURCE_DATE_EPOCH
 ARG KEEP_SHA
 
+# Optional keystore overrides. When KEYSTORE_FILE points at an existing file
+# inside the build context (e.g. a path copied in, or `/run/secrets/...`
+# mounted via `docker build --secret`), the caller-provided keystore is used
+# instead of the throwaway keystore and the APK will match the official bytes.
+# WARNING: passing secrets as --build-arg leaves them in `docker history`.
+# Prefer `--secret` mounts for the keystore file; passwords should be read
+# from a mounted secret inside a wrapper entrypoint if strict hygiene is
+# required.
+ARG KEYSTORE_FILE
+ARG KEYSTORE_PASSWORD
+ARG KEY_ALIAS
+ARG KEY_PASSWORD
+
 # Pinned toolchain versions. Cross-validated by scripts/check-toolchain-pins.sh.
 ARG DEBIAN_SNAPSHOT=20250601T000000Z
 ARG JDK_VERSION=17.0.13+11
@@ -184,6 +197,17 @@ RUN if [ -z "$KEEP_SHA" ]; then \
 
 # Build. SOURCE_DATE_EPOCH is passed through to both the Rust build (via
 # build-rust.sh) and Gradle's packaging/signing.
+#
+# THROWAWAY KEYSTORE policy (applied below when no keystore is provided):
+# DO NOT SHIP APKS SIGNED WITH THIS KEY. The throwaway key is generated per
+# build for local reproducibility verification only. The resulting APK's
+# payload is reproducible; only the signing block varies. Android installs
+# are pinned to signing identity, so accidentally shipping an APK signed
+# with this publicly-known key means anyone can sign updates for your app.
+# To match the official release bytes, pass a real keystore into the build
+# (e.g. via `docker build --secret id=keystore,src=...` bind-mounted to a
+# known path) and set KEYSTORE_FILE/KEYSTORE_PASSWORD/KEY_ALIAS/KEY_PASSWORD
+# in the build environment before invoking docker build.
 WORKDIR /build/keep-android
 RUN set -eux; \
     if [ -z "${SOURCE_DATE_EPOCH}" ] || [ "${SOURCE_DATE_EPOCH}" = "0" ]; then \
@@ -192,30 +216,30 @@ RUN set -eux; \
     echo "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH"; \
     export KEEP_REPO=/build/keep; \
     export AWS_LC_SYS_CMAKE_BUILDER=1; \
+    KEYSTORE_FILE="${KEYSTORE_FILE:-}"; \
+    KEYSTORE_PASSWORD="${KEYSTORE_PASSWORD:-}"; \
+    KEY_ALIAS="${KEY_ALIAS:-}"; \
+    KEY_PASSWORD="${KEY_PASSWORD:-}"; \
     ./scripts/check-toolchain-pins.sh; \
     ./build-rust.sh; \
-    # ========================================================================
-    # THROWAWAY KEYSTORE — DO NOT SHIP APKS SIGNED WITH THIS KEY.
-    # ------------------------------------------------------------------------
-    # Generated per build for local reproducibility verification only. The
-    # resulting APK's payload is reproducible; only the signing block varies.
-    # Android installs are pinned to signing identity — accidentally shipping
-    # an APK signed with this publicly-known key means anyone can sign updates
-    # for your app. To match the official release bytes, mount a real keystore
-    # via --secret and pass KEYSTORE_FILE/PASSWORD/KEY_ALIAS/KEY_PASSWORD.
-    # ========================================================================
-    keytool -genkeypair -v \
-        -keystore /tmp/throwaway.keystore \
-        -storetype PKCS12 \
-        -storepass THROWAWAY_DO_NOT_SHIP \
-        -keypass THROWAWAY_DO_NOT_SHIP \
-        -alias THROWAWAY-DO-NOT-SHIP \
-        -keyalg RSA -keysize 4096 -validity 36500 \
-        -dname "CN=keep-reproducibility-THROWAWAY-DO-NOT-SHIP, O=local, C=US"; \
-    KEYSTORE_FILE=/tmp/throwaway.keystore \
-    KEYSTORE_PASSWORD=THROWAWAY_DO_NOT_SHIP \
-    KEY_ALIAS=THROWAWAY-DO-NOT-SHIP \
-    KEY_PASSWORD=THROWAWAY_DO_NOT_SHIP \
+    if [ -z "$KEYSTORE_FILE" ] || [ ! -f "$KEYSTORE_FILE" ]; then \
+        echo "No KEYSTORE_FILE provided; generating throwaway keystore (DO NOT SHIP)."; \
+        keytool -genkeypair -v \
+            -keystore /tmp/throwaway.keystore \
+            -storetype PKCS12 \
+            -storepass THROWAWAY_DO_NOT_SHIP \
+            -keypass THROWAWAY_DO_NOT_SHIP \
+            -alias THROWAWAY-DO-NOT-SHIP \
+            -keyalg RSA -keysize 4096 -validity 36500 \
+            -dname "CN=keep-reproducibility-THROWAWAY-DO-NOT-SHIP, O=local, C=US"; \
+        KEYSTORE_FILE=/tmp/throwaway.keystore; \
+        KEYSTORE_PASSWORD=THROWAWAY_DO_NOT_SHIP; \
+        KEY_ALIAS=THROWAWAY-DO-NOT-SHIP; \
+        KEY_PASSWORD=THROWAWAY_DO_NOT_SHIP; \
+    else \
+        echo "Using caller-provided KEYSTORE_FILE=$KEYSTORE_FILE"; \
+    fi; \
+    export KEYSTORE_FILE KEYSTORE_PASSWORD KEY_ALIAS KEY_PASSWORD; \
     ./gradlew assembleRelease --no-daemon; \
     mkdir -p /out; \
     cp app/build/outputs/apk/release/app-release.apk /out/app-release.apk; \

--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -27,6 +27,7 @@ ARG SOURCE_DATE_EPOCH
 ARG KEEP_SHA
 
 # Pinned toolchain versions. Cross-validated by scripts/check-toolchain-pins.sh.
+ARG DEBIAN_SNAPSHOT=20250601T000000Z
 ARG JDK_VERSION=17.0.13+11
 ARG ANDROID_CMDLINE_TOOLS_VERSION=11076708
 ARG ANDROID_BUILD_TOOLS_VERSION=36.0.0
@@ -60,7 +61,20 @@ ARG RUSTUP_INIT_X64_SHA256=20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c0
 ARG RUSTUP_INIT_AARCH64_SHA256=e3853c5a252fca15252d07cb23a1bdd9377a8c6f3efa01531109281ae47f841c
 
 # System packages required to bootstrap the SDK and Rust builds.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+#
+# APT is pinned to a snapshot.debian.org timestamp so package versions cannot
+# drift between rebuilds. This is critical because `AWS_LC_SYS_CMAKE_BUILDER=1`
+# causes aws-lc-sys to compile native artifacts with the host cmake/gcc,
+# and any version change there would perturb the final APK's .so bytes.
+# Acquire::Check-Valid-Until=false is required because snapshot suites eventually
+# have stale Valid-Until stamps.
+RUN printf 'deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/%s/ bookworm main\ndeb [check-valid-until=no] https://snapshot.debian.org/archive/debian-security/%s/ bookworm-security main\ndeb [check-valid-until=no] https://snapshot.debian.org/archive/debian/%s/ bookworm-updates main\n' \
+        "${DEBIAN_SNAPSHOT}" "${DEBIAN_SNAPSHOT}" "${DEBIAN_SNAPSHOT}" \
+        > /etc/apt/sources.list \
+    && printf 'Acquire::Check-Valid-Until "false";\nAcquire::Retries "5";\n' \
+        > /etc/apt/apt.conf.d/99snapshot \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
         unzip \

--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -60,7 +60,7 @@ ARG RUST_VERSION=1.89.0
 ARG RUSTUP_VERSION=1.28.2
 ARG CARGO_NDK_VERSION=4.1.2
 
-ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-0} \
+ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-} \
     LC_ALL=C \
     TZ=UTC \
     LANG=C.UTF-8 \
@@ -269,7 +269,7 @@ RUN if [ -z "$KEEP_SHA" ]; then \
 # in the build environment before invoking docker build.
 WORKDIR /build/keep-android
 RUN set -eux; \
-    if [ -z "${SOURCE_DATE_EPOCH}" ] || [ "${SOURCE_DATE_EPOCH}" = "0" ]; then \
+    if [ -z "${SOURCE_DATE_EPOCH:-}" ]; then \
         export SOURCE_DATE_EPOCH="$(./scripts/derive-sde.sh)"; \
     fi; \
     echo "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH"; \

--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -26,18 +26,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG SOURCE_DATE_EPOCH
 ARG KEEP_SHA
 
-ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-0} \
-    LC_ALL=C \
-    TZ=UTC \
-    LANG=C.UTF-8 \
-    ANDROID_HOME=/opt/android-sdk \
-    ANDROID_SDK_ROOT=/opt/android-sdk \
-    ANDROID_NDK_HOME=/opt/android-sdk/ndk/29.0.14206865 \
-    JAVA_HOME=/opt/jdk-17 \
-    CARGO_HOME=/opt/cargo \
-    RUSTUP_HOME=/opt/rustup \
-    PATH=/opt/cargo/bin:/opt/jdk-17/bin:/opt/android-sdk/cmdline-tools/latest/bin:/opt/android-sdk/platform-tools:/opt/android-sdk/build-tools/36.0.0:${PATH}
-
 # Pinned toolchain versions. Cross-validated by scripts/check-toolchain-pins.sh.
 ARG JDK_VERSION=17.0.13+11
 ARG ANDROID_CMDLINE_TOOLS_VERSION=11076708
@@ -47,6 +35,18 @@ ARG ANDROID_NDK_VERSION=29.0.14206865
 ARG RUST_VERSION=1.89.0
 ARG RUSTUP_VERSION=1.28.2
 ARG CARGO_NDK_VERSION=4.1.2
+
+ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-0} \
+    LC_ALL=C \
+    TZ=UTC \
+    LANG=C.UTF-8 \
+    ANDROID_HOME=/opt/android-sdk \
+    ANDROID_SDK_ROOT=/opt/android-sdk \
+    ANDROID_NDK_HOME=/opt/android-sdk/ndk/${ANDROID_NDK_VERSION} \
+    JAVA_HOME=/opt/jdk-17 \
+    CARGO_HOME=/opt/cargo \
+    RUSTUP_HOME=/opt/rustup \
+    PATH=/opt/cargo/bin:/opt/jdk-17/bin:/opt/android-sdk/cmdline-tools/latest/bin:/opt/android-sdk/platform-tools:/opt/android-sdk/build-tools/${ANDROID_BUILD_TOOLS_VERSION}:${PATH}
 
 # SHA-256 checksums for bootstrap downloads. Updating any version above also
 # requires refreshing the matching hash here. Sources:

--- a/REPRODUCIBLE_BUILDS.md
+++ b/REPRODUCIBLE_BUILDS.md
@@ -137,10 +137,18 @@ export SOURCE_DATE_EPOCH="$(./scripts/derive-sde.sh)"
 # Native libs + UniFFI Kotlin bindings.
 ./build-rust.sh
 
-# Android release APK. Signing is optional for reproducibility verification;
-# without a `KEYSTORE_FILE` the container build (Section 4) generates a
-# throwaway keystore per build and signs with it. For host builds, if no
-# `storeFile` is resolved, Gradle falls back to the debug signing key.
+# Android release APK. Signing behavior differs between the host and
+# container paths:
+#   * Host build: if no `KEYSTORE_FILE` is exported and no `storeFile` is
+#     resolved by `app/build.gradle.kts`, Gradle falls back to the debug
+#     signing key and still writes `app-release.apk`.
+#   * Container build (Section 4): `Dockerfile.reproducible` intentionally
+#     generates a throwaway keystore per build when `KEYSTORE_FILE` is unset,
+#     so the APK is always release-signed. This enforces a deterministic
+#     signing path for reproducibility verification; the fallback-to-debug
+#     behavior of `app/build.gradle.kts` is therefore not exercised by the
+#     container. Pass `KEYSTORE_FILE`/`KEYSTORE_PASSWORD`/`KEY_ALIAS`/
+#     `KEY_PASSWORD` to sign with a real key inside the container.
 ./gradlew assembleRelease --no-daemon
 ```
 

--- a/REPRODUCIBLE_BUILDS.md
+++ b/REPRODUCIBLE_BUILDS.md
@@ -276,15 +276,21 @@ verify that two builds of the same sources in the same environment produce
 identical bytes, which is exactly what `.github/workflows/reproducibility.yml`
 does weekly and on every release tag:
 
+Requires `KEEP_REPO` to be exported (see § 3.2); `"$KEEP_REPO/keep-mobile/target"`
+is removed explicitly so the sibling cargo target dir is purged even when
+`keep` is checked out outside this repo tree.
+
 ```bash
+: "${KEEP_REPO:?set KEEP_REPO to your keep checkout, e.g. export KEEP_REPO=\"\$PWD/../keep\"}"
+
 ./gradlew clean --no-daemon
-rm -rf app/src/main/jniLibs app/src/main/kotlin/io/privkey/keep/uniffi keep/keep-mobile/target
+rm -rf app/src/main/jniLibs app/src/main/kotlin/io/privkey/keep/uniffi "$KEEP_REPO/keep-mobile/target"
 ./build-rust.sh
 ./gradlew assembleRelease --no-daemon
 cp app/build/outputs/apk/release/app-release.apk /tmp/build1.apk
 
 ./gradlew clean --no-daemon
-rm -rf app/src/main/jniLibs app/src/main/kotlin/io/privkey/keep/uniffi keep/keep-mobile/target
+rm -rf app/src/main/jniLibs app/src/main/kotlin/io/privkey/keep/uniffi "$KEEP_REPO/keep-mobile/target"
 ./build-rust.sh
 ./gradlew assembleRelease --no-daemon
 cp app/build/outputs/apk/release/app-release.apk /tmp/build2.apk

--- a/REPRODUCIBLE_BUILDS.md
+++ b/REPRODUCIBLE_BUILDS.md
@@ -214,12 +214,12 @@ and a `SHA256SUMS` file is attached).
 # 1. Confirm the checksum of the download.
 sha256sum -c SHA256SUMS
 
-# 2. Strip the signing block from the official APK (the payload is what is
-#    reproducible; the signature block is not, since it requires the release
-#    signing key).
-# For a byte-equal comparison, rebuild with the same key; otherwise use
-# diffoscope which highlights that only META-INF/*.SF, *.RSA, and the APK
-# signing block differ.
+# 2. Compare the official APK with your local build. The payload is what is
+#    reproducible; the signing block is not, since it requires the release
+#    signing key. diffoscope runs directly on the two APKs and highlights the
+#    signing-block differences inline — no manual stripping required.
+#    A plain `sha256sum` match is only expected when you rebuild with the same
+#    signing key as the release.
 
 sudo apt-get install -y diffoscope
 diffoscope --html diffoscope.html --text diffoscope.txt \

--- a/REPRODUCIBLE_BUILDS.md
+++ b/REPRODUCIBLE_BUILDS.md
@@ -39,6 +39,7 @@ files where they appear. Run it after any toolchain change. Do not substitute.
 |----------------------------|------------------------------------------|--------------------------------------------------|
 | Host OS (CI reference)     | Ubuntu 24.04                             | `.github/workflows/release.yml` (`runs-on`)      |
 | Container base             | Debian 12 bookworm-slim (digest-pinned)  | `Dockerfile.reproducible` (`FROM debian@sha256:...`) |
+| Debian APT snapshot        | snapshot.debian.org fixed timestamp      | `Dockerfile.reproducible` (`DEBIAN_SNAPSHOT`)    |
 | JDK                        | Temurin 17                               | `build.gradle.kts` (`expectedJavaMajor = 17`)    |
 | Android SDK build-tools    | 36.0.0                                   | `.github/workflows/release.yml` (`BUILD_TOOLS_VERSION`) |
 | Android `compileSdk`       | 36                                       | `app/build.gradle.kts`                           |

--- a/REPRODUCIBLE_BUILDS.md
+++ b/REPRODUCIBLE_BUILDS.md
@@ -1,0 +1,290 @@
+# Reproducible Builds
+
+This document describes how to independently reproduce the official release APK
+of keep-android bit-for-bit from source. A successful reproduction yields a
+file whose SHA-256 matches the APK published on the corresponding
+[GitHub release](https://github.com/privkeyio/keep-android/releases) once the
+release's signature block is stripped or the same signing key is used.
+
+The recipe is pinned, self-contained, and does not require contacting the
+maintainers. If your build does not match, the automated
+`.github/workflows/reproducibility.yml` job (which rebuilds twice and compares)
+is the reference and your environment drift is the likely cause.
+
+## Overview
+
+A reproducible keep-android build requires:
+
+1. Source at the exact commit of the release tag.
+2. The `keep` Rust workspace at the SHA pinned in `keep.version`.
+3. Exact toolchain versions (JDK, Android SDK build-tools, Android NDK, Rust, cargo-ndk).
+4. `SOURCE_DATE_EPOCH` derived from the later of the two repos' HEAD commit times.
+5. Path remapping in `rustc` (already encoded in `build-rust.sh`).
+
+Two paths are supported:
+
+- **Host build** (Section 3) — install the pinned toolchain on your host.
+- **Container build** (Section 4) — use `Dockerfile.reproducible` at the repo root.
+
+After building, verify via `apksigner` and compare to the release APK via
+`diffoscope` (Section 5).
+
+## 1. Pinned Toolchain (source of truth)
+
+`scripts/check-toolchain-pins.sh` cross-validates the Rust, cargo-ndk, NDK,
+JDK major, build-tools, AGP, Kotlin compose plugin, and KSP pins across all
+files where they appear. Run it after any toolchain change. Do not substitute.
+
+| Component                  | Version                                  | Source of truth                                  |
+|----------------------------|------------------------------------------|--------------------------------------------------|
+| Host OS (CI reference)     | Ubuntu 24.04                             | `.github/workflows/release.yml` (`runs-on`)      |
+| Container base             | Debian 12 bookworm-slim (digest-pinned)  | `Dockerfile.reproducible` (`FROM debian@sha256:...`) |
+| JDK                        | Temurin 17                               | `build.gradle.kts` (`expectedJavaMajor = 17`)    |
+| Android SDK build-tools    | 36.0.0                                   | `.github/workflows/release.yml` (`BUILD_TOOLS_VERSION`) |
+| Android `compileSdk`       | 36                                       | `app/build.gradle.kts`                           |
+| Android `minSdk`           | 33                                       | `app/build.gradle.kts`                           |
+| Android NDK                | 29.0.14206865                            | `build.gradle.kts` (`expectedNdkVersion`)        |
+| Rust (rustc/cargo)         | 1.89.0                                   | `build-rust.sh` (`EXPECTED_RUST`) / `keep/rust-toolchain.toml` |
+| cargo-ndk                  | 4.1.2                                    | `build-rust.sh` (`CARGO_NDK_VERSION`)            |
+| Android Gradle Plugin      | 9.1.0                                    | `build.gradle.kts`                               |
+| Kotlin Compose plugin      | 2.3.20                                   | `build.gradle.kts`                               |
+| KSP                        | 2.3.6                                    | `build.gradle.kts`                               |
+
+The container build (Section 4) is the canonical reproducibility path — its
+toolchain layers are byte-pinned (base image digest + SHA-256 of every
+downloaded archive). Host builds on other distros may not produce
+byte-identical APKs even with matching tool versions, since aapt2/dex tooling
+can embed host libc strings and tzdata.
+
+## 2. Pinned Source
+
+- **keep-android**: check out the tag of the release you are reproducing
+  (e.g. `v0.5.2`). The current `keep` pin lives in
+  [`keep.version`](./keep.version) at that tag — read it with
+  `tr -d '[:space:]' < keep.version`.
+- **keep** (Rust workspace): checked out at the 40-char hex SHA in
+  `keep.version`. The Gradle task `verifyKeepVersion` aborts the build if the
+  checkout drifts, so you cannot silently reproduce against the wrong sources.
+
+> **Trust model.** The recipe pins `keep` by commit SHA, which defeats
+> post-hoc tampering of the `keep` repo, but does not by itself attest to who
+> authored that commit. Before trusting a reproduction, verify the
+> keep-android release tag's GPG/SSH signature out of band
+> (`git tag --verify v<x.y.z>`).
+
+Clone both:
+
+```bash
+# Pick the release tag you want to reproduce.
+TAG=v0.5.2  # example — substitute the release you are verifying
+
+git clone https://github.com/privkeyio/keep-android.git
+git -C keep-android checkout "$TAG"
+
+KEEP_SHA="$(tr -d '[:space:]' < keep-android/keep.version)"
+git clone https://github.com/privkeyio/keep.git
+git -C keep checkout "$KEEP_SHA"
+```
+
+Both directories must be siblings, or `KEEP_REPO` must point at the `keep`
+checkout.
+
+## 3. Host Build
+
+### 3.1 Install the pinned toolchain
+
+- **JDK 17 (Temurin)**: install from your package manager or
+  [Adoptium](https://adoptium.net/). Ensure `java -version` reports 17.
+- **Android SDK**: install `cmdline-tools`, then run:
+  ```bash
+  sdkmanager --install "platforms;android-36" \
+                      "build-tools;36.0.0" \
+                      "ndk;29.0.14206865"
+  ```
+  Export `ANDROID_HOME` to the SDK root (CI uses
+  `/usr/local/lib/android/sdk`; Debian/Ubuntu packages use
+  `/usr/lib/android-sdk`).
+- **Rust 1.89.0 + cargo-ndk 4.1.2**:
+  ```bash
+  rustup toolchain install 1.89.0
+  rustup override set 1.89.0   # optional; rust-toolchain.toml also pins it
+  rustup target add aarch64-linux-android x86_64-linux-android
+  cargo install --locked cargo-ndk --version 4.1.2
+  ```
+
+`scripts/check-toolchain-pins.sh` cross-verifies every pin and fails loudly on
+drift; run it after installation:
+
+```bash
+cd keep-android
+./scripts/check-toolchain-pins.sh
+```
+
+### 3.2 Build the APK
+
+```bash
+cd keep-android
+
+export ANDROID_HOME=/path/to/android-sdk
+export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/29.0.14206865"
+export KEEP_REPO="$PWD/../keep"
+export AWS_LC_SYS_CMAKE_BUILDER=1
+
+# Deterministic timestamp (later of the two repos' HEAD commit times).
+export SOURCE_DATE_EPOCH="$(./scripts/derive-sde.sh)"
+
+# Native libs + UniFFI Kotlin bindings.
+./build-rust.sh
+
+# Android release APK. Signing is optional for reproducibility verification;
+# without `KEYSTORE_FILE` set (or no `storeFile` resolved), Gradle falls back
+# to the debug signing key and still writes `app-release.apk`.
+./gradlew assembleRelease --no-daemon
+```
+
+Output: `app/build/outputs/apk/release/app-release.apk`.
+
+If you want to reproduce the exact byte layout of the published APK, you must
+sign with the same release key; otherwise the APK payload is identical but the
+signing block (v2/v3) differs. For pure reproducibility verification (two
+independent builds of the same sources producing identical bytes), use a
+throwaway keystore and compare two of your own builds, as
+`.github/workflows/reproducibility.yml` does.
+
+## 4. Container Build
+
+A self-contained `Dockerfile.reproducible` at the repo root encapsulates the
+host build. It pins a Debian base image by digest and installs the exact
+toolchain versions.
+
+The container build requires `.git` to exist in the keep-android checkout
+(it is needed by `scripts/derive-sde.sh`). The shipped `.dockerignore`
+preserves `.git/`; do not exclude it.
+
+```bash
+cd keep-android
+
+# Export the pinned keep SHA and a deterministic timestamp.
+export KEEP_SHA="$(tr -d '[:space:]' < keep.version)"
+export SOURCE_DATE_EPOCH="$(./scripts/derive-sde.sh)"
+
+# BuildKit is required for the `--output` export stage.
+DOCKER_BUILDKIT=1 docker build \
+    --build-arg KEEP_SHA="$KEEP_SHA" \
+    --build-arg SOURCE_DATE_EPOCH="$SOURCE_DATE_EPOCH" \
+    --output type=local,dest=out \
+    -f Dockerfile.reproducible \
+    .
+
+ls out/   # app-release.apk
+```
+
+The container:
+
+1. Starts from a digest-pinned Debian slim base.
+2. Installs Temurin JDK 17, Android cmdline-tools, build-tools 36.0.0, NDK
+   29.0.14206865, Rust 1.89.0, and cargo-ndk 4.1.2.
+3. Copies the keep-android sources in and clones `keep` at the pinned SHA.
+4. Runs `build-rust.sh` and `./gradlew assembleRelease` with
+   `SOURCE_DATE_EPOCH` set.
+5. Exports the unsigned release APK to `./out/`.
+
+## 5. Verify the Result
+
+### 5.1 Inspect APK signature (official release only)
+
+The official APK is signed with APK signature scheme v2/v3. Many system
+`apksigner` packages (e.g. Debian's 0.9) are too old to verify v2/v3. Use the
+build-tools 36.0.0 `apksigner` shipped with the SDK:
+
+```bash
+# Use the build-tools version pinned in the table above (Section 1).
+BUILD_TOOLS_VERSION=36.0.0
+"$ANDROID_HOME/build-tools/${BUILD_TOOLS_VERSION}/apksigner" verify --print-certs \
+    keep-android-v0.5.2.apk
+```
+
+### 5.2 Compare against the release APK
+
+Download the published APK and its checksum from the corresponding GitHub
+release (both live under `https://github.com/privkeyio/keep-android/releases`
+and a `SHA256SUMS` file is attached).
+
+```bash
+# 1. Confirm the checksum of the download.
+sha256sum -c SHA256SUMS
+
+# 2. Strip the signing block from the official APK (the payload is what is
+#    reproducible; the signature block is not, since it requires the release
+#    signing key).
+# For a byte-equal comparison, rebuild with the same key; otherwise use
+# diffoscope which highlights that only META-INF/*.SF, *.RSA, and the APK
+# signing block differ.
+
+sudo apt-get install -y diffoscope
+diffoscope --html diffoscope.html --text diffoscope.txt \
+    keep-android-v0.5.2.apk \
+    app/build/outputs/apk/release/app-release.apk
+```
+
+A reproducible build produces a `diffoscope` report in which:
+
+- All `classes*.dex`, `resources.arsc`, `AndroidManifest.xml`, native `.so`
+  libraries, and asset files are byte-identical.
+- Only the signing block (`META-INF/CERT.*`, `META-INF/MANIFEST.MF`,
+  `META-INF/*.SF`, APK signature scheme v2/v3 block) differs, because the
+  release was signed with a key you do not hold.
+
+If anything else differs, your environment has drifted from the pins.
+
+### 5.3 Independent double-build check
+
+You do not need the published APK at all to verify reproducibility — you can
+verify that two builds of the same sources in the same environment produce
+identical bytes, which is exactly what `.github/workflows/reproducibility.yml`
+does weekly and on every release tag:
+
+```bash
+./gradlew clean --no-daemon
+rm -rf app/src/main/jniLibs app/src/main/kotlin/io/privkey/keep/uniffi keep/keep-mobile/target
+./build-rust.sh
+./gradlew assembleRelease --no-daemon
+cp app/build/outputs/apk/release/app-release.apk /tmp/build1.apk
+
+./gradlew clean --no-daemon
+rm -rf app/src/main/jniLibs app/src/main/kotlin/io/privkey/keep/uniffi keep/keep-mobile/target
+./build-rust.sh
+./gradlew assembleRelease --no-daemon
+cp app/build/outputs/apk/release/app-release.apk /tmp/build2.apk
+
+sha256sum /tmp/build1.apk /tmp/build2.apk
+```
+
+The two SHA-256 hashes MUST be identical.
+
+## 6. Troubleshooting
+
+- **`SOURCE_DATE_EPOCH is not set`**: you invoked `assembleRelease` without
+  exporting it. Always run
+  `export SOURCE_DATE_EPOCH="$(./scripts/derive-sde.sh)"` first.
+- **`rustc version mismatch`**: rustup selected a different toolchain than
+  `rust-toolchain.toml` pins. Run `rustup toolchain install 1.89.0` and ensure
+  no `RUSTUP_TOOLCHAIN` override is set.
+- **`keep checkout ... does not match pinned ...`**: run
+  `git -C ../keep checkout "$(tr -d '[:space:]' < keep.version)"`.
+- **`cargo-ndk version mismatch`**: run
+  `cargo install --locked cargo-ndk --version 4.1.2 --force`.
+- **NDK missing**: `sdkmanager --install "ndk;29.0.14206865"`.
+- **`apksigner` verify reports v2/v3 unsupported**: your system `apksigner` is
+  too old; use `$ANDROID_HOME/build-tools/36.0.0/apksigner`.
+
+## 7. Reporting Reproducibility Failures
+
+If you followed the recipe exactly and cannot reproduce a release, file an
+issue at <https://github.com/privkeyio/keep-android/issues> with:
+
+- The release tag you were reproducing.
+- The exact commands you ran (prefer the container build for reproducibility).
+- The `diffoscope --text` output.
+- The output of `scripts/check-toolchain-pins.sh` and
+  `rustc --version`, `cargo ndk --version`, `java -version`, `sdkmanager --list_installed`.

--- a/REPRODUCIBLE_BUILDS.md
+++ b/REPRODUCIBLE_BUILDS.md
@@ -138,8 +138,9 @@ export SOURCE_DATE_EPOCH="$(./scripts/derive-sde.sh)"
 ./build-rust.sh
 
 # Android release APK. Signing is optional for reproducibility verification;
-# without `KEYSTORE_FILE` set (or no `storeFile` resolved), Gradle falls back
-# to the debug signing key and still writes `app-release.apk`.
+# without a `KEYSTORE_FILE` the container build (Section 4) generates a
+# throwaway keystore per build and signs with it. For host builds, if no
+# `storeFile` is resolved, Gradle falls back to the debug signing key.
 ./gradlew assembleRelease --no-daemon
 ```
 
@@ -188,7 +189,29 @@ The container:
 3. Copies the keep-android sources in and clones `keep` at the pinned SHA.
 4. Runs `build-rust.sh` and `./gradlew assembleRelease` with
    `SOURCE_DATE_EPOCH` set.
-5. Exports the unsigned release APK to `./out/`.
+5. Exports the signed release APK to `./out/` (signed with a per-build
+   throwaway keystore unless a keystore is supplied; see § 4.1).
+
+### 4.1 Optional build-args
+
+- `KEEP_SHA` (default: read from `keep.version`): 40-char hex commit SHA of
+  the `keep` Rust workspace to check out. Overriding this reproduces against
+  a different pin than the shipped one and is for forensic use only.
+- `KEEP_REMOTE` (default: `https://github.com/privkeyio/keep.git`): the
+  remote to clone `keep` from. Only https URLs are accepted. Useful when
+  mirroring the source behind a restricted network.
+- `SOURCE_DATE_EPOCH` (default: derived by `scripts/derive-sde.sh` inside
+  the container): deterministic timestamp for the build. The literal value
+  `0` is accepted and honored verbatim (1970-01-01).
+- `KEYSTORE_FILE` / `KEYSTORE_PASSWORD` / `KEY_ALIAS` / `KEY_PASSWORD`: pass
+  a real keystore into the build to produce an APK whose signing block
+  matches the released bytes. Passing secrets via `--build-arg` leaves them
+  in `docker history`; prefer mounting a keystore file with
+  `docker build --secret id=keystore,src=/path/to/keystore.jks` and setting
+  `KEYSTORE_FILE=/run/secrets/keystore` via an entrypoint wrapper. When
+  `KEYSTORE_FILE` is set, all three of `KEYSTORE_PASSWORD`, `KEY_ALIAS`,
+  and `KEY_PASSWORD` must also be provided or the build fails fast. Without
+  any of these, a throwaway keystore is generated and used (DO NOT SHIP).
 
 ## 5. Verify the Result
 

--- a/scripts/check-toolchain-pins.sh
+++ b/scripts/check-toolchain-pins.sh
@@ -34,6 +34,7 @@ RELEASE_YML="$ROOT/.github/workflows/release.yml"
 REPRO_YML="$ROOT/.github/workflows/reproducibility.yml"
 GRADLE_KTS="$ROOT/build.gradle.kts"
 TOOLCHAIN_TOML="$ROOT/keep/rust-toolchain.toml"
+DOCKERFILE="$ROOT/Dockerfile.reproducible"
 
 for f in "$BUILD_RUST" "$CI_YML" "$RELEASE_YML" "$REPRO_YML" "$GRADLE_KTS"; do
     [ -f "$f" ] || fail "missing file: $f"
@@ -100,6 +101,33 @@ check_equal "cargo-ndk version"   "$BR_CARGO_NDK"  "$CI_CARGO_NDK"  "$REL_CARGO_
 check_equal "ndk version"         "$CI_NDK"        "$REL_NDK"       "$GRADLE_NDK"     "$REPRO_NDK"
 check_equal "jdk major version"   "$GRADLE_JDK"    "$CI_JDK"        "$REL_JDK"        "$REPRO_JDK"
 check_equal "build-tools version" "$REL_BUILD_TOOLS" "$REPRO_BUILD_TOOLS"
+
+# Cross-check Dockerfile.reproducible pins against the same sources of truth
+# so the container recipe cannot drift silently.
+if [ -f "$DOCKERFILE" ]; then
+    DOCKER_RUST=$(extract "$DOCKERFILE" 'ARG RUST_VERSION=('"$SEMVER"')')
+    DOCKER_CARGO_NDK=$(extract "$DOCKERFILE" 'ARG CARGO_NDK_VERSION=('"$SEMVER"')')
+    DOCKER_NDK=$(extract "$DOCKERFILE" 'ARG ANDROID_NDK_VERSION=('"$NDK_VER"')')
+    DOCKER_BUILD_TOOLS=$(extract "$DOCKERFILE" 'ARG ANDROID_BUILD_TOOLS_VERSION=('"$NDK_VER"')')
+    DOCKER_JDK_MAJOR=$(extract "$DOCKERFILE" 'ARG JDK_VERSION=([0-9]+)\.[0-9]+\.[0-9]+\+[0-9]+')
+    check_equal "Dockerfile rust version"        "$BR_RUST"        "$DOCKER_RUST"
+    check_equal "Dockerfile cargo-ndk version"   "$BR_CARGO_NDK"   "$DOCKER_CARGO_NDK"
+    check_equal "Dockerfile ndk version"         "$GRADLE_NDK"     "$DOCKER_NDK"
+    check_equal "Dockerfile build-tools version" "$REL_BUILD_TOOLS" "$DOCKER_BUILD_TOOLS"
+    check_equal "Dockerfile jdk major"           "$GRADLE_JDK"     "$DOCKER_JDK_MAJOR"
+else
+    echo "note: $DOCKERFILE not present; skipping container-recipe checks."
+fi
+
+# AGP / Kotlin compose / KSP plugin pins live only in build.gradle.kts. Verify
+# they are present and parseable so the doc table cannot reference something
+# the build no longer pins.
+AGP_VERSION=$(extract "$GRADLE_KTS" 'id\("com\.android\.application"\) version "('"$SEMVER"')"')
+KOTLIN_COMPOSE_VERSION=$(extract "$GRADLE_KTS" 'id\("org\.jetbrains\.kotlin\.plugin\.compose"\) version "('"$SEMVER"')"')
+KSP_VERSION=$(extract "$GRADLE_KTS" 'id\("com\.google\.devtools\.ksp"\) version "('"$SEMVER"')"')
+echo "ok: AGP version = $AGP_VERSION"
+echo "ok: Kotlin compose plugin = $KOTLIN_COMPOSE_VERSION"
+echo "ok: KSP version = $KSP_VERSION"
 
 if [ -f "$TOOLCHAIN_TOML" ]; then
     TOML_CHANNEL=$(sed -nE 's/^channel *= *"([^"]+)".*/\1/p' "$TOOLCHAIN_TOML" | head -1)

--- a/scripts/check-toolchain-pins.sh
+++ b/scripts/check-toolchain-pins.sh
@@ -33,10 +33,11 @@ CI_YML="$ROOT/.github/workflows/ci.yml"
 RELEASE_YML="$ROOT/.github/workflows/release.yml"
 REPRO_YML="$ROOT/.github/workflows/reproducibility.yml"
 GRADLE_KTS="$ROOT/build.gradle.kts"
+APP_GRADLE_KTS="$ROOT/app/build.gradle.kts"
 TOOLCHAIN_TOML="$ROOT/keep/rust-toolchain.toml"
 DOCKERFILE="$ROOT/Dockerfile.reproducible"
 
-for f in "$BUILD_RUST" "$CI_YML" "$RELEASE_YML" "$REPRO_YML" "$GRADLE_KTS"; do
+for f in "$BUILD_RUST" "$CI_YML" "$RELEASE_YML" "$REPRO_YML" "$GRADLE_KTS" "$APP_GRADLE_KTS"; do
     [ -f "$f" ] || fail "missing file: $f"
 done
 
@@ -67,7 +68,6 @@ REPRO_BUILD_TOOLS=$(yaml_env "$REPRO_YML" BUILD_TOOLS_VERSION "$NDK_VER")
 
 GRADLE_NDK=$(extract "$GRADLE_KTS" 'expectedNdkVersion = "([0-9.]+)"')
 GRADLE_JDK=$(extract "$GRADLE_KTS" 'expectedJavaMajor = ([0-9]+)')
-GRADLE_COMPILE_SDK=$(extract "$ROOT/app/build.gradle.kts" 'compileSdk = ([0-9]+)')
 
 extract_unique() {
     # extract_unique <file> <regex with one capture group>: all matches must be equal
@@ -106,6 +106,7 @@ check_equal "build-tools version" "$REL_BUILD_TOOLS" "$REPRO_BUILD_TOOLS"
 # Cross-check Dockerfile.reproducible pins against the same sources of truth
 # so the container recipe cannot drift silently.
 if [ -f "$DOCKERFILE" ]; then
+    GRADLE_COMPILE_SDK=$(extract "$APP_GRADLE_KTS" 'compileSdk = ([0-9]+)')
     DOCKER_RUST=$(extract "$DOCKERFILE" 'ARG RUST_VERSION=('"$SEMVER"')')
     DOCKER_CARGO_NDK=$(extract "$DOCKERFILE" 'ARG CARGO_NDK_VERSION=('"$SEMVER"')')
     DOCKER_NDK=$(extract "$DOCKERFILE" 'ARG ANDROID_NDK_VERSION=('"$NDK_VER"')')

--- a/scripts/check-toolchain-pins.sh
+++ b/scripts/check-toolchain-pins.sh
@@ -67,6 +67,7 @@ REPRO_BUILD_TOOLS=$(yaml_env "$REPRO_YML" BUILD_TOOLS_VERSION "$NDK_VER")
 
 GRADLE_NDK=$(extract "$GRADLE_KTS" 'expectedNdkVersion = "([0-9.]+)"')
 GRADLE_JDK=$(extract "$GRADLE_KTS" 'expectedJavaMajor = ([0-9]+)')
+GRADLE_COMPILE_SDK=$(extract "$ROOT/app/build.gradle.kts" 'compileSdk = ([0-9]+)')
 
 extract_unique() {
     # extract_unique <file> <regex with one capture group>: all matches must be equal
@@ -110,11 +111,13 @@ if [ -f "$DOCKERFILE" ]; then
     DOCKER_NDK=$(extract "$DOCKERFILE" 'ARG ANDROID_NDK_VERSION=('"$NDK_VER"')')
     DOCKER_BUILD_TOOLS=$(extract "$DOCKERFILE" 'ARG ANDROID_BUILD_TOOLS_VERSION=('"$NDK_VER"')')
     DOCKER_JDK_MAJOR=$(extract "$DOCKERFILE" 'ARG JDK_VERSION=([0-9]+)\.[0-9]+\.[0-9]+\+[0-9]+')
+    DOCKER_ANDROID_PLATFORM=$(extract "$DOCKERFILE" 'ARG ANDROID_PLATFORM=android-([0-9]+)')
     check_equal "Dockerfile rust version"        "$BR_RUST"        "$DOCKER_RUST"
     check_equal "Dockerfile cargo-ndk version"   "$BR_CARGO_NDK"   "$DOCKER_CARGO_NDK"
     check_equal "Dockerfile ndk version"         "$GRADLE_NDK"     "$DOCKER_NDK"
     check_equal "Dockerfile build-tools version" "$REL_BUILD_TOOLS" "$DOCKER_BUILD_TOOLS"
     check_equal "Dockerfile jdk major"           "$GRADLE_JDK"     "$DOCKER_JDK_MAJOR"
+    check_equal "Dockerfile android platform"    "$GRADLE_COMPILE_SDK" "$DOCKER_ANDROID_PLATFORM"
 else
     echo "note: $DOCKERFILE not present; skipping container-recipe checks."
 fi


### PR DESCRIPTION
Closes #228 (recipe portion). Remaining distribution-channel work tracked in separate issues.

## Summary

Adds a pinned, self-contained reproducible-build recipe for keep-android.

### What's included
- `REPRODUCIBLE_BUILDS.md`: end-to-end verification guide (host + container paths, apksigner + diffoscope comparison against the released APK).
- `Dockerfile.reproducible`: aligned with `keep/Dockerfile.reproducible` via the same Rust 1.89.0 pin and `keep.version` SHA lock. Hardened with:
  - base image digest + `--platform=linux/amd64` pin
  - Debian APT snapshot pinning
  - SHA-256-verified JDK, Android NDK, rustup-init, cargo-ndk
  - direct NDK download (not via sdkmanager) to close the supply-chain gap
  - conditional throwaway keystore; a real keystore can be mounted via `KEYSTORE_FILE` + `--secret` to reproduce released APK bytes end-to-end
  - `KEEP_REMOTE` override arg for mirrored source hosting
  - non-root `builder` user for the build stage
- `scripts/check-toolchain-pins.sh`: cross-file pin validator (rustc, cargo-ndk, NDK, JDK major, build-tools, AGP, Kotlin compose, KSP).
- `.github/workflows/reproducibility.yml`: double-build + diffoscope CI, runs on every tag and weekly.

### Follow-ups for acceptance #2 of #228 (distribution channel listing)
Tracked in separate issues:
- mlkit to open-source scanner swap (F-Droid blocker)
- full F-Droid dependency audit
- fdroiddata MR submission (depends on mlkit swap)
- IzzyOnDroid inclusion request (no mlkit blocker; fastest path)

## Test plan
- [x] `scripts/check-toolchain-pins.sh` passes
- [x] All shell RUN blocks in `Dockerfile.reproducible` pass `bash -n`
- [x] Dockerfile structure validated, no stray top-level directives
- [x] `reproducibility` CI workflow green on this branch (label the PR `reproducibility` to trigger)
