### PR TITLE
nip55: return RESULT_OK + rejected on user reject (not RESULT_CANCELED)

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/nip55/Nip55Activity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/Nip55Activity.kt
@@ -751,7 +751,7 @@ class Nip55Activity : FragmentActivity() {
             requestId = it.requestId
         }
 
-        val req = request ?: return finishWithError("User rejected")
+        val req = request ?: return finishWithError("Invalid request")
         val callerId = callerPackage
         val store = permissionStore
         val eventKind = req.eventKind()
@@ -761,7 +761,7 @@ class Nip55Activity : FragmentActivity() {
                 store.denyPermission(callerId, req.requestType, eventKind, duration)
                 store.logOperation(callerId, req.requestType, eventKind, "deny", wasAutomatic = false)
             }
-            finishWithError("User rejected")
+            finishWithRejection()
         }
     }
 
@@ -835,6 +835,21 @@ class Nip55Activity : FragmentActivity() {
         val resultIntent = Intent().apply {
             putExtra("results", json)
             putExtra("package", packageName)
+        }
+        setResult(RESULT_OK, resultIntent)
+        finish()
+    }
+
+    // A user rejection is NOT a signer failure: per NIP-55, return RESULT_OK with
+    // rejected=true so the client can tell a declined request from a crash
+    // (RESULT_CANCELED). finishWithError stays reserved for actual failures.
+    private fun finishWithRejection() {
+        cancelAllNotifications()
+        if (BuildConfig.DEBUG) Log.d(TAG, "User rejected request (requestId=$requestId)")
+        val resultIntent = Intent().apply {
+            putExtra("rejected", true)
+            putExtra("package", packageName)
+            requestId?.let { putExtra("id", it) }
         }
         setResult(RESULT_OK, resultIntent)
         finish()


### PR DESCRIPTION
## What

On the NIP-55 Intent path, a user rejection now returns `RESULT_OK` with `putExtra("rejected", true)` (plus echoed `id` + `package`) instead of `RESULT_CANCELED` + an `error` extra. Closes #328.

## Why

`nips/55.md` (Using Intents):
> A `resultCode` other than `Activity.RESULT_OK` means the _signer_ failed (e.g. it crashed), not that the _user_ rejected the request. When the _user_ rejects, the _signer_ returns `RESULT_OK` with a `rejected` extra set to `true`.

keep previously returned `RESULT_CANCELED` on user rejection, so a spec-compliant client read a deliberate decline as a signer crash (and might retry or surface the wrong error). The reference signer (Amber, `IntentUtils.kt:1039`) returns `RESULT_OK` + `rejected=true`; this matches it.

The batch path already returned `RESULT_OK` with `rejected:true` per item (#325), so the single path is now consistent.

## How

New `finishWithRejection()` (RESULT_OK + `rejected`/`id`/`package`); `handleReject` routes user rejection through it. `finishWithError` stays reserved for actual signer failures (`RESULT_CANCELED`). `denyPermission` + the `"deny"` audit entry are unchanged. ContentProvider path untouched.

## Compatibility note

Client-visible behavior change: a client that previously treated keep's `RESULT_CANCELED` as a rejection now receives `RESULT_OK` and must check the `rejected` extra (per spec). This is the spec-correct behavior.

## Testing

`assembleDebug` / `testDebugUnitTest` / `lintDebug` / `verifyNoProprietaryDeps` pass. Reject-result coverage is tracked under #323 (approval/reject path hardening).

Closes #328.