### PR TITLE
release: v1.0.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "io.privkey.keep"
         minSdk = 33
         targetSdk = 36
-        versionCode = 12
-        versionName = "1.0.0"
+        versionCode = 13
+        versionName = "1.0.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
App version bump to **1.0.1** (versionCode 13) for the v1.0.1 release.

Built against keep **v0.4.3** (pinned via `keep.version`, bumped in #275): imported-share aggregation fix (`Unknown identifier`), idempotent `generate_and_send_share` (no spurious `No nonces stored`), reorder-tolerant signing, group-member-scoped subscriptions. These land in the keep-mobile co-signer node used by the app.