### PR TITLE
nip55: unit-test the batch accumulation decision (extract pure helper)

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/nip55/BatchAccumulation.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/BatchAccumulation.kt
@@ -1,0 +1,38 @@
+package io.privkey.keep.nip55
+
+import io.privkey.keep.uniffi.Nip55RequestType
+
+internal enum class BatchAccumulation { ACCUMULATE, DROP_OVER_CAP, RESET }
+
+/**
+ * Decides what happens to a newly-parsed NIP-55 request relative to the requests
+ * already pending in a singleTop [Nip55Activity]:
+ *
+ * - [BatchAccumulation.ACCUMULATE] — append it to the pending batch.
+ * - [BatchAccumulation.DROP_OVER_CAP] — ignore it; the batch is already at the cap.
+ * - [BatchAccumulation.RESET] — clear the pending batch and start fresh with it.
+ *
+ * Only same-caller *operation* requests accumulate. `get_public_key` never batches
+ * (neither a new one nor one already pending), and a request from a different
+ * caller resets — both guard against folding unrelated requests into one approval.
+ *
+ * Pure function: no Activity state, no native calls, fully unit-testable.
+ */
+internal fun batchAccumulationDecision(
+    pendingTypes: List<Nip55RequestType>,
+    pendingCaller: String?,
+    newType: Nip55RequestType,
+    newCaller: String,
+    maxBatchSize: Int
+): BatchAccumulation {
+    val batchable = newType != Nip55RequestType.GET_PUBLIC_KEY
+    val canAccumulate = pendingTypes.isNotEmpty() &&
+        batchable &&
+        pendingCaller == newCaller &&
+        pendingTypes.all { it != Nip55RequestType.GET_PUBLIC_KEY }
+    return when {
+        !canAccumulate -> BatchAccumulation.RESET
+        pendingTypes.size >= maxBatchSize -> BatchAccumulation.DROP_OVER_CAP
+        else -> BatchAccumulation.ACCUMULATE
+    }
+}

--- a/app/src/main/kotlin/io/privkey/keep/nip55/Nip55Activity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/Nip55Activity.kt
@@ -145,19 +145,24 @@ class Nip55Activity : FragmentActivity() {
         val parsedId = rawId?.takeIf { it.isNotBlank() } ?: parsed.id
 
         // Accumulate only same-caller operation requests (never get_public_key) up to the cap.
-        val batchable = parsed.requestType != Nip55RequestType.GET_PUBLIC_KEY
-        val canAccumulate = pending.isNotEmpty() &&
-            batchable &&
-            batchCaller == caller &&
-            pending.all { it.request.requestType != Nip55RequestType.GET_PUBLIC_KEY }
-        if (canAccumulate) {
-            if (pending.size >= MAX_BATCH_SIZE) {
+        when (
+            batchAccumulationDecision(
+                pendingTypes = pending.map { it.request.requestType },
+                pendingCaller = batchCaller,
+                newType = parsed.requestType,
+                newCaller = caller,
+                maxBatchSize = MAX_BATCH_SIZE
+            )
+        ) {
+            BatchAccumulation.DROP_OVER_CAP -> {
                 if (BuildConfig.DEBUG) Log.w(TAG, "Dropping batch request beyond cap of $MAX_BATCH_SIZE")
                 return
             }
-        } else {
-            cancelAllNotifications()
-            pending.clear()
+            BatchAccumulation.RESET -> {
+                cancelAllNotifications()
+                pending.clear()
+            }
+            BatchAccumulation.ACCUMULATE -> {} // keep pending; the new item is appended below
         }
 
         val item = PendingNip55Request(parsed, parsedId, uriStr ?: "")

--- a/app/src/test/kotlin/io/privkey/keep/nip55/BatchAccumulationTest.kt
+++ b/app/src/test/kotlin/io/privkey/keep/nip55/BatchAccumulationTest.kt
@@ -80,6 +80,17 @@ class BatchAccumulationTest {
     }
 
     @Test
+    fun atCapFromDifferentCallerResets() {
+        // The different-caller check must win over the cap check: a full batch from
+        // caller A must not cause caller B's request to be silently dropped.
+        val full = List(cap) { Nip55RequestType.SIGN_EVENT }
+        assertEquals(
+            BatchAccumulation.RESET,
+            decide(full, pendingCaller = app, newType = Nip55RequestType.SIGN_EVENT, newCaller = "com.other.app")
+        )
+    }
+
+    @Test
     fun oneBelowCapStillAccumulates() {
         val nearFull = List(cap - 1) { Nip55RequestType.SIGN_EVENT }
         assertEquals(

--- a/app/src/test/kotlin/io/privkey/keep/nip55/BatchAccumulationTest.kt
+++ b/app/src/test/kotlin/io/privkey/keep/nip55/BatchAccumulationTest.kt
@@ -1,0 +1,90 @@
+package io.privkey.keep.nip55
+
+import io.privkey.keep.uniffi.Nip55RequestType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Regression coverage for the NIP-55 batch grouping rules (gh #323), which gate
+ * which requests get folded into a single approval. Decisions only; the Activity
+ * flow (biometric/FROST/result codes) is native-bound and out of unit scope.
+ */
+class BatchAccumulationTest {
+
+    private val app = "com.test.app"
+    private val cap = 20
+
+    private fun decide(
+        pending: List<Nip55RequestType>,
+        pendingCaller: String?,
+        newType: Nip55RequestType,
+        newCaller: String = app
+    ) = batchAccumulationDecision(pending, pendingCaller, newType, newCaller, cap)
+
+    @Test
+    fun firstRequestResets() {
+        // Empty pending: nothing to accumulate into, so the request starts a batch.
+        assertEquals(
+            BatchAccumulation.RESET,
+            decide(emptyList(), pendingCaller = null, newType = Nip55RequestType.SIGN_EVENT)
+        )
+    }
+
+    @Test
+    fun sameCallerOperationAccumulates() {
+        assertEquals(
+            BatchAccumulation.ACCUMULATE,
+            decide(listOf(Nip55RequestType.SIGN_EVENT), app, Nip55RequestType.SIGN_EVENT)
+        )
+    }
+
+    @Test
+    fun encryptDecryptMixAccumulatesForSameCaller() {
+        assertEquals(
+            BatchAccumulation.ACCUMULATE,
+            decide(listOf(Nip55RequestType.SIGN_EVENT, Nip55RequestType.NIP44_ENCRYPT), app, Nip55RequestType.NIP44_DECRYPT)
+        )
+    }
+
+    @Test
+    fun differentCallerResets() {
+        assertEquals(
+            BatchAccumulation.RESET,
+            decide(listOf(Nip55RequestType.SIGN_EVENT), pendingCaller = app, newType = Nip55RequestType.SIGN_EVENT, newCaller = "com.other.app")
+        )
+    }
+
+    @Test
+    fun newGetPublicKeyNeverBatches() {
+        assertEquals(
+            BatchAccumulation.RESET,
+            decide(listOf(Nip55RequestType.SIGN_EVENT), app, Nip55RequestType.GET_PUBLIC_KEY)
+        )
+    }
+
+    @Test
+    fun pendingGetPublicKeyIsNeverBatchedInto() {
+        assertEquals(
+            BatchAccumulation.RESET,
+            decide(listOf(Nip55RequestType.GET_PUBLIC_KEY), app, Nip55RequestType.SIGN_EVENT)
+        )
+    }
+
+    @Test
+    fun atCapDropsOverflow() {
+        val full = List(cap) { Nip55RequestType.SIGN_EVENT }
+        assertEquals(
+            BatchAccumulation.DROP_OVER_CAP,
+            decide(full, app, Nip55RequestType.SIGN_EVENT)
+        )
+    }
+
+    @Test
+    fun oneBelowCapStillAccumulates() {
+        val nearFull = List(cap - 1) { Nip55RequestType.SIGN_EVENT }
+        assertEquals(
+            BatchAccumulation.ACCUMULATE,
+            decide(nearFull, app, Nip55RequestType.SIGN_EVENT)
+        )
+    }
+}


### PR DESCRIPTION
## What

Extracts the NIP-55 batch grouping rules out of `Nip55Activity.handleIntent` into a pure `batchAccumulationDecision(...)` function (`BatchAccumulation.kt`) and adds unit-test coverage. `handleIntent` now calls the helper; behavior is unchanged.

Advances #323 (does not close it — see Remaining).

## Why

The batch accumulation rules decide which requests get folded into a single approval — a security-relevant grouping that had **zero** test coverage. The permission model/store/parsing paths are already well-covered by existing tests; this was the genuine gap. Extracting the decision makes it testable on the JVM (no device/native), per the RMP testability principle.

## Decision rules (now covered)

`ACCUMULATE` only same-caller *operation* requests; `get_public_key` never batches (neither a new one nor one already pending); a different caller `RESET`s; at the cap, overflow is `DROP_OVER_CAP`. Behavior-preserving vs the previous inline logic.

## Tests

`BatchAccumulationTest` (8 cases): first-request reset, same-caller accumulate, encrypt/decrypt mix, different-caller reset, new `get_public_key` never batches, pending `get_public_key` never batched into, at-cap drop, one-below-cap accumulate. Runs in `testDebugUnitTest`. `assembleDebug` / `lintDebug` / `verifyNoProprietaryDeps` pass.

## Remaining for #323 (infra-blocked, not in this PR)

- Activity-flow end-to-end (batch TOCTOU consent binding, reject-result `setResult`): needs the Rust `.so` + a real biometric + FROST node, so it's instrumented-harness-only — can't be reached as JVM/Robolectric tests.
- NIP-46 bunker gating coverage (separate subsystem, same native dependency).

Refs #323.