### PR TITLE
Add live activity log for relay, bunker, and peer events

### DIFF
--- a/app/src/androidTest/kotlin/io/privkey/keep/nip55/PermissionDatabaseIntegrationTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/nip55/PermissionDatabaseIntegrationTest.kt
@@ -20,6 +20,7 @@ class PermissionDatabaseIntegrationTest {
     private lateinit var permissionDao: Nip55PermissionDao
     private lateinit var auditLogDao: Nip55AuditLogDao
     private lateinit var appSettingsDao: Nip55AppSettingsDao
+    private lateinit var eventLogDao: EventLogDao
 
     private fun createPermission(
         callerPackage: String = "com.test.app",
@@ -82,7 +83,22 @@ class PermissionDatabaseIntegrationTest {
         permissionDao = database.permissionDao()
         auditLogDao = database.auditLogDao()
         appSettingsDao = database.appSettingsDao()
+        eventLogDao = database.eventLogDao()
     }
+
+    private fun createEventLog(
+        timestamp: Long = System.currentTimeMillis(),
+        category: String = EventLogCategory.RELAY.name,
+        level: String = EventLogLevel.INFO.name,
+        source: String = "",
+        message: String = "event"
+    ) = EventLogEntry(
+        timestamp = timestamp,
+        category = category,
+        level = level,
+        source = source,
+        message = message
+    )
 
     @After
     fun teardown() {
@@ -359,5 +375,94 @@ class PermissionDatabaseIntegrationTest {
         val all = permissionDao.getAll()
         assertEquals(1, all.size)
         assertEquals("deny", all[0].decision)
+    }
+
+    @Test
+    fun eventLogInsertAndCount() = runBlocking {
+        assertEquals(0, eventLogDao.getCount())
+        eventLogDao.insert(createEventLog(message = "first"))
+        eventLogDao.insert(createEventLog(message = "second"))
+
+        assertEquals(2, eventLogDao.getCount())
+        val recent = eventLogDao.getRecent(10)
+        assertEquals(2, recent.size)
+        assertEquals("second", recent[0].message)
+        assertEquals("first", recent[1].message)
+    }
+
+    @Test
+    fun eventLogKeysetPagination() = runBlocking {
+        repeat(25) { i -> eventLogDao.insert(createEventLog(message = "event $i")) }
+
+        val page1 = eventLogDao.getPageBefore(Long.MAX_VALUE, 10)
+        assertEquals(10, page1.size)
+        val page2 = eventLogDao.getPageBefore(page1.last().id, 10)
+        assertEquals(10, page2.size)
+        val page3 = eventLogDao.getPageBefore(page2.last().id, 10)
+        assertEquals(5, page3.size)
+
+        val ids = (page1 + page2 + page3).map { it.id }
+        assertEquals(ids.size, ids.toSet().size)
+        assertEquals(ids, ids.sortedDescending())
+    }
+
+    @Test
+    fun eventLogKeysetPaginationStableUnderConcurrentInsert() = runBlocking {
+        repeat(10) { eventLogDao.insert(createEventLog(message = "initial")) }
+
+        val page1 = eventLogDao.getPageBefore(Long.MAX_VALUE, 5)
+        assertEquals(5, page1.size)
+
+        repeat(5) { eventLogDao.insert(createEventLog(message = "inserted later")) }
+
+        val page2 = eventLogDao.getPageBefore(page1.last().id, 5)
+        val combinedIds = (page1 + page2).map { it.id }
+        assertEquals(combinedIds.size, combinedIds.toSet().size)
+        assertTrue(page2.all { it.id < page1.last().id })
+    }
+
+    @Test
+    fun eventLogTrimToMostRecent() = runBlocking {
+        repeat(20) { i -> eventLogDao.insert(createEventLog(message = "event $i")) }
+
+        eventLogDao.trimToMostRecent(5)
+
+        assertEquals(5, eventLogDao.getCount())
+        val remaining = eventLogDao.getRecent(100)
+        assertEquals(5, remaining.size)
+        assertEquals("event 19", remaining[0].message)
+        assertEquals("event 15", remaining[4].message)
+    }
+
+    @Test
+    fun eventLogTrimNoOpWhenUnderCap() = runBlocking {
+        repeat(3) { eventLogDao.insert(createEventLog()) }
+
+        eventLogDao.trimToMostRecent(10)
+
+        assertEquals(3, eventLogDao.getCount())
+    }
+
+    @Test
+    fun eventLogDeleteOlderThan() = runBlocking {
+        val now = System.currentTimeMillis()
+        eventLogDao.insert(createEventLog(timestamp = now - 100000, message = "old"))
+        eventLogDao.insert(createEventLog(timestamp = now - 1000, message = "recent"))
+
+        eventLogDao.deleteOlderThan(now - 50000)
+
+        val remaining = eventLogDao.getRecent(100)
+        assertEquals(1, remaining.size)
+        assertEquals("recent", remaining[0].message)
+    }
+
+    @Test
+    fun eventLogDeleteAll() = runBlocking {
+        repeat(5) { eventLogDao.insert(createEventLog()) }
+
+        eventLogDao.deleteAll()
+
+        assertEquals(0, eventLogDao.getCount())
+        assertTrue(eventLogDao.getRecent(10).isEmpty())
     }
 }

--- a/app/src/main/kotlin/io/privkey/keep/ExportLogsScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ExportLogsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.content.FileProvider
+import io.privkey.keep.nip55.EventLogStore
 import io.privkey.keep.nip55.PermissionStore
 import io.privkey.keep.storage.AndroidKeystoreStorage
 import io.privkey.keep.uniffi.KeepMobile
@@ -53,6 +54,7 @@ fun ExportLogsScreen(
     storage: AndroidKeystoreStorage,
     signingAuditLog: SigningAuditLog?,
     permissionStore: PermissionStore?,
+    eventLogStore: EventLogStore?,
     foregroundServiceEnabled: Boolean,
     onDismiss: () -> Unit
 ) {
@@ -110,6 +112,7 @@ fun ExportLogsScreen(
                         storage = storage,
                         signingAuditLog = signingAuditLog,
                         permissionStore = permissionStore,
+                        eventLogStore = eventLogStore,
                         foregroundServiceEnabled = foregroundServiceEnabled
                     )
                 }
@@ -265,6 +268,7 @@ private suspend fun buildExportContent(
     storage: AndroidKeystoreStorage,
     signingAuditLog: SigningAuditLog?,
     permissionStore: PermissionStore?,
+    eventLogStore: EventLogStore?,
     foregroundServiceEnabled: Boolean
 ): String {
     val accountCountDisplay = runCatching { storage.listAllShares().size }.fold(
@@ -306,6 +310,23 @@ private suspend fun buildExportContent(
         }
     }
 
+    val activityLogResult = eventLogStore?.let { store ->
+        runCatching {
+            val total = store.getCount()
+            val entries = store.getRecent(1000)
+            val formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneId.systemDefault())
+            val text = entries.joinToString("\n") { e ->
+                val ts = formatter.format(Instant.ofEpochMilli(e.timestamp))
+                val src = if (e.source.isBlank()) "" else "${e.source} "
+                "$ts [${e.category}/${e.level}] $src${e.message}"
+            }
+            Triple(text, entries.size, total)
+        }.getOrElse { e ->
+            if (e is CancellationException) throw e
+            Triple("(export failed: ${e::class.simpleName})", 0, 0)
+        }
+    }
+
     return buildString {
         appendLine("=== Keep Diagnostics ===")
         appendLine("Exported: $timestamp")
@@ -340,6 +361,17 @@ private suspend fun buildExportContent(
                 appendLine("(truncated to $exported of $total entries)")
             }
             appendLine(json)
+        }
+        appendLine()
+        appendLine("=== Activity Log ===")
+        if (activityLogResult == null) {
+            appendLine("(unavailable)")
+        } else {
+            val (text, exported, total) = activityLogResult
+            if (total > exported) {
+                appendLine("(truncated to $exported of $total entries)")
+            }
+            if (text.isBlank()) appendLine("(no activity)") else appendLine(text)
         }
     }
 }

--- a/app/src/main/kotlin/io/privkey/keep/KeepMobileApp.kt
+++ b/app/src/main/kotlin/io/privkey/keep/KeepMobileApp.kt
@@ -206,7 +206,7 @@ class KeepMobileApp : Application() {
             permissionStore = store
             callerVerificationStore = CallerVerificationStore(this)
             autoSigningSafeguards = AutoSigningSafeguards(this)
-            val eventLog = EventLogStore(db)
+            val eventLog = EventLogStore.getInstance(db)
             eventLogStore = eventLog
             initializeSigningAuditLog(db)
             applicationScope.launch {

--- a/app/src/main/kotlin/io/privkey/keep/KeepMobileApp.kt
+++ b/app/src/main/kotlin/io/privkey/keep/KeepMobileApp.kt
@@ -11,6 +11,9 @@ import io.privkey.keep.descriptor.DescriptorSessionManager
 import io.privkey.keep.nip46.BunkerService
 import io.privkey.keep.nip55.AutoSigningSafeguards
 import io.privkey.keep.nip55.CallerVerificationStore
+import io.privkey.keep.nip55.EventLogCategory
+import io.privkey.keep.nip55.EventLogLevel
+import io.privkey.keep.nip55.EventLogStore
 import io.privkey.keep.nip55.Nip55Database
 import io.privkey.keep.nip55.PermissionStore
 import io.privkey.keep.service.KeepAliveService
@@ -25,10 +28,12 @@ import io.privkey.keep.storage.KillSwitchStore
 import io.privkey.keep.storage.PinStore
 import io.privkey.keep.storage.SignPolicyStore
 import io.privkey.keep.uniffi.BunkerConfigInfo
+import io.privkey.keep.uniffi.ConnectionStatus
 import io.privkey.keep.uniffi.KeepLiveState
 import io.privkey.keep.uniffi.KeepMobile
 import io.privkey.keep.uniffi.KeepStateCallback
 import io.privkey.keep.uniffi.Nip55Handler
+import io.privkey.keep.uniffi.PeerStatus
 import io.privkey.keep.uniffi.ProxyConfigInfo
 import io.privkey.keep.uniffi.RelayConfigInfo
 import io.privkey.keep.uniffi.SigningAuditLog
@@ -45,6 +50,7 @@ import java.util.UUID
 import javax.crypto.Cipher
 
 private const val TAG = "KeepMobileApp"
+private const val EVENT_LOG_MAX_AGE_MS = 7L * 24 * 60 * 60 * 1000
 
 class KeepMobileApp : Application() {
     private var keepMobile: KeepMobile? = null
@@ -60,6 +66,7 @@ class KeepMobileApp : Application() {
     private var callerVerificationStore: CallerVerificationStore? = null
     private var autoSigningSafeguards: AutoSigningSafeguards? = null
     private var signingAuditLog: SigningAuditLog? = null
+    private var eventLogStore: EventLogStore? = null
     private var networkManager: NetworkConnectivityManager? = null
     private var signingNotificationManager: SigningNotificationManager? = null
     private var initError: String? = null
@@ -78,6 +85,11 @@ class KeepMobileApp : Application() {
 
     @Volatile
     private var killSwitchMigrationFailed: Boolean = false
+
+    // Activity-log dedup state. Read/written only inside the state-callback's
+    // mainHandler.post block, so it is effectively single-threaded.
+    private var lastConnStatusKey: String? = null
+    private val lastPeerStatus = HashMap<UShort, PeerStatus>()
 
     override fun onCreate() {
         super.onCreate()
@@ -113,12 +125,63 @@ class KeepMobileApp : Application() {
                             applicationContext,
                             state.pendingRequests,
                         )
+                        captureActivityEvents(state)
                     }
                 }
             })
         }.onFailure { e ->
             initError = getString(R.string.keep_mobile_init_failed_error)
             if (BuildConfig.DEBUG) Log.e(TAG, "Failed to initialize KeepMobile: ${e::class.simpleName}", e)
+        }
+    }
+
+    // Called only on the main thread (from the state callback's mainHandler.post),
+    // so the dedup fields need no synchronization. Logs relay status only on
+    // transitions and peers only on per-share status changes; the first callback
+    // seeds state without emitting to avoid a startup burst.
+    private fun captureActivityEvents(state: KeepLiveState) {
+        val statusKey = connectionStatusKey(state.connectionStatus)
+        if (statusKey != lastConnStatusKey) {
+            val previous = lastConnStatusKey
+            lastConnStatusKey = statusKey
+            if (previous != null || state.connectionStatus !is ConnectionStatus.Disconnected) {
+                val (level, source, message) = connectionEventDetails(state.connectionStatus)
+                logActivityEvent(EventLogCategory.RELAY, level, source, message)
+            }
+        }
+
+        val seeded = lastPeerStatus.isNotEmpty()
+        for (peer in state.peers) {
+            val prev = lastPeerStatus[peer.shareIndex]
+            if (prev != peer.status) {
+                lastPeerStatus[peer.shareIndex] = peer.status
+                if (seeded || prev != null) {
+                    val label = peer.name?.takeIf { it.isNotBlank() } ?: "share #${peer.shareIndex}"
+                    val level = if (peer.status == PeerStatus.OFFLINE) EventLogLevel.WARN else EventLogLevel.INFO
+                    logActivityEvent(EventLogCategory.PEER, level, label, "peer ${peer.status.name.lowercase()}")
+                }
+            }
+        }
+    }
+
+    private fun connectionStatusKey(status: ConnectionStatus): String = when (status) {
+        is ConnectionStatus.Disconnected -> "disconnected"
+        is ConnectionStatus.Connecting -> "connecting"
+        is ConnectionStatus.Connected -> "connected"
+        is ConnectionStatus.Error -> "error:${status.message}"
+    }
+
+    private fun connectionEventDetails(status: ConnectionStatus): Triple<EventLogLevel, String, String> = when (status) {
+        is ConnectionStatus.Disconnected -> Triple(EventLogLevel.WARN, "", "disconnected")
+        is ConnectionStatus.Connecting -> Triple(EventLogLevel.INFO, "", "connecting")
+        is ConnectionStatus.Connected -> Triple(EventLogLevel.INFO, "", "connected")
+        is ConnectionStatus.Error -> Triple(EventLogLevel.ERROR, "", status.message)
+    }
+
+    private fun logActivityEvent(category: EventLogCategory, level: EventLogLevel, source: String, message: String) {
+        val store = eventLogStore ?: return
+        applicationScope.launch {
+            runCatching { store.log(category, level, source, message) }
         }
     }
 
@@ -143,10 +206,15 @@ class KeepMobileApp : Application() {
             permissionStore = store
             callerVerificationStore = CallerVerificationStore(this)
             autoSigningSafeguards = AutoSigningSafeguards(this)
+            val eventLog = EventLogStore(db)
+            eventLogStore = eventLog
             initializeSigningAuditLog(db)
             applicationScope.launch {
                 store.cleanupExpired()
                 callerVerificationStore?.cleanupExpiredNonces()
+                runCatching {
+                    eventLog.cleanupOld(System.currentTimeMillis() - EVENT_LOG_MAX_AGE_MS)
+                }
             }
         }.onFailure { e ->
             if (BuildConfig.DEBUG) Log.e(TAG, "Failed to initialize PermissionStore: ${e::class.simpleName}")
@@ -240,6 +308,8 @@ class KeepMobileApp : Application() {
     fun getAutoSigningSafeguards(): AutoSigningSafeguards? = autoSigningSafeguards
 
     fun getSigningAuditLog(): SigningAuditLog? = signingAuditLog
+
+    fun getEventLogStore(): EventLogStore? = eventLogStore
 
     fun getSigningNotificationManager(): SigningNotificationManager? = signingNotificationManager
 
@@ -373,6 +443,7 @@ class KeepMobileApp : Application() {
             runAccountSwitchCleanup("clear caller trust") { callerVerificationStore?.clearAllTrust() }
             runAccountSwitchCleanup("clear auto-signing state") { autoSigningSafeguards?.clearAll() }
             runAccountSwitchCleanup("clear signing audit log") { permissionStore?.clearAuditLog() }
+            runAccountSwitchCleanup("clear activity log") { eventLogStore?.clear() }
         }
     }
 

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -43,6 +43,7 @@ import io.privkey.keep.nip46.BunkerScreen
 import io.privkey.keep.nip46.BunkerService
 import io.privkey.keep.nip55.AppPermissionsScreen
 import io.privkey.keep.nip55.ConnectedAppsScreen
+import io.privkey.keep.nip55.EventLogScreen
 import io.privkey.keep.nip55.PermissionStore
 import io.privkey.keep.nip55.PermissionsManagementScreen
 import io.privkey.keep.nip55.SignPolicyScreen
@@ -296,6 +297,7 @@ fun MainScreen(
 
     val appLiveState = (LocalContext.current.applicationContext as? KeepMobileApp)?.liveState
     val signingAuditLog = (LocalContext.current.applicationContext as? KeepMobileApp)?.getSigningAuditLog()
+    val eventLogStore = (LocalContext.current.applicationContext as? KeepMobileApp)?.getEventLogStore()
     val peers = appLiveState?.peers ?: emptyList()
     val pendingCount = appLiveState?.pendingRequests?.size ?: 0
     val connectionStatus = appLiveState?.connectionStatus
@@ -322,6 +324,7 @@ fun MainScreen(
     var profileRelays by remember { mutableStateOf(emptyList<String>()) }
     var showSecuritySettings by remember { mutableStateOf(false) }
     var showExportLogs by remember { mutableStateOf(false) }
+    var showEventLog by remember { mutableStateOf(false) }
     var showBackupRestore by remember { mutableStateOf(false) }
     var showRecoverNsec by remember { mutableStateOf(false) }
     var showCreateAccountScreen by remember { mutableStateOf(false) }
@@ -526,6 +529,10 @@ fun MainScreen(
                 showSecuritySettings = false
                 showExportLogs = true
             },
+            onViewActivityLog = {
+                showSecuritySettings = false
+                showEventLog = true
+            },
             onDismiss = { showSecuritySettings = false }
         )
         return
@@ -537,10 +544,22 @@ fun MainScreen(
             storage = storage,
             signingAuditLog = signingAuditLog,
             permissionStore = permissionStore,
+            eventLogStore = eventLogStore,
             foregroundServiceEnabled = foregroundServiceEnabled,
             onDismiss = { showExportLogs = false }
         )
         return
+    }
+
+    if (showEventLog) {
+        if (eventLogStore != null) {
+            EventLogScreen(
+                eventLogStore = eventLogStore,
+                onDismiss = { showEventLog = false }
+            )
+            return
+        }
+        showEventLog = false
     }
 
     if (showBackupRestore) {

--- a/app/src/main/kotlin/io/privkey/keep/SecuritySettingsScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/SecuritySettingsScreen.kt
@@ -27,6 +27,7 @@ fun SecuritySettingsScreen(
     killSwitchEnabled: Boolean,
     onKillSwitchToggle: (Boolean) -> Unit,
     onExportLogs: () -> Unit,
+    onViewActivityLog: () -> Unit,
     onDismiss: () -> Unit
 ) {
     val context = LocalContext.current
@@ -78,6 +79,8 @@ fun SecuritySettingsScreen(
                 onToggle = onBiometricLockOnLaunchChanged,
                 biometricAvailable = biometricAvailable
             )
+
+            ActivityLogCard(onClick = onViewActivityLog)
 
             ExportLogsCard(onClick = onExportLogs)
 

--- a/app/src/main/kotlin/io/privkey/keep/SettingsCards.kt
+++ b/app/src/main/kotlin/io/privkey/keep/SettingsCards.kt
@@ -324,6 +324,28 @@ fun TorOrbotCard(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
+fun ActivityLogCard(onClick: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth(), onClick = onClick) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(stringResource(R.string.settings_activity_log_title), style = MaterialTheme.typography.titleMedium)
+                Text(
+                    stringResource(R.string.settings_activity_log_subtitle),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Text(stringResource(R.string.settings_activity_log_action), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
 fun ExportLogsCard(onClick: () -> Unit) {
     Card(modifier = Modifier.fillMaxWidth(), onClick = onClick) {
         Row(

--- a/app/src/main/kotlin/io/privkey/keep/nip46/BunkerService.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip46/BunkerService.kt
@@ -18,6 +18,9 @@ import io.privkey.keep.filterRelaysPreConnection
 import io.privkey.keep.KeepMobileApp
 import io.privkey.keep.MainActivity
 import io.privkey.keep.R
+import io.privkey.keep.nip55.EventLogCategory
+import io.privkey.keep.nip55.EventLogLevel
+import io.privkey.keep.nip55.EventLogStore
 import io.privkey.keep.nip55.Nip55Database
 import io.privkey.keep.nip55.PermissionDecision
 import io.privkey.keep.nip55.PermissionStore
@@ -236,6 +239,7 @@ class BunkerService : Service() {
     private var networkManager: NetworkConnectivityManager? = null
     private var keepMobileRef: io.privkey.keep.uniffi.KeepMobile? = null
     private var permissionStore: PermissionStore? = null
+    private var eventLogStore: EventLogStore? = null
 
     override fun onCreate() {
         super.onCreate()
@@ -270,7 +274,9 @@ class BunkerService : Service() {
 
         startForeground(NOTIFICATION_ID, createNotification(isActive = false))
 
-        permissionStore = PermissionStore(Nip55Database.getInstance(this))
+        val db = Nip55Database.getInstance(this)
+        permissionStore = PermissionStore(db)
+        eventLogStore = EventLogStore(db)
 
         val relays = runCatching { keepMobile.getRelayConfig(null).bunkerRelays }.getOrDefault(emptyList())
         if (relays.isEmpty()) {
@@ -329,6 +335,18 @@ class BunkerService : Service() {
 
                 override fun onConnect(pubkey: String, name: String) {
                     if (BuildConfig.DEBUG) Log.d(TAG, "Bunker: app connected ${pubkey.take(8)}")
+                    eventLogStore?.let { activityLog ->
+                        serviceScope.launch {
+                            runCatching {
+                                activityLog.log(
+                                    category = EventLogCategory.BUNKER,
+                                    level = EventLogLevel.INFO,
+                                    source = name.ifBlank { pubkey.take(8) },
+                                    message = "connected"
+                                )
+                            }
+                        }
+                    }
                 }
             }
 
@@ -405,6 +423,23 @@ class BunkerService : Service() {
     }
 
     private fun logBunkerEvent(event: BunkerLogEvent) {
+        eventLogStore?.let { activityLog ->
+            serviceScope.launch {
+                runCatching {
+                    val message = buildString {
+                        append(event.action)
+                        event.detail?.takeIf { it.isNotBlank() }?.let { append(": "); append(it) }
+                    }
+                    activityLog.log(
+                        category = EventLogCategory.BUNKER,
+                        level = if (event.success) EventLogLevel.INFO else EventLogLevel.WARN,
+                        source = event.app,
+                        message = message
+                    )
+                }
+            }
+        }
+
         val store = permissionStore ?: return
         val requestType = mapMethodToNip55RequestType(event.action) ?: return
         serviceScope.launch {
@@ -578,6 +613,7 @@ class BunkerService : Service() {
         bunkerHandler = null
         keepMobileRef = null
         permissionStore = null
+        eventLogStore = null
         _bunkerUrl.value = null
         _status.value = BunkerStatus.STOPPED
 

--- a/app/src/main/kotlin/io/privkey/keep/nip46/BunkerService.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip46/BunkerService.kt
@@ -276,7 +276,7 @@ class BunkerService : Service() {
 
         val db = Nip55Database.getInstance(this)
         permissionStore = PermissionStore(db)
-        eventLogStore = EventLogStore(db)
+        eventLogStore = EventLogStore.getInstance(db)
 
         val relays = runCatching { keepMobile.getRelayConfig(null).bunkerRelays }.getOrDefault(emptyList())
         if (relays.isEmpty()) {
@@ -335,18 +335,7 @@ class BunkerService : Service() {
 
                 override fun onConnect(pubkey: String, name: String) {
                     if (BuildConfig.DEBUG) Log.d(TAG, "Bunker: app connected ${pubkey.take(8)}")
-                    eventLogStore?.let { activityLog ->
-                        serviceScope.launch {
-                            runCatching {
-                                activityLog.log(
-                                    category = EventLogCategory.BUNKER,
-                                    level = EventLogLevel.INFO,
-                                    source = name.ifBlank { pubkey.take(8) },
-                                    message = "connected"
-                                )
-                            }
-                        }
-                    }
+                    logActivity(EventLogCategory.BUNKER, EventLogLevel.INFO, name.ifBlank { pubkey.take(8) }, "connected")
                 }
             }
 
@@ -422,23 +411,24 @@ class BunkerService : Service() {
         }
     }
 
-    private fun logBunkerEvent(event: BunkerLogEvent) {
-        eventLogStore?.let { activityLog ->
-            serviceScope.launch {
-                runCatching {
-                    val message = buildString {
-                        append(event.action)
-                        event.detail?.takeIf { it.isNotBlank() }?.let { append(": "); append(it) }
-                    }
-                    activityLog.log(
-                        category = EventLogCategory.BUNKER,
-                        level = if (event.success) EventLogLevel.INFO else EventLogLevel.WARN,
-                        source = event.app,
-                        message = message
-                    )
-                }
-            }
+    private fun logActivity(category: EventLogCategory, level: EventLogLevel, source: String, message: String) {
+        val activityLog = eventLogStore ?: return
+        serviceScope.launch {
+            runCatching { activityLog.log(category, level, source, message) }
         }
+    }
+
+    private fun logBunkerEvent(event: BunkerLogEvent) {
+        val message = buildString {
+            append(event.action)
+            event.detail?.takeIf { it.isNotBlank() }?.let { append(": "); append(it) }
+        }
+        logActivity(
+            EventLogCategory.BUNKER,
+            if (event.success) EventLogLevel.INFO else EventLogLevel.WARN,
+            event.app,
+            message
+        )
 
         val store = permissionStore ?: return
         val requestType = mapMethodToNip55RequestType(event.action) ?: return

--- a/app/src/main/kotlin/io/privkey/keep/nip55/EventLogDao.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/EventLogDao.kt
@@ -1,0 +1,29 @@
+package io.privkey.keep.nip55
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+
+@Dao
+interface EventLogDao {
+    @Insert
+    suspend fun insert(entry: EventLogEntry): Long
+
+    @Query("SELECT * FROM event_log ORDER BY id DESC LIMIT :limit OFFSET :offset")
+    suspend fun getPage(limit: Int, offset: Int): List<EventLogEntry>
+
+    @Query("SELECT * FROM event_log ORDER BY id DESC LIMIT :limit")
+    suspend fun getRecent(limit: Int): List<EventLogEntry>
+
+    @Query("SELECT COUNT(*) FROM event_log")
+    suspend fun getCount(): Int
+
+    @Query("DELETE FROM event_log WHERE timestamp < :before")
+    suspend fun deleteOlderThan(before: Long)
+
+    @Query("DELETE FROM event_log")
+    suspend fun deleteAll()
+
+    @Query("DELETE FROM event_log WHERE id < (SELECT MIN(id) FROM (SELECT id FROM event_log ORDER BY id DESC LIMIT :cap))")
+    suspend fun trimToMostRecent(cap: Int)
+}

--- a/app/src/main/kotlin/io/privkey/keep/nip55/EventLogDao.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/EventLogDao.kt
@@ -9,8 +9,8 @@ interface EventLogDao {
     @Insert
     suspend fun insert(entry: EventLogEntry): Long
 
-    @Query("SELECT * FROM event_log ORDER BY id DESC LIMIT :limit OFFSET :offset")
-    suspend fun getPage(limit: Int, offset: Int): List<EventLogEntry>
+    @Query("SELECT * FROM event_log WHERE id < :beforeId ORDER BY id DESC LIMIT :limit")
+    suspend fun getPageBefore(beforeId: Long, limit: Int): List<EventLogEntry>
 
     @Query("SELECT * FROM event_log ORDER BY id DESC LIMIT :limit")
     suspend fun getRecent(limit: Int): List<EventLogEntry>

--- a/app/src/main/kotlin/io/privkey/keep/nip55/EventLogEntities.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/EventLogEntities.kt
@@ -1,0 +1,25 @@
+package io.privkey.keep.nip55
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+enum class EventLogCategory { RELAY, BUNKER, PEER }
+
+enum class EventLogLevel { INFO, WARN, ERROR }
+
+@Entity(
+    tableName = "event_log",
+    indices = [
+        Index(value = ["timestamp"]),
+        Index(value = ["category", "timestamp"])
+    ]
+)
+data class EventLogEntry(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val timestamp: Long,
+    val category: String,
+    val level: String,
+    val source: String = "",
+    val message: String = ""
+)

--- a/app/src/main/kotlin/io/privkey/keep/nip55/EventLogScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/EventLogScreen.kt
@@ -1,0 +1,187 @@
+package io.privkey.keep.nip55
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import io.privkey.keep.R
+import io.privkey.keep.uniffi.formatTimestampDetailed
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+private const val PAGE_SIZE = 50
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EventLogScreen(
+    eventLogStore: EventLogStore,
+    onDismiss: () -> Unit
+) {
+    var logs by remember { mutableStateOf<List<EventLogEntry>>(emptyList()) }
+    var isLoading by remember { mutableStateOf(true) }
+    var isLoadingMore by remember { mutableStateOf(false) }
+    var hasMore by remember { mutableStateOf(true) }
+    var showClearDialog by remember { mutableStateOf(false) }
+    val coroutineScope = rememberCoroutineScope()
+    val listState = rememberLazyListState()
+
+    fun loadLogs(reset: Boolean = false) {
+        coroutineScope.launch {
+            if (reset) isLoading = true else isLoadingMore = true
+            val offset = if (reset) 0 else logs.size
+            val newLogs = withContext(Dispatchers.IO) {
+                runCatching { eventLogStore.getPage(PAGE_SIZE, offset) }.getOrDefault(emptyList())
+            }
+            logs = if (reset) newLogs else logs + newLogs
+            hasMore = newLogs.size == PAGE_SIZE
+            isLoading = false
+            isLoadingMore = false
+        }
+    }
+
+    LaunchedEffect(Unit) { loadLogs(reset = true) }
+
+    val shouldLoadMore by remember {
+        derivedStateOf {
+            val lastVisibleItem = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+            lastVisibleItem >= logs.size - 5 && hasMore && !isLoadingMore && !isLoading
+        }
+    }
+
+    LaunchedEffect(shouldLoadMore) {
+        if (shouldLoadMore) loadLogs(reset = false)
+    }
+
+    if (showClearDialog) {
+        AlertDialog(
+            onDismissRequest = { showClearDialog = false },
+            title = { Text(stringResource(R.string.activity_log_clear_dialog_title)) },
+            text = { Text(stringResource(R.string.activity_log_clear_dialog_text)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    showClearDialog = false
+                    coroutineScope.launch {
+                        withContext(Dispatchers.IO) { runCatching { eventLogStore.clear() } }
+                        loadLogs(reset = true)
+                    }
+                }) { Text(stringResource(R.string.activity_log_clear_confirm)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showClearDialog = false }) {
+                    Text(stringResource(R.string.activity_log_cancel))
+                }
+            }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.activity_log_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onDismiss) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.back))
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { showClearDialog = true }, enabled = logs.isNotEmpty()) {
+                        Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.activity_log_clear))
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            when {
+                isLoading -> CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                logs.isEmpty() -> Text(
+                    text = stringResource(R.string.activity_log_empty),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.align(Alignment.Center)
+                )
+                else -> LazyColumn(
+                    state = listState,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(items = logs, key = { it.id }) { entry -> EventLogCard(entry) }
+                    if (isLoadingMore) {
+                        item {
+                            Box(
+                                modifier = Modifier.fillMaxWidth().padding(16.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EventLogCard(entry: EventLogEntry) {
+    val containerColor = when (entry.level) {
+        EventLogLevel.ERROR.name -> MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.5f)
+        EventLogLevel.WARN.name -> MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.4f)
+        else -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+    }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = containerColor)
+    ) {
+        Column(modifier = Modifier.fillMaxWidth().padding(12.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(text = entry.category, style = MaterialTheme.typography.titleSmall)
+                Text(
+                    text = entry.level,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            if (entry.source.isNotBlank()) {
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = entry.source,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(text = entry.message, style = MaterialTheme.typography.bodyMedium)
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = formatTimestampDetailed(entry.timestamp / 1000),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/io/privkey/keep/nip55/EventLogScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/EventLogScreen.kt
@@ -39,9 +39,9 @@ fun EventLogScreen(
     fun loadLogs(reset: Boolean = false) {
         coroutineScope.launch {
             if (reset) isLoading = true else isLoadingMore = true
-            val offset = if (reset) 0 else logs.size
+            val beforeId = if (reset) Long.MAX_VALUE else (logs.lastOrNull()?.id ?: Long.MAX_VALUE)
             val newLogs = withContext(Dispatchers.IO) {
-                runCatching { eventLogStore.getPage(PAGE_SIZE, offset) }.getOrDefault(emptyList())
+                runCatching { eventLogStore.getPageBefore(beforeId, PAGE_SIZE) }.getOrDefault(emptyList())
             }
             logs = if (reset) newLogs else logs + newLogs
             hasMore = newLogs.size == PAGE_SIZE

--- a/app/src/main/kotlin/io/privkey/keep/nip55/EventLogStore.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/EventLogStore.kt
@@ -12,8 +12,8 @@ class EventLogStore(database: Nip55Database) {
                 timestamp = System.currentTimeMillis(),
                 category = category.name,
                 level = level.name,
-                source = source.take(MAX_SOURCE_LEN),
-                message = message.take(MAX_MESSAGE_LEN)
+                source = sanitize(source).take(MAX_SOURCE_LEN),
+                message = sanitize(message).take(MAX_MESSAGE_LEN)
             )
         )
         if (insertCounter.incrementAndGet() % TRIM_EVERY == 0) {
@@ -21,8 +21,8 @@ class EventLogStore(database: Nip55Database) {
         }
     }
 
-    suspend fun getPage(limit: Int, offset: Int): List<EventLogEntry> =
-        dao.getPage(limit.coerceIn(1, 100), offset.coerceAtLeast(0))
+    suspend fun getPageBefore(beforeId: Long, limit: Int): List<EventLogEntry> =
+        dao.getPageBefore(beforeId, limit.coerceIn(1, 100))
 
     suspend fun getRecent(limit: Int): List<EventLogEntry> =
         dao.getRecent(limit.coerceAtLeast(0))
@@ -38,5 +38,17 @@ class EventLogStore(database: Nip55Database) {
         private const val TRIM_EVERY = 64
         private const val MAX_SOURCE_LEN = 256
         private const val MAX_MESSAGE_LEN = 1024
+
+        private val CONTROL_CHARS = Regex("[\\u0000-\\u001F\\u007F]")
+
+        private fun sanitize(value: String): String = CONTROL_CHARS.replace(value, " ")
+
+        @Volatile
+        private var INSTANCE: EventLogStore? = null
+
+        fun getInstance(database: Nip55Database): EventLogStore =
+            INSTANCE ?: synchronized(this) {
+                INSTANCE ?: EventLogStore(database).also { INSTANCE = it }
+            }
     }
 }

--- a/app/src/main/kotlin/io/privkey/keep/nip55/EventLogStore.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/EventLogStore.kt
@@ -1,0 +1,42 @@
+package io.privkey.keep.nip55
+
+import java.util.concurrent.atomic.AtomicInteger
+
+class EventLogStore(database: Nip55Database) {
+    private val dao = database.eventLogDao()
+    private val insertCounter = AtomicInteger(0)
+
+    suspend fun log(category: EventLogCategory, level: EventLogLevel, source: String, message: String) {
+        dao.insert(
+            EventLogEntry(
+                timestamp = System.currentTimeMillis(),
+                category = category.name,
+                level = level.name,
+                source = source.take(MAX_SOURCE_LEN),
+                message = message.take(MAX_MESSAGE_LEN)
+            )
+        )
+        if (insertCounter.incrementAndGet() % TRIM_EVERY == 0) {
+            dao.trimToMostRecent(RING_CAP)
+        }
+    }
+
+    suspend fun getPage(limit: Int, offset: Int): List<EventLogEntry> =
+        dao.getPage(limit.coerceIn(1, 100), offset.coerceAtLeast(0))
+
+    suspend fun getRecent(limit: Int): List<EventLogEntry> =
+        dao.getRecent(limit.coerceAtLeast(0))
+
+    suspend fun getCount(): Int = dao.getCount()
+
+    suspend fun clear() = dao.deleteAll()
+
+    suspend fun cleanupOld(before: Long) = dao.deleteOlderThan(before)
+
+    companion object {
+        const val RING_CAP = 2000
+        private const val TRIM_EVERY = 64
+        private const val MAX_SOURCE_LEN = 256
+        private const val MAX_MESSAGE_LEN = 1024
+    }
+}

--- a/app/src/main/kotlin/io/privkey/keep/nip55/PermissionDatabase.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/PermissionDatabase.kt
@@ -8,12 +8,13 @@ import io.privkey.keep.storage.LegacyPrefsMigration
 import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
 import java.security.SecureRandom
 
-@Database(entities = [Nip55Permission::class, Nip55AuditLog::class, Nip55AppSettings::class, VelocityEntry::class], version = 7)
+@Database(entities = [Nip55Permission::class, Nip55AuditLog::class, Nip55AppSettings::class, VelocityEntry::class, EventLogEntry::class], version = 8)
 abstract class Nip55Database : RoomDatabase() {
     abstract fun permissionDao(): Nip55PermissionDao
     abstract fun auditLogDao(): Nip55AuditLogDao
     abstract fun appSettingsDao(): Nip55AppSettingsDao
     abstract fun velocityDao(): VelocityDao
+    abstract fun eventLogDao(): EventLogDao
 
     companion object {
         init {
@@ -88,7 +89,24 @@ abstract class Nip55Database : RoomDatabase() {
             }
         }
 
-        private val MIGRATIONS = arrayOf(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7)
+        private val MIGRATION_7_8 = object : Migration(7, 8) {
+            override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
+                db.execSQL("""
+                    CREATE TABLE IF NOT EXISTS event_log (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        timestamp INTEGER NOT NULL,
+                        category TEXT NOT NULL,
+                        level TEXT NOT NULL,
+                        source TEXT NOT NULL DEFAULT '',
+                        message TEXT NOT NULL DEFAULT ''
+                    )
+                """)
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_event_log_timestamp ON event_log(timestamp)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_event_log_category_timestamp ON event_log(category, timestamp)")
+            }
+        }
+
+        private val MIGRATIONS = arrayOf(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8)
 
         private fun getEncryptedPrefs(context: Context) =
             KeystoreEncryptedPrefs.create(context, PREFS_NAME)

--- a/app/src/main/res/values/strings_settings.xml
+++ b/app/src/main/res/values/strings_settings.xml
@@ -41,6 +41,20 @@
     <string name="settings_tor_activate">Activate</string>
     <string name="settings_tor_port_range_error">Port must be 1-65535</string>
 
+    <!-- ActivityLogCard -->
+    <string name="settings_activity_log_title">Activity Log</string>
+    <string name="settings_activity_log_subtitle">Live relay, bunker, and peer events</string>
+    <string name="settings_activity_log_action">View</string>
+
+    <!-- EventLogScreen -->
+    <string name="activity_log_title">Activity Log</string>
+    <string name="activity_log_empty">No activity yet</string>
+    <string name="activity_log_clear">Clear</string>
+    <string name="activity_log_clear_dialog_title">Clear Activity Log?</string>
+    <string name="activity_log_clear_dialog_text">This permanently removes all recorded activity events.</string>
+    <string name="activity_log_clear_confirm">Clear</string>
+    <string name="activity_log_cancel">Cancel</string>
+
     <!-- ExportLogsCard -->
     <string name="settings_export_logs_title">Export &amp; Share Logs</string>
     <string name="settings_export_logs_subtitle">Save diagnostics and audit history to a file</string>

--- a/app/src/main/res/values/strings_share.xml
+++ b/app/src/main/res/values/strings_share.xml
@@ -3,8 +3,8 @@
     <!-- ExportLogsScreen -->
     <string name="export_logs_title">Export &amp; Share Logs</string>
     <string name="export_logs_card_title">Diagnostic Logs</string>
-    <string name="export_logs_description">Collects app diagnostics into a plain text file. Includes: device manufacturer/model, Android version, app version and build type, account count, foreground service and Tor/proxy configuration, signing audit history (caller package names, caller display names, event kinds, and free-text reasons), and NIP-55 permission audit history. Does not include private keys, nsec, or seed words.</string>
-    <string name="export_logs_warning">Warning: audit entries include caller display names and free-text reasons supplied by third-party apps. These fields may contain personal information or attacker-controlled content. Review the file before sharing.</string>
+    <string name="export_logs_description">Collects app diagnostics into a plain text file. Includes: device manufacturer/model, Android version, app version and build type, account count, foreground service and Tor/proxy configuration, signing audit history (caller package names, caller display names, event kinds, and free-text reasons), NIP-55 permission audit history, and the activity log (relay connection events, bunker events with connected-app names and pubkey prefixes, and peer online/offline transitions with peer names). Does not include private keys, nsec, or seed words.</string>
+    <string name="export_logs_warning">Warning: audit and activity-log entries include caller display names, connected-app names and pubkey prefixes, peer names, and free-text reasons supplied by third-party apps and relays. These fields may contain personal information or attacker-controlled content. Review the file before sharing.</string>
     <string name="export_logs_save_to_file">Save to File</string>
     <string name="export_logs_share">Share</string>
     <string name="export_logs_saved_toast">Logs saved</string>


### PR DESCRIPTION
## Summary

Adds a live activity log that continuously captures runtime events, complementing the existing Export Logs (which only covers diagnostics + audit history). Reachable from Settings → Security → Activity Log.

Captured events:
- **Relay** connection-status transitions (connecting/connected/disconnected/error)
- **Peer** online/offline changes per FROST share
- **Bunker/NIP-46** activity (all `onLog` events, including ones previously dropped, plus `onConnect`)

## Changes

- **Storage**: new `EventLogEntry` + `EventLogDao` + `EventLogStore` in the existing encrypted `Nip55Database` (SQLCipher); schema v7→v8 via `MIGRATION_7_8`. Bounded by a 2000-row ring cap (trimmed every 64 inserts) and a 7-day age cleanup.
- **Capture**: relay/peer transitions logged in the `KeepStateCallback` (dedup state on the main thread, DB writes off it); bunker events logged from `BunkerService`. All writes are fire-and-forget and never block the signing path.
- **Viewer**: new `EventLogScreen` (paginated, level-colored cards, Clear with confirmation).
- **Export**: new `=== Activity Log ===` section in the diagnostics export (most-recent 1000 entries).
- **Privacy**: cleared on account switch, same as the signing/NIP-55 audit logs.

## Testing

- `compileDebugKotlin` + unit/androidTest source sets compile clean (JDK 17).
- Verified on a physical device via an upgrade install (exercises `MIGRATION_7_8`, no crash): card renders, viewer opens, connecting to relays produced a captured `RELAY/connected` event, and the Clear flow empties the log.