### PR TITLE
Add exodus-privacy scan report (0 trackers)

### DIFF
--- a/docs/audit/dependency-audit.md
+++ b/docs/audit/dependency-audit.md
@@ -1,0 +1,32 @@
+# Dependency Audit
+
+Audit of the release dependency tree for proprietary and tracker
+libraries, as a prerequisite for F-Droid / IzzyOnDroid submission.
+
+## Status
+
+- **Proprietary artifacts in `releaseRuntimeClasspath`:** none.
+- **Trackers in release APK:** none. See [`exodus-report.md`](exodus-report.md).
+
+## History
+
+- **Pre-swap audit (#244):** identified 17 proprietary artifacts
+  transitively pulled in by `com.google.mlkit:barcode-scanning`
+  (ML Kit, Play Services, Firebase, DataTransport, ODML).
+- **Swap (#248):** replaced Google ML Kit barcode scanning with
+  [ZXing](https://github.com/zxing/zxing), removing all 17 proprietary
+  artifacts from the release classpath.
+- **Post-swap re-audit (#244):** confirmed zero flagged artifacts.
+- **Exodus scan (#250):** confirmed zero trackers in the built release
+  APK, documented in [`exodus-report.md`](exodus-report.md).
+
+## Reproduce
+
+```sh
+JAVA_HOME=/path/to/jdk17 ANDROID_HOME=/path/to/android-sdk \
+  ./gradlew :app:dependencies --configuration releaseRuntimeClasspath
+```
+
+Scan the tree for `com.google.*` (ZXing core `com.google.zxing:core`
+is OSS and permitted). Any other `com.google.*` artifact is
+disqualifying and must have a replacement issue filed.

--- a/docs/audit/exodus-report.json
+++ b/docs/audit/exodus-report.json
@@ -1,0 +1,30 @@
+{
+  "application": {
+    "handle": "io.privkey.keep",
+    "version_name": "0.6.3",
+    "version_code": "11",
+    "uaid": "C9B43AAD88C7FBE5C8D69F936F0D99F98C59A61D",
+    "name": "Keep",
+    "permissions": [
+      "android.permission.FOREGROUND_SERVICE",
+      "android.permission.POST_NOTIFICATIONS",
+      "io.privkey.keep.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION",
+      "android.permission.USE_BIOMETRIC",
+      "android.permission.CAMERA",
+      "android.permission.ACCESS_NETWORK_STATE",
+      "android.permission.USE_FINGERPRINT",
+      "android.permission.FOREGROUND_SERVICE_DATA_SYNC",
+      "android.permission.RECEIVE_BOOT_COMPLETED",
+      "android.permission.INTERNET"
+    ],
+    "libraries": [
+      "androidx.window.extensions",
+      "androidx.window.sidecar"
+    ]
+  },
+  "apk": {
+    "path": "/app/app-release.apk",
+    "checksum": "c6bc53053325310efd726407c06d2c1f93721ed8b10492c3c05d227162eaf365"
+  },
+  "trackers": []
+}

--- a/docs/audit/exodus-report.md
+++ b/docs/audit/exodus-report.md
@@ -1,0 +1,45 @@
+# Exodus Privacy Scan
+
+Static tracker analysis of the release APK, performed with
+[exodus-standalone](https://github.com/Exodus-Privacy/exodus-standalone).
+
+## Result
+
+**0 trackers detected.**
+
+Raw JSON: [`exodus-report.json`](exodus-report.json)
+
+## Scan metadata
+
+| Field | Value |
+| --- | --- |
+| App | `io.privkey.keep` |
+| Version | 0.6.3 (code 11) |
+| APK SHA-256 | `c6bc53053325310efd726407c06d2c1f93721ed8b10492c3c05d227162eaf365` |
+| Scanner | `exodusprivacy/exodus-standalone` (Docker) |
+| Image digest | `sha256:a6531be9a6b666a8ffb6aec98b409cf6faf65536c5b9597e5b99195ca9422b88` |
+| Scanner tag | v1.5.0 |
+| Scan date | 2026-04-20 |
+
+## Reproduce
+
+From the repo root, build a release APK with the pinned toolchain (see
+[`REPRODUCIBLE_BUILDS.md`](../REPRODUCIBLE_BUILDS.md)), then:
+
+```sh
+docker run --rm \
+  -v "$(pwd)/app/build/outputs/apk/release:/app" \
+  exodusprivacy/exodus-standalone@sha256:a6531be9a6b666a8ffb6aec98b409cf6faf65536c5b9597e5b99195ca9422b88 \
+  /app/app-release.apk -j
+```
+
+Or upload the APK to the hosted scanner at
+<https://reports.exodus-privacy.eu.org/en/analysis/submit/>.
+
+## Context
+
+This scan is the runtime confirmation of the static dependency audit
+(issue #244, resolved in #248 by replacing Google ML Kit with ZXing). The
+audit established that `releaseRuntimeClasspath` contains zero artifacts
+from Google Play Services / ML Kit / Firebase / DataTransport. This scan
+confirms that property holds against the built APK.


### PR DESCRIPTION
Closes #250.

## Summary
- Builds release APK and runs `exodusprivacy/exodus-standalone` against it.
- Result: **0 trackers detected.**
- Commits raw JSON, narrative report with reproduction steps (pinned image digest + APK SHA-256), and a dependency-audit history doc tying #244 → #248 → #250 together.

## Files
- `docs/audit/exodus-report.json` raw scan output
- `docs/audit/exodus-report.md` narrative, metadata, reproduce steps
- `docs/audit/dependency-audit.md` audit history referenced by #250

## Test plan
- [x] Fresh release APK built with pinned toolchain (JDK 17, reproducible keep checkout)
- [x] Exodus scan completed, JSON `trackers` array is empty
- [x] APK SHA-256 and scanner image digest recorded for reproducibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive dependency audit documentation with current status and historical records
  * Added tracker scan report confirming zero trackers detected in the release APK
  * Included reproducible verification instructions for auditing dependencies and scanning for trackers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->