### PR TITLE
Default relay to wss://bucket.coracle.social

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/KeepMobileApp.kt
+++ b/app/src/main/kotlin/io/privkey/keep/KeepMobileApp.kt
@@ -250,7 +250,9 @@ class KeepMobileApp : Application() {
             if (liveState != null && mobile.getShareInfo() != null) return
 
             val relays = getActiveRelays().ifEmpty {
-                listOf("wss://relay.damus.io", "wss://nos.lol", "wss://relay.primal.net")
+                // coracle reliably delivers the ephemeral (kind 24242) events FROST
+                // coordination depends on; most public relays drop them.
+                listOf("wss://bucket.coracle.social")
             }
             val store = storage
             withContext(initDispatcher) {


### PR DESCRIPTION
## Summary
Sets the default relay (used when none is configured) to **wss://bucket.coracle.social**, matching keep-startos and keep-desktop/keep-core.

## Why
coracle's relay reliably delivers the rapid ephemeral (kind 24242) events FROST coordination depends on; most public relays drop them, which causes missed or prematurely-rejected co-sign rounds. Previously the fallback was damus/nos.lol/primal.

Operators can still add more relays in the Connections screen for redundancy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the default relay endpoint configuration used in fallback scenarios to improve connection stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/privkeyio/keep-android/pull/279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->