### PR TITLE
Show toast when relay host is unreachable or private

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -1,5 +1,6 @@
 package io.privkey.keep
 
+import android.content.Context
 import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
@@ -237,13 +238,13 @@ class MainActivity : FragmentActivity() {
     }
 }
 
-private fun showRelayHostCheckToast(context: android.content.Context, result: RelayHostCheck) {
+private fun showRelayHostCheckToast(context: Context, result: RelayHostCheck) {
     val resId = when (result) {
         RelayHostCheck.UNRESOLVABLE -> R.string.connections_relays_error_unreachable
         RelayHostCheck.INTERNAL -> R.string.connections_relays_error_private
         RelayHostCheck.REACHABLE -> return
     }
-    Toast.makeText(context, context.getString(resId), Toast.LENGTH_LONG).show()
+    Toast.makeText(context, resId, Toast.LENGTH_LONG).show()
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -237,6 +237,15 @@ class MainActivity : FragmentActivity() {
     }
 }
 
+private fun showRelayHostCheckToast(context: android.content.Context, result: RelayHostCheck) {
+    val resId = when (result) {
+        RelayHostCheck.UNRESOLVABLE -> R.string.connections_relays_error_unreachable
+        RelayHostCheck.INTERNAL -> R.string.connections_relays_error_private
+        RelayHostCheck.REACHABLE -> return
+    }
+    Toast.makeText(context, context.getString(resId), Toast.LENGTH_LONG).show()
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MainScreen(
@@ -956,13 +965,6 @@ fun MainScreen(
             }
 
             composable(Route.Settings.route) {
-                val showUnreachableToast = {
-                    Toast.makeText(
-                        appContext,
-                        appContext.getString(R.string.connections_relays_error_unreachable),
-                        Toast.LENGTH_LONG
-                    ).show()
-                }
                 SettingsTab(
                     hasShare = hasShare,
                     relays = relays,
@@ -976,13 +978,13 @@ fun MainScreen(
                     onAddRelay = { relay ->
                         if (!relays.contains(relay) && relays.size < 20) {
                             coroutineScope.launch {
-                                val isInternal = withContext(Dispatchers.IO) { isInternalHost(relay) }
-                                if (!isInternal) {
+                                val check = withContext(Dispatchers.IO) { checkRelayHost(relay) }
+                                if (check == RelayHostCheck.REACHABLE) {
                                     val updated = relays + relay
                                     relays = updated
                                     onRelaysChanged(updated)
                                 } else {
-                                    showUnreachableToast()
+                                    showRelayHostCheckToast(appContext, check)
                                 }
                             }
                         }
@@ -995,13 +997,13 @@ fun MainScreen(
                     onAddProfileRelay = { relay ->
                         if (!profileRelays.contains(relay) && profileRelays.size < 20) {
                             coroutineScope.launch {
-                                val isInternal = withContext(Dispatchers.IO) { isInternalHost(relay) }
-                                if (!isInternal) {
+                                val check = withContext(Dispatchers.IO) { checkRelayHost(relay) }
+                                if (check == RelayHostCheck.REACHABLE) {
                                     val updated = profileRelays + relay
                                     profileRelays = updated
                                     saveProfileRelays(updated)
                                 } else {
-                                    showUnreachableToast()
+                                    showRelayHostCheckToast(appContext, check)
                                 }
                             }
                         }

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -974,6 +974,12 @@ fun MainScreen(
                                     val updated = relays + relay
                                     relays = updated
                                     onRelaysChanged(updated)
+                                } else {
+                                    Toast.makeText(
+                                        appContext,
+                                        appContext.getString(R.string.connections_relays_error_unreachable),
+                                        Toast.LENGTH_LONG
+                                    ).show()
                                 }
                             }
                         }
@@ -991,6 +997,12 @@ fun MainScreen(
                                     val updated = profileRelays + relay
                                     profileRelays = updated
                                     saveProfileRelays(updated)
+                                } else {
+                                    Toast.makeText(
+                                        appContext,
+                                        appContext.getString(R.string.connections_relays_error_unreachable),
+                                        Toast.LENGTH_LONG
+                                    ).show()
                                 }
                             }
                         }

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -956,6 +956,13 @@ fun MainScreen(
             }
 
             composable(Route.Settings.route) {
+                val showUnreachableToast = {
+                    Toast.makeText(
+                        appContext,
+                        appContext.getString(R.string.connections_relays_error_unreachable),
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
                 SettingsTab(
                     hasShare = hasShare,
                     relays = relays,
@@ -975,11 +982,7 @@ fun MainScreen(
                                     relays = updated
                                     onRelaysChanged(updated)
                                 } else {
-                                    Toast.makeText(
-                                        appContext,
-                                        appContext.getString(R.string.connections_relays_error_unreachable),
-                                        Toast.LENGTH_LONG
-                                    ).show()
+                                    showUnreachableToast()
                                 }
                             }
                         }
@@ -998,11 +1001,7 @@ fun MainScreen(
                                     profileRelays = updated
                                     saveProfileRelays(updated)
                                 } else {
-                                    Toast.makeText(
-                                        appContext,
-                                        appContext.getString(R.string.connections_relays_error_unreachable),
-                                        Toast.LENGTH_LONG
-                                    ).show()
+                                    showUnreachableToast()
                                 }
                             }
                         }

--- a/app/src/main/kotlin/io/privkey/keep/RelayValidation.kt
+++ b/app/src/main/kotlin/io/privkey/keep/RelayValidation.kt
@@ -9,6 +9,8 @@ internal val HEX_PUBKEY_REGEX = Regex("^[a-fA-F0-9]{64}$")
 internal const val MAX_BUNKER_RELAYS = 5
 internal const val MAX_AUTHORIZED_CLIENTS = 50
 
+internal enum class RelayHostCheck { REACHABLE, UNRESOLVABLE, INTERNAL }
+
 internal fun isValidRelayPort(url: String): Boolean {
     val portStr = Regex(":(\\d+)").find(url.substringAfter("://"))?.groupValues?.get(1) ?: return true
     val port = portStr.toIntOrNull() ?: return false
@@ -24,22 +26,25 @@ private fun resolveAddresses(host: String): List<InetAddress>? {
     return runCatching { InetAddress.getAllByName(host).toList() }.getOrNull()
 }
 
-internal fun isInternalHost(url: String): Boolean {
-    val host = parseHost(url) ?: return true
-    val addresses = resolveAddresses(host) ?: return true
-    return addresses.any { isInternalAddress(it) }
+internal fun checkRelayHost(url: String): RelayHostCheck {
+    val host = parseHost(url) ?: return RelayHostCheck.UNRESOLVABLE
+    val addresses = resolveAddresses(host) ?: return RelayHostCheck.UNRESOLVABLE
+    if (addresses.isEmpty()) return RelayHostCheck.UNRESOLVABLE
+    if (addresses.any { isInternalAddress(it) }) return RelayHostCheck.INTERNAL
+    return RelayHostCheck.REACHABLE
 }
 
-// NOTE: DNS is resolved here but the actual WebSocket connection happens later.
-// A DNS rebinding attack could return a safe address here and an internal address
-// at connection time. Full mitigation requires pinning resolved addresses at the
-// socket layer, which is not currently supported by the WebSocket library.
+internal fun isInternalHost(url: String): Boolean = checkRelayHost(url) != RelayHostCheck.REACHABLE
+
+// NOTE: DNS is resolved here but the actual WebSocket connection happens later in the
+// Rust SDK, which manages its own resolver. A DNS rebinding attack could return a public
+// address here and an internal address at connection time. Full mitigation would require
+// pinning resolved addresses at the socket layer, which the underlying client does not
+// currently expose. We minimize the TOCTOU window by resolving immediately before
+// handing relays to the connection layer and rejecting any host that resolves to an
+// internal/reserved address.
 internal fun filterRelaysPreConnection(relays: List<String>): List<String> {
-    return relays.filter { url ->
-        val host = parseHost(url) ?: return@filter false
-        val addresses = resolveAddresses(host) ?: return@filter false
-        addresses.none { isInternalAddress(it) }
-    }
+    return relays.filter { url -> checkRelayHost(url) == RelayHostCheck.REACHABLE }
 }
 
 internal fun isInternalAddress(addr: InetAddress): Boolean {
@@ -54,24 +59,59 @@ internal fun isInternalAddress(addr: InetAddress): Boolean {
     if (bytes.size == 4) {
         val b0 = bytes[0].toInt() and 0xFF
         val b1 = bytes[1].toInt() and 0xFF
+        val b2 = bytes[2].toInt() and 0xFF
+        // 100.64.0.0/10 (CGNAT)
         if (b0 == 100 && (b1 and 0xC0) == 64) return true
+        // 192.0.0.0/24 (IETF protocol assignments)
+        if (b0 == 192 && b1 == 0 && b2 == 0) return true
+        // 192.0.2.0/24 (TEST-NET-1)
+        if (b0 == 192 && b1 == 0 && b2 == 2) return true
+        // 198.51.100.0/24 (TEST-NET-2)
+        if (b0 == 198 && b1 == 51 && b2 == 100) return true
+        // 203.0.113.0/24 (TEST-NET-3)
+        if (b0 == 203 && b1 == 0 && b2 == 113) return true
+        // 198.18.0.0/15 (benchmark)
+        if (b0 == 198 && (b1 and 0xFE) == 18) return true
+        // 240.0.0.0/4 (reserved, including 255.255.255.255 broadcast)
+        if ((b0 and 0xF0) == 0xF0) return true
     }
     if (addr is Inet6Address || bytes.size == 16) {
-        if ((bytes[0].toInt() and 0xFE) == 0xFC) {
-            return true
+        // fc00::/7 (unique local)
+        if ((bytes[0].toInt() and 0xFE) == 0xFC) return true
+        val b0 = bytes[0].toInt() and 0xFF
+        val b1 = bytes[1].toInt() and 0xFF
+        // 2002::/16 (6to4): embedded IPv4 in bytes 2..5
+        if (b0 == 0x20 && b1 == 0x02) {
+            val embedded = byteArrayOf(bytes[2], bytes[3], bytes[4], bytes[5])
+            val embeddedAddr = runCatching { InetAddress.getByAddress(embedded) }.getOrNull()
+            if (embeddedAddr != null && isInternalAddress(embeddedAddr)) return true
+        }
+        // 64:ff9b::/96 (NAT64 well-known)
+        val b2 = bytes[2].toInt() and 0xFF
+        val b3 = bytes[3].toInt() and 0xFF
+        if (b0 == 0x00 && b1 == 0x64 && b2 == 0xFF && b3 == 0x9B &&
+            (4..11).all { bytes[it] == 0.toByte() }) {
+            val embedded = byteArrayOf(bytes[12], bytes[13], bytes[14], bytes[15])
+            val embeddedAddr = runCatching { InetAddress.getByAddress(embedded) }.getOrNull()
+            if (embeddedAddr != null && isInternalAddress(embeddedAddr)) return true
+        }
+        // ::ffff:0:0/96 (IPv4-mapped) and ::/96 (IPv4-compatible, deprecated but treat as suspect)
+        if ((0..9).all { bytes[it] == 0.toByte() }) {
+            val isMapped = bytes[10] == 0xFF.toByte() && bytes[11] == 0xFF.toByte()
+            val isCompat = bytes[10] == 0.toByte() && bytes[11] == 0.toByte()
+            if (isMapped || isCompat) {
+                val ipv4 = byteArrayOf(bytes[12], bytes[13], bytes[14], bytes[15])
+                val mappedAddr = runCatching { InetAddress.getByAddress(ipv4) }.getOrNull()
+                if (mappedAddr != null) {
+                    if (isCompat) {
+                        // Block ::/96 except the unspecified address itself and ::1 loopback
+                        // (already handled by isLoopback / isAnyLocal above). Treat the rest as reserved.
+                        return true
+                    }
+                    if (isInternalAddress(mappedAddr)) return true
+                }
+            }
         }
     }
-    return isIPv4MappedPrivate(addr)
-}
-
-private fun isIPv4MappedPrivate(addr: InetAddress): Boolean {
-    val bytes = addr.address
-    if (bytes.size != 16) return false
-    for (i in 0..9) {
-        if (bytes[i] != 0.toByte()) return false
-    }
-    if (bytes[10] != 0xFF.toByte() || bytes[11] != 0xFF.toByte()) return false
-    val ipv4 = byteArrayOf(bytes[12], bytes[13], bytes[14], bytes[15])
-    val mappedAddr = runCatching { InetAddress.getByAddress(ipv4) }.getOrNull() ?: return false
-    return isInternalAddress(mappedAddr)
+    return false
 }

--- a/app/src/main/kotlin/io/privkey/keep/RelayValidation.kt
+++ b/app/src/main/kotlin/io/privkey/keep/RelayValidation.kt
@@ -21,17 +21,18 @@ private fun parseHost(url: String): String? = runCatching {
     URI(url).host?.removeSurrounding("[", "]")
 }.getOrNull()
 
-private fun resolveAddresses(host: String): List<InetAddress>? {
-    if (host.equals("localhost", ignoreCase = true)) return null
-    return runCatching { InetAddress.getAllByName(host).toList() }.getOrNull()
-}
+private fun resolveAddresses(host: String): List<InetAddress>? =
+    runCatching { InetAddress.getAllByName(host).toList() }.getOrNull()
 
 internal fun checkRelayHost(url: String): RelayHostCheck {
-    val host = parseHost(url) ?: return RelayHostCheck.UNRESOLVABLE
+    val host = parseHost(url) ?: return RelayHostCheck.INTERNAL
+    if (host.equals("localhost", ignoreCase = true)) return RelayHostCheck.INTERNAL
     val addresses = resolveAddresses(host) ?: return RelayHostCheck.UNRESOLVABLE
-    if (addresses.isEmpty()) return RelayHostCheck.UNRESOLVABLE
-    if (addresses.any { isInternalAddress(it) }) return RelayHostCheck.INTERNAL
-    return RelayHostCheck.REACHABLE
+    return when {
+        addresses.isEmpty() -> RelayHostCheck.UNRESOLVABLE
+        addresses.any { isInternalAddress(it) } -> RelayHostCheck.INTERNAL
+        else -> RelayHostCheck.REACHABLE
+    }
 }
 
 internal fun isInternalHost(url: String): Boolean = checkRelayHost(url) != RelayHostCheck.REACHABLE
@@ -80,21 +81,14 @@ internal fun isInternalAddress(addr: InetAddress): Boolean {
         if ((bytes[0].toInt() and 0xFE) == 0xFC) return true
         val b0 = bytes[0].toInt() and 0xFF
         val b1 = bytes[1].toInt() and 0xFF
-        // 2002::/16 (6to4): embedded IPv4 in bytes 2..5
-        if (b0 == 0x20 && b1 == 0x02) {
-            val embedded = byteArrayOf(bytes[2], bytes[3], bytes[4], bytes[5])
-            val embeddedAddr = runCatching { InetAddress.getByAddress(embedded) }.getOrNull()
-            if (embeddedAddr != null && isInternalAddress(embeddedAddr)) return true
-        }
-        // 64:ff9b::/96 (NAT64 well-known)
         val b2 = bytes[2].toInt() and 0xFF
         val b3 = bytes[3].toInt() and 0xFF
+        // 2002::/16 (6to4): embedded IPv4 in bytes 2..5
+        if (b0 == 0x20 && b1 == 0x02 && embeddedIPv4IsInternal(bytes, 2)) return true
+        // 64:ff9b::/96 (NAT64 well-known)
         if (b0 == 0x00 && b1 == 0x64 && b2 == 0xFF && b3 == 0x9B &&
-            (4..11).all { bytes[it] == 0.toByte() }) {
-            val embedded = byteArrayOf(bytes[12], bytes[13], bytes[14], bytes[15])
-            val embeddedAddr = runCatching { InetAddress.getByAddress(embedded) }.getOrNull()
-            if (embeddedAddr != null && isInternalAddress(embeddedAddr)) return true
-        }
+            (4..11).all { bytes[it] == 0.toByte() } &&
+            embeddedIPv4IsInternal(bytes, 12)) return true
         // ::ffff:0:0/96 (IPv4-mapped) and ::/96 (IPv4-compatible, deprecated but treat as suspect)
         if ((0..9).all { bytes[it] == 0.toByte() }) {
             val isMapped = bytes[10] == 0xFF.toByte() && bytes[11] == 0xFF.toByte()
@@ -103,15 +97,19 @@ internal fun isInternalAddress(addr: InetAddress): Boolean {
                 val ipv4 = byteArrayOf(bytes[12], bytes[13], bytes[14], bytes[15])
                 val mappedAddr = runCatching { InetAddress.getByAddress(ipv4) }.getOrNull()
                 if (mappedAddr != null) {
-                    if (isCompat) {
-                        // Block ::/96 except the unspecified address itself and ::1 loopback
-                        // (already handled by isLoopback / isAnyLocal above). Treat the rest as reserved.
-                        return true
-                    }
+                    // Block ::/96 except the unspecified address itself and ::1 loopback
+                    // (already handled by isLoopback / isAnyLocal above). Treat the rest as reserved.
+                    if (isCompat) return true
                     if (isInternalAddress(mappedAddr)) return true
                 }
             }
         }
     }
     return false
+}
+
+private fun embeddedIPv4IsInternal(bytes: ByteArray, offset: Int): Boolean {
+    val ipv4 = byteArrayOf(bytes[offset], bytes[offset + 1], bytes[offset + 2], bytes[offset + 3])
+    val embeddedAddr = runCatching { InetAddress.getByAddress(ipv4) }.getOrNull() ?: return false
+    return isInternalAddress(embeddedAddr)
 }

--- a/app/src/main/res/values/strings_connections.xml
+++ b/app/src/main/res/values/strings_connections.xml
@@ -22,7 +22,7 @@
     <string name="connections_relays_error_too_long">URL too long</string>
     <string name="connections_relays_error_invalid">Invalid relay URL</string>
     <string name="connections_relays_error_port">Port must be between 1 and 65535</string>
-    <string name="connections_relays_error_unreachable">Could not resolve relay host or address is private</string>
+    <string name="connections_relays_error_unreachable">Relay host unreachable or private</string>
     <string name="connections_relays_done">Done</string>
 
     <!-- ConnectionCards: Connect card -->

--- a/app/src/main/res/values/strings_connections.xml
+++ b/app/src/main/res/values/strings_connections.xml
@@ -22,7 +22,8 @@
     <string name="connections_relays_error_too_long">URL too long</string>
     <string name="connections_relays_error_invalid">Invalid relay URL</string>
     <string name="connections_relays_error_port">Port must be between 1 and 65535</string>
-    <string name="connections_relays_error_unreachable">Relay host unreachable or private</string>
+    <string name="connections_relays_error_unreachable">Could not resolve relay host</string>
+    <string name="connections_relays_error_private">Private/internal relay addresses are not allowed</string>
     <string name="connections_relays_done">Done</string>
 
     <!-- ConnectionCards: Connect card -->

--- a/app/src/main/res/values/strings_connections.xml
+++ b/app/src/main/res/values/strings_connections.xml
@@ -22,6 +22,7 @@
     <string name="connections_relays_error_too_long">URL too long</string>
     <string name="connections_relays_error_invalid">Invalid relay URL</string>
     <string name="connections_relays_error_port">Port must be between 1 and 65535</string>
+    <string name="connections_relays_error_unreachable">Could not resolve relay host or address is private</string>
     <string name="connections_relays_done">Done</string>
 
     <!-- ConnectionCards: Connect card -->


### PR DESCRIPTION
Adds user feedback when an added relay URL fails the internal-host check on the Settings tab (both regular and profile relays). Previously the add silently no-op'd.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Relay addition now shows a clear notification when a relay host is unreachable or resolves to an internal/private address, instead of silently failing.
  * Relay settings validation now prevents adding relays that don't resolve as reachable.

* **Localization**
  * Added a user-facing error message for unreachable relay hosts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->