### PR TITLE
nip55: verify get_public_key pubkey before persisting grants/trust

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/nip55/Nip55Activity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/Nip55Activity.kt
@@ -467,6 +467,14 @@ class Nip55Activity : FragmentActivity() {
                 val signResult = signOneRequest(req, requestId, nip55Handler, callerId, keystoreStorage, currentApp)
                 signResult
                     .onSuccess { response ->
+                        // Verify a get_public_key response BEFORE persisting any grant
+                        // or first-use trust, so a failed connect leaves no persisted
+                        // state (#330).
+                        val pubkeyError = verifyGetPublicKeyResult(response)
+                        if (pubkeyError != null) {
+                            finishWithError(pubkeyError)
+                            return@onSuccess
+                        }
                         recordGrantAndTrust(store, callerId, req, eventKind, duration)
                         // On a get_public_key connect, grant the checked pre-declared
                         // permission bundle so the ContentProvider can answer those
@@ -794,26 +802,34 @@ class Nip55Activity : FragmentActivity() {
         }
     }
 
+    // Returns an error code if a get_public_key response fails integrity verification
+    // (empty, or does not match the stored group pubkey), else null. Other request
+    // types trivially pass. Used both to gate grant/trust persistence before it
+    // happens and to gate returning the result.
+    private fun verifyGetPublicKeyResult(response: Nip55Response): String? {
+        if (request?.requestType != Nip55RequestType.GET_PUBLIC_KEY) return null
+        if (response.result.isEmpty()) {
+            if (BuildConfig.DEBUG) Log.e(TAG, "Handler returned empty pubkey result")
+            return "pubkey_verification_failed"
+        }
+        val groupPubkey = storage?.getShareMetadata()?.groupPubkey
+        if (groupPubkey == null || groupPubkey.isEmpty()) {
+            if (BuildConfig.DEBUG) Log.e(TAG, "Stored pubkey unavailable for verification")
+            return "pubkey_verification_failed"
+        }
+        val storedPubkey = groupPubkey.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+        if (!MessageDigest.isEqual(response.result.toByteArray(Charsets.UTF_8), storedPubkey.toByteArray(Charsets.UTF_8))) {
+            if (BuildConfig.DEBUG) Log.e(TAG, "Pubkey verification failed: mismatch detected")
+            return "pubkey_verification_failed"
+        }
+        return null
+    }
+
     private fun finishWithResult(response: Nip55Response) {
         cancelAllNotifications()
         val req = request
 
-        if (req?.requestType == Nip55RequestType.GET_PUBLIC_KEY) {
-            if (response.result.isEmpty()) {
-                if (BuildConfig.DEBUG) Log.e(TAG, "Handler returned empty pubkey result")
-                return finishWithError("pubkey_verification_failed")
-            }
-            val groupPubkey = storage?.getShareMetadata()?.groupPubkey
-            if (groupPubkey == null || groupPubkey.isEmpty()) {
-                if (BuildConfig.DEBUG) Log.e(TAG, "Stored pubkey unavailable for verification")
-                return finishWithError("pubkey_verification_failed")
-            }
-            val storedPubkey = groupPubkey.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
-            if (!MessageDigest.isEqual(response.result.toByteArray(Charsets.UTF_8), storedPubkey.toByteArray(Charsets.UTF_8))) {
-                if (BuildConfig.DEBUG) Log.e(TAG, "Pubkey verification failed: mismatch detected")
-                return finishWithError("pubkey_verification_failed")
-            }
-        }
+        verifyGetPublicKeyResult(response)?.let { return finishWithError(it) }
 
         if (BuildConfig.DEBUG) Log.d(TAG, "Returning result for ${req?.requestType?.name} (requestId=${requestId})")
         val resultIntent = Intent().apply {

--- a/app/src/main/kotlin/io/privkey/keep/nip55/Nip55Activity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/Nip55Activity.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.net.URL
-import java.security.MessageDigest
 import java.util.UUID
 import javax.crypto.Cipher
 
@@ -472,6 +471,7 @@ class Nip55Activity : FragmentActivity() {
                         // state (#330).
                         val pubkeyError = verifyGetPublicKeyResult(response)
                         if (pubkeyError != null) {
+                            store?.logOperation(callerId, req.requestType, eventKind, "pubkey_verification_failed", wasAutomatic = false)
                             finishWithError(pubkeyError)
                             return@onSuccess
                         }
@@ -802,33 +802,20 @@ class Nip55Activity : FragmentActivity() {
         }
     }
 
-    // Returns an error code if a get_public_key response fails integrity verification
-    // (empty, or does not match the stored group pubkey), else null. Other request
-    // types trivially pass. Used both to gate grant/trust persistence before it
-    // happens and to gate returning the result.
-    private fun verifyGetPublicKeyResult(response: Nip55Response): String? {
-        if (request?.requestType != Nip55RequestType.GET_PUBLIC_KEY) return null
-        if (response.result.isEmpty()) {
-            if (BuildConfig.DEBUG) Log.e(TAG, "Handler returned empty pubkey result")
-            return "pubkey_verification_failed"
-        }
-        val groupPubkey = storage?.getShareMetadata()?.groupPubkey
-        if (groupPubkey == null || groupPubkey.isEmpty()) {
-            if (BuildConfig.DEBUG) Log.e(TAG, "Stored pubkey unavailable for verification")
-            return "pubkey_verification_failed"
-        }
-        val storedPubkey = groupPubkey.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
-        if (!MessageDigest.isEqual(response.result.toByteArray(Charsets.UTF_8), storedPubkey.toByteArray(Charsets.UTF_8))) {
-            if (BuildConfig.DEBUG) Log.e(TAG, "Pubkey verification failed: mismatch detected")
-            return "pubkey_verification_failed"
-        }
-        return null
-    }
+    // Reads the captured request type and stored group pubkey, then delegates to
+    // the pure checkPubkey helper. Used both to gate grant/trust persistence before
+    // it happens and to gate returning the result.
+    private fun verifyGetPublicKeyResult(response: Nip55Response): String? =
+        checkPubkey(request?.requestType, response.result, storage?.getShareMetadata()?.groupPubkey)
 
     private fun finishWithResult(response: Nip55Response) {
         cancelAllNotifications()
         val req = request
 
+        // Defense-in-depth: the single-request path already verified this before
+        // persisting any grant/trust. This re-check intentionally duplicates that
+        // gate so other callers of finishWithResult can never return an unverified
+        // get_public_key result; do not assume either gate covers the other.
         verifyGetPublicKeyResult(response)?.let { return finishWithError(it) }
 
         if (BuildConfig.DEBUG) Log.d(TAG, "Returning result for ${req?.requestType?.name} (requestId=${requestId})")

--- a/app/src/main/kotlin/io/privkey/keep/nip55/PubkeyVerification.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/PubkeyVerification.kt
@@ -1,0 +1,38 @@
+package io.privkey.keep.nip55
+
+import android.util.Log
+import io.privkey.keep.BuildConfig
+import io.privkey.keep.uniffi.Nip55RequestType
+import java.security.MessageDigest
+
+private const val TAG = "PubkeyVerification"
+
+/**
+ * Integrity check for a get_public_key handler result. Returns an error code if
+ * the [resultString] is empty, the stored [groupPubkey] is missing/empty, or the
+ * two do not match (constant-time, on the hex-encoded bytes the handler emits);
+ * else null. Non-get_public_key request types trivially pass.
+ *
+ * Takes its inputs as parameters (no Activity state) so it is fully unit-testable.
+ */
+internal fun checkPubkey(
+    requestType: Nip55RequestType?,
+    resultString: String,
+    groupPubkey: ByteArray?
+): String? {
+    if (requestType != Nip55RequestType.GET_PUBLIC_KEY) return null
+    if (resultString.isEmpty()) {
+        if (BuildConfig.DEBUG) Log.e(TAG, "Handler returned empty pubkey result")
+        return "pubkey_verification_failed"
+    }
+    if (groupPubkey == null || groupPubkey.isEmpty()) {
+        if (BuildConfig.DEBUG) Log.e(TAG, "Stored pubkey unavailable for verification")
+        return "pubkey_verification_failed"
+    }
+    val storedPubkey = groupPubkey.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+    if (!MessageDigest.isEqual(resultString.toByteArray(Charsets.UTF_8), storedPubkey.toByteArray(Charsets.UTF_8))) {
+        if (BuildConfig.DEBUG) Log.e(TAG, "Pubkey verification failed: mismatch detected")
+        return "pubkey_verification_failed"
+    }
+    return null
+}

--- a/app/src/test/kotlin/io/privkey/keep/nip55/PubkeyVerificationTest.kt
+++ b/app/src/test/kotlin/io/privkey/keep/nip55/PubkeyVerificationTest.kt
@@ -1,0 +1,63 @@
+package io.privkey.keep.nip55
+
+import io.privkey.keep.uniffi.Nip55RequestType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Regression coverage for the get_public_key integrity gate (gh #330), which
+ * blocks persisting grants/trust and returning a result when a handler's pubkey
+ * does not match the stored group pubkey. The Activity wiring (storage/result
+ * codes) is native-bound and out of unit scope.
+ */
+class PubkeyVerificationTest {
+
+    private val pubkeyBytes = ByteArray(32) { it.toByte() }
+    private val pubkeyHex = pubkeyBytes.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+
+    @Test
+    fun emptyResultFails() {
+        assertEquals(
+            "pubkey_verification_failed",
+            checkPubkey(Nip55RequestType.GET_PUBLIC_KEY, "", pubkeyBytes)
+        )
+    }
+
+    @Test
+    fun nullStoredKeyFails() {
+        assertEquals(
+            "pubkey_verification_failed",
+            checkPubkey(Nip55RequestType.GET_PUBLIC_KEY, pubkeyHex, null)
+        )
+    }
+
+    @Test
+    fun emptyStoredKeyFails() {
+        assertEquals(
+            "pubkey_verification_failed",
+            checkPubkey(Nip55RequestType.GET_PUBLIC_KEY, pubkeyHex, ByteArray(0))
+        )
+    }
+
+    @Test
+    fun mismatchFails() {
+        val other = ByteArray(32) { (it + 1).toByte() }
+        assertEquals(
+            "pubkey_verification_failed",
+            checkPubkey(Nip55RequestType.GET_PUBLIC_KEY, pubkeyHex, other)
+        )
+    }
+
+    @Test
+    fun exactMatchPasses() {
+        assertNull(checkPubkey(Nip55RequestType.GET_PUBLIC_KEY, pubkeyHex, pubkeyBytes))
+    }
+
+    @Test
+    fun nonGetPublicKeyTypePasses() {
+        // Operation requests carry no pubkey to verify, so they trivially pass even
+        // with empty result and missing stored key.
+        assertNull(checkPubkey(Nip55RequestType.SIGN_EVENT, "", null))
+    }
+}


### PR DESCRIPTION
## What

On a `get_public_key` connect, the returned-pubkey integrity check now runs **before** any grant or first-use trust is persisted. Previously `recordGrantAndTrust` (first-use trust) and `grantDeclaredBundle` (the permissions bundle) ran first, and the pubkey check happened later in `finishWithResult` — so if the check failed, the connect was reported `pubkey_verification_failed` to the caller yet the persisted grants + trust remained. Closes #330.

## How

Extracted the check into `verifyGetPublicKeyResult(response): String?` (empty / stored-pubkey-mismatch → error code, else null; non-`get_public_key` trivially passes). `onSuccess` calls it before persisting and bails on failure; `finishWithResult` reuses the same function before returning (single source of the check, defense-in-depth).

## Behavior

- Happy path unchanged.
- Non-`get_public_key` requests (sign/encrypt/decrypt) trivially pass — no behavior change.
- Only change: on a pubkey mismatch (an internal integrity failure, not attacker-controlled input), no grant or first-use trust is persisted for a connect that's reported as failed.

## Testing

`assembleDebug` / `testDebugUnitTest` / `lintDebug` / `verifyNoProprietaryDeps` pass.

Closes #330.