### PR TITLE
nip55: anchor audit chain to resist tamper

### DIFF
--- a/app/src/androidTest/kotlin/io/privkey/keep/nip55/RiskAssessorInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/nip55/RiskAssessorInstrumentedTest.kt
@@ -221,6 +221,7 @@ class RiskAssessorInstrumentedTest {
         override suspend fun getDistinctCallers(): List<String> = emptyList()
         override suspend fun getLastUsedTimeForPermission(callerPackage: String, requestType: String, eventKind: Int): Long? = null
         override suspend fun getLastEntryHash(): String? = null
+        override suspend fun getLastPreviousHash(): String? = null
         override suspend fun getAllOrdered(): List<Nip55AuditLog> = emptyList()
         override suspend fun getCount(): Int = 0
         override suspend fun countByPackageAndKind(packageName: String, eventKind: Int): Int = kindCount

--- a/app/src/main/kotlin/io/privkey/keep/KeepMobileApp.kt
+++ b/app/src/main/kotlin/io/privkey/keep/KeepMobileApp.kt
@@ -232,7 +232,7 @@ class KeepMobileApp : Application() {
 
     private fun initializeSigningAuditLog(db: Nip55Database) {
         runCatching {
-            val storage = AndroidSigningAuditStorage(db.auditLogDao())
+            val storage = AndroidSigningAuditStorage(db)
             signingAuditLog = SigningAuditLog(storage)
         }.onFailure { e ->
             Log.e(TAG, "Failed to initialize SigningAuditLog: ${e::class.simpleName}")

--- a/app/src/main/kotlin/io/privkey/keep/nip55/AuditAnchor.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/AuditAnchor.kt
@@ -53,3 +53,24 @@ internal fun shouldSeed(anchor: AuditAnchor?, rustResult: ChainVerificationResul
     anchor == null &&
         (rustResult is ChainVerificationResult.Valid ||
             rustResult is ChainVerificationResult.PartiallyVerified)
+
+/**
+ * True when the DB is exactly one append ahead of the [anchor] and that newest row
+ * chains onto the anchored tail ([newestPreviousHash] == [AuditAnchor.latestEntryHash]).
+ *
+ * The anchor advances only after the Room transaction commits, so a crash (or a
+ * not-yet-visible concurrent append) can leave a legitimately-appended row durable
+ * while the anchor still trails by one. Re-pinning instead of flagging is safe: a
+ * forged extra row cannot carry a valid HMAC [Nip55AuditLog.entryHash], so it is
+ * still caught by the Rust walk at verify time. Callers that have a Rust result
+ * should additionally require [rustIntact] before treating this as benign.
+ */
+internal fun isResumableAppend(
+    anchor: AuditAnchor,
+    entryCount: Long,
+    newestPreviousHash: String?,
+    rustIntact: Boolean
+): Boolean =
+    rustIntact &&
+        entryCount == anchor.entryCount + 1L &&
+        newestPreviousHash == anchor.latestEntryHash

--- a/app/src/main/kotlin/io/privkey/keep/nip55/AuditAnchor.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/AuditAnchor.kt
@@ -17,15 +17,20 @@ data class AuditAnchor(val latestEntryHash: String, val entryCount: Long)
  * is never downgraded. A null anchor (first run on an upgraded install) defers to
  * the Rust result so the caller can trust-on-first-use seed it.
  *
+ * A set [tamperDetected] sticky flag (out-of-band mutation caught at append/prune
+ * time) is authoritative: it overrides any now-consistent chain the walk reports.
+ *
  * Pure function: no storage, no native calls, fully unit-testable.
  */
 internal fun resolveChainVerification(
+    tamperDetected: Boolean,
     anchor: AuditAnchor?,
     entryCount: Long,
     latestEntryHash: String,
     latestEntryId: Long,
     rustResult: ChainVerificationResult
 ): ChainVerificationResult {
+    if (tamperDetected) return ChainVerificationResult.Tampered(latestEntryId)
     if (rustResult is ChainVerificationResult.Broken || rustResult is ChainVerificationResult.Tampered) {
         return rustResult
     }
@@ -38,3 +43,13 @@ internal fun resolveChainVerification(
     }
     return rustResult
 }
+
+/**
+ * Trust-on-first-use seed decision: only seed the anchor when there is none yet
+ * (fresh/upgraded install) AND the Rust walk reports an intact chain, so a
+ * corrupt chain is never baselined as the source of truth.
+ */
+internal fun shouldSeed(anchor: AuditAnchor?, rustResult: ChainVerificationResult): Boolean =
+    anchor == null &&
+        (rustResult is ChainVerificationResult.Valid ||
+            rustResult is ChainVerificationResult.PartiallyVerified)

--- a/app/src/main/kotlin/io/privkey/keep/nip55/AuditAnchor.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/AuditAnchor.kt
@@ -73,4 +73,24 @@ internal fun isResumableAppend(
 ): Boolean =
     rustIntact &&
         entryCount == anchor.entryCount + 1L &&
-        newestPreviousHash == anchor.latestEntryHash
+        // The first row after a reset chains onto the empty zero anchor: its
+        // previousHash is null, which must read as equal to the "" anchor tail.
+        (newestPreviousHash ?: "") == anchor.latestEntryHash
+
+/**
+ * True when the DB has fewer rows than the [anchor] but its newest row's hash still
+ * matches the anchored tail. That is exactly the footprint of a head prune (oldest
+ * rows removed, tail untouched) whose post-commit anchor advance was lost to a crash:
+ * safe to re-pin to the lower count. Tail truncation deletes the newest rows, so the
+ * tail hash would differ and this stays false. Callers must require [rustIntact].
+ */
+internal fun isResumablePrune(
+    anchor: AuditAnchor,
+    entryCount: Long,
+    latestEntryHash: String,
+    rustIntact: Boolean
+): Boolean =
+    rustIntact &&
+        entryCount < anchor.entryCount &&
+        entryCount > 0L &&
+        latestEntryHash == anchor.latestEntryHash

--- a/app/src/main/kotlin/io/privkey/keep/nip55/AuditAnchor.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/AuditAnchor.kt
@@ -41,6 +41,13 @@ internal fun resolveChainVerification(
     if (entryCount < anchor.entryCount || latestEntryHash != anchor.latestEntryHash) {
         return ChainVerificationResult.Truncated(latestEntryId)
     }
+    // Anchor matches the DB exactly (count + tail). A Rust Truncated here means the head
+    // row's previousHash dangles, a sanctioned head prune whose post-commit anchor we
+    // already advanced, not an attack: deleting head rows drops count below the anchor
+    // (caught above) and altering the tail fails the tail-hash check above. The keystore
+    // anchor (which a Room-write attacker cannot forge) vouches that this exact (count,
+    // tail) is the pruned state, so trust it over the dangling-head walk.
+    if (rustResult is ChainVerificationResult.Truncated) return ChainVerificationResult.Valid
     return rustResult
 }
 
@@ -64,14 +71,21 @@ internal fun shouldSeed(anchor: AuditAnchor?, rustResult: ChainVerificationResul
  * forged extra row cannot carry a valid HMAC [Nip55AuditLog.entryHash], so it is
  * still caught by the Rust walk at verify time. Callers that have a Rust result
  * should additionally require [rustIntact] before treating this as benign.
+ *
+ * A legitimate crash-resumed append always carries a real (non-empty) HMAC
+ * [latestEntryHash]; an all-legacy head injection against the empty zero anchor has
+ * an empty tail, so requiring [latestEntryHash] non-empty makes that injection fall
+ * through to resolveChainVerification → Tampered instead of being anchored as history.
  */
 internal fun isResumableAppend(
     anchor: AuditAnchor,
     entryCount: Long,
     newestPreviousHash: String?,
+    latestEntryHash: String,
     rustIntact: Boolean
 ): Boolean =
     rustIntact &&
+        latestEntryHash.isNotEmpty() &&
         entryCount == anchor.entryCount + 1L &&
         // The first row after a reset chains onto the empty zero anchor: its
         // previousHash is null, which must read as equal to the "" anchor tail.

--- a/app/src/main/kotlin/io/privkey/keep/nip55/AuditAnchor.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/AuditAnchor.kt
@@ -1,0 +1,40 @@
+package io.privkey.keep.nip55
+
+/**
+ * Tamper-resistant tail marker for the NIP-55 audit chain, persisted OUTSIDE Room
+ * (in the Keystore-backed encrypted prefs that also hold the HMAC key) so an
+ * attacker with on-device Room write access cannot forge it.
+ */
+data class AuditAnchor(val latestEntryHash: String, val entryCount: Long)
+
+/**
+ * Reconciles the Rust chain walk against the stored [anchor] to catch attacks the
+ * walk alone cannot see: tail truncation (newest rows deleted, leaving an
+ * otherwise-valid prefix) and head fabrication (rows prepended, which the walk
+ * would excuse as legacy / [ChainVerificationResult.PartiallyVerified]).
+ *
+ * A Rust integrity failure ([ChainVerificationResult.Broken]/[ChainVerificationResult.Tampered])
+ * is never downgraded. A null anchor (first run on an upgraded install) defers to
+ * the Rust result so the caller can trust-on-first-use seed it.
+ *
+ * Pure function: no storage, no native calls, fully unit-testable.
+ */
+internal fun resolveChainVerification(
+    anchor: AuditAnchor?,
+    entryCount: Long,
+    latestEntryHash: String,
+    latestEntryId: Long,
+    rustResult: ChainVerificationResult
+): ChainVerificationResult {
+    if (rustResult is ChainVerificationResult.Broken || rustResult is ChainVerificationResult.Tampered) {
+        return rustResult
+    }
+    if (anchor == null) return rustResult
+    if (entryCount > anchor.entryCount) {
+        return ChainVerificationResult.Tampered(latestEntryId)
+    }
+    if (entryCount < anchor.entryCount || latestEntryHash != anchor.latestEntryHash) {
+        return ChainVerificationResult.Truncated(latestEntryId)
+    }
+    return rustResult
+}

--- a/app/src/main/kotlin/io/privkey/keep/nip55/AuditLogWriter.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/AuditLogWriter.kt
@@ -56,7 +56,13 @@ internal class AuditLogWriter(private val database: Nip55Database) {
         if (anchor == null) return false
         val tail = auditDao.getLastEntryHash() ?: ""
         val count = auditDao.getCount().toLong()
-        return tail != anchor.latestEntryHash || count != anchor.entryCount
+        if (tail == anchor.latestEntryHash && count == anchor.entryCount) return false
+        // A legit append whose post-commit anchor advance was lost to a crash leaves the
+        // DB one row ahead, chained onto the anchored tail. Re-pin without flagging.
+        if (isResumableAppend(anchor, count, auditDao.getLastPreviousHash(), rustIntact = true)) {
+            return false
+        }
+        return true
     }
 
     private suspend fun advanceAnchor() {

--- a/app/src/main/kotlin/io/privkey/keep/nip55/AuditLogWriter.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/AuditLogWriter.kt
@@ -1,0 +1,73 @@
+package io.privkey.keep.nip55
+
+import androidx.room.withTransaction
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * The single seam through which the anchored nip55_audit_log table may be mutated.
+ * Every append/prune/clear pairs the Room write with an integrity-checked anchor
+ * update so no alternate writer can advance the chain without the anchor noticing
+ * (gh #308). The anchor (a Keystore-backed prefs commit) is only advanced AFTER the
+ * Room transaction commits, so a rollback can never leave it ahead of the DB.
+ */
+internal class AuditLogWriter(private val database: Nip55Database) {
+    private val auditDao = database.auditLogDao()
+
+    suspend fun append(
+        buildLog: (previousHash: String?) -> Nip55AuditLog,
+        extraInTransaction: (suspend () -> Unit)? = null
+    ) = mutex.withLock {
+        val anchor = Nip55Database.getAuditAnchor()
+        var tamper = false
+        database.withTransaction {
+            tamper = anchorMismatch(anchor)
+            extraInTransaction?.invoke()
+            auditDao.insert(buildLog(auditDao.getLastEntryHash()))
+        }
+        if (tamper) Nip55Database.setAuditTamperDetected()
+        advanceAnchor()
+    }
+
+    // Head prune (oldest rows only): the tail must be untouched, so a pre-prune
+    // mismatch against the anchor is out-of-band tampering. Re-pin to the post-prune
+    // state regardless so the legitimately shrunk count is recorded.
+    suspend fun prune(before: Long, extraInTransaction: suspend () -> Unit) = mutex.withLock {
+        val anchor = Nip55Database.getAuditAnchor()
+        var tamper = false
+        database.withTransaction {
+            tamper = anchorMismatch(anchor)
+            auditDao.deleteOlderThan(before)
+            extraInTransaction()
+        }
+        if (tamper) Nip55Database.setAuditTamperDetected()
+        advanceAnchor()
+    }
+
+    suspend fun clear(extraInTransaction: (suspend () -> Unit)? = null) = mutex.withLock {
+        database.withTransaction {
+            auditDao.deleteAll()
+            extraInTransaction?.invoke()
+        }
+        Nip55Database.resetAuditAnchor()
+    }
+
+    private suspend fun anchorMismatch(anchor: AuditAnchor?): Boolean {
+        if (anchor == null) return false
+        val tail = auditDao.getLastEntryHash() ?: ""
+        val count = auditDao.getCount().toLong()
+        return tail != anchor.latestEntryHash || count != anchor.entryCount
+    }
+
+    private suspend fun advanceAnchor() {
+        Nip55Database.setAuditAnchor(
+            AuditAnchor(auditDao.getLastEntryHash() ?: "", auditDao.getCount().toLong())
+        )
+    }
+
+    companion object {
+        // Serializes every audit write so an in-flight append cannot observe another
+        // writer's half-committed state and raise a false tamper flag.
+        private val mutex = Mutex()
+    }
+}

--- a/app/src/main/kotlin/io/privkey/keep/nip55/AuditLogWriter.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/AuditLogWriter.kt
@@ -57,11 +57,26 @@ internal class AuditLogWriter(private val database: Nip55Database) {
         Nip55Database.resetAuditAnchor()
     }
 
-    // Atomic read of rows + anchor under the same lock every write takes, so no
-    // append/prune/clear can interleave between the two reads and skew the snapshot.
-    suspend fun snapshot(): Pair<List<Nip55AuditLog>, AuditAnchor?> = mutex.withLock {
+    // Atomic read of rows + anchor + tamper flag under the same lock every write takes,
+    // so no append/prune/clear can interleave between the reads and skew the snapshot.
+    suspend fun snapshot(): Triple<List<Nip55AuditLog>, AuditAnchor?, Boolean> = mutex.withLock {
         reconcilePendingClear()
-        auditDao.getAllOrdered() to Nip55Database.getAuditAnchor()
+        Triple(
+            auditDao.getAllOrdered(),
+            Nip55Database.getAuditAnchor(),
+            Nip55Database.isAuditTamperDetected()
+        )
+    }
+
+    // Compare-and-set the anchor under the write lock: only pin to (expectedHash, expectedCount)
+    // if the live DB still matches the snapshot the caller reconciled. A concurrent append/prune
+    // that already advanced the anchor since the snapshot wins; we must never roll it back.
+    suspend fun reconcileAnchor(expectedCount: Long, expectedHash: String) = mutex.withLock {
+        val liveTail = auditDao.getLastEntryHash() ?: ""
+        val liveCount = auditDao.getCount().toLong()
+        if (liveCount == expectedCount && liveTail == expectedHash) {
+            Nip55Database.setAuditAnchor(AuditAnchor(expectedHash, expectedCount))
+        }
     }
 
     // Finish a clear() whose post-commit anchor reset was lost to a crash: an empty DB
@@ -83,7 +98,7 @@ internal class AuditLogWriter(private val database: Nip55Database) {
         if (tail == anchor.latestEntryHash && count == anchor.entryCount) return false
         // A legit append whose post-commit anchor advance was lost to a crash leaves the
         // DB one row ahead, chained onto the anchored tail. Re-pin without flagging.
-        if (isResumableAppend(anchor, count, auditDao.getLastPreviousHash(), rustIntact = true)) {
+        if (isResumableAppend(anchor, count, auditDao.getLastPreviousHash(), tail, rustIntact = true)) {
             return false
         }
         // Likewise a crash-interrupted head prune: fewer rows but the same tail. The Rust

--- a/app/src/main/kotlin/io/privkey/keep/nip55/AuditLogWriter.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/AuditLogWriter.kt
@@ -18,6 +18,7 @@ internal class AuditLogWriter(private val database: Nip55Database) {
         buildLog: (previousHash: String?) -> Nip55AuditLog,
         extraInTransaction: (suspend () -> Unit)? = null
     ) = mutex.withLock {
+        reconcilePendingClear()
         val anchor = Nip55Database.getAuditAnchor()
         var tamper = false
         database.withTransaction {
@@ -33,6 +34,7 @@ internal class AuditLogWriter(private val database: Nip55Database) {
     // mismatch against the anchor is out-of-band tampering. Re-pin to the post-prune
     // state regardless so the legitimately shrunk count is recorded.
     suspend fun prune(before: Long, extraInTransaction: suspend () -> Unit) = mutex.withLock {
+        reconcilePendingClear()
         val anchor = Nip55Database.getAuditAnchor()
         var tamper = false
         database.withTransaction {
@@ -44,12 +46,34 @@ internal class AuditLogWriter(private val database: Nip55Database) {
         advanceAnchor()
     }
 
+    // Two-phase clear: the pending marker is committed before the wipe so a crash
+    // between the DB commit and the anchor reset is recoverable (see reconcilePendingClear).
     suspend fun clear(extraInTransaction: (suspend () -> Unit)? = null) = mutex.withLock {
+        Nip55Database.setAuditClearPending()
         database.withTransaction {
             auditDao.deleteAll()
             extraInTransaction?.invoke()
         }
         Nip55Database.resetAuditAnchor()
+    }
+
+    // Atomic read of rows + anchor under the same lock every write takes, so no
+    // append/prune/clear can interleave between the two reads and skew the snapshot.
+    suspend fun snapshot(): Pair<List<Nip55AuditLog>, AuditAnchor?> = mutex.withLock {
+        reconcilePendingClear()
+        auditDao.getAllOrdered() to Nip55Database.getAuditAnchor()
+    }
+
+    // Finish a clear() whose post-commit anchor reset was lost to a crash: an empty DB
+    // means the wipe committed, so complete the reset; a non-empty DB means the clear
+    // transaction rolled back, so just drop the (attacker-unforgeable) marker.
+    private suspend fun reconcilePendingClear() {
+        if (!Nip55Database.isAuditClearPending()) return
+        if (auditDao.getCount() == 0) {
+            Nip55Database.resetAuditAnchor()
+        } else {
+            Nip55Database.clearAuditClearPending()
+        }
     }
 
     private suspend fun anchorMismatch(anchor: AuditAnchor?): Boolean {
@@ -60,6 +84,11 @@ internal class AuditLogWriter(private val database: Nip55Database) {
         // A legit append whose post-commit anchor advance was lost to a crash leaves the
         // DB one row ahead, chained onto the anchored tail. Re-pin without flagging.
         if (isResumableAppend(anchor, count, auditDao.getLastPreviousHash(), rustIntact = true)) {
+            return false
+        }
+        // Likewise a crash-interrupted head prune: fewer rows but the same tail. The Rust
+        // walk at verify time is authoritative for the rustIntact assumption here.
+        if (isResumablePrune(anchor, count, tail, rustIntact = true)) {
             return false
         }
         return true

--- a/app/src/main/kotlin/io/privkey/keep/nip55/PermissionDaos.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/PermissionDaos.kt
@@ -130,6 +130,9 @@ interface Nip55AuditLogDao {
     @Query("SELECT entryHash FROM nip55_audit_log ORDER BY id DESC LIMIT 1")
     suspend fun getLastEntryHash(): String?
 
+    @Query("SELECT previousHash FROM nip55_audit_log ORDER BY id DESC LIMIT 1")
+    suspend fun getLastPreviousHash(): String?
+
     @Query("SELECT * FROM nip55_audit_log ORDER BY id ASC")
     suspend fun getAllOrdered(): List<Nip55AuditLog>
 

--- a/app/src/main/kotlin/io/privkey/keep/nip55/PermissionDatabase.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/PermissionDatabase.kt
@@ -27,9 +27,14 @@ abstract class Nip55Database : RoomDatabase() {
         private const val PREFS_NAME = "nip55_db_prefs"
         private const val KEY_DB_PASSPHRASE = "db_passphrase"
         private const val KEY_HMAC_SECRET = "hmac_secret"
+        private const val KEY_AUDIT_ANCHOR_HASH = "audit_anchor_hash"
+        private const val KEY_AUDIT_ANCHOR_COUNT = "audit_anchor_count"
 
         @Volatile
         private var hmacKey: ByteArray? = null
+
+        @Volatile
+        private var appContext: Context? = null
 
         private val MIGRATION_1_2 = object : Migration(1, 2) {
             override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
@@ -157,9 +162,29 @@ abstract class Nip55Database : RoomDatabase() {
 
         fun getHmacKey(): ByteArray? = hmacKey
 
+        // Audit tail anchor lives in the Keystore-backed encrypted prefs (same trust
+        // tier as the HMAC key), out of reach of an attacker with Room write access.
+        fun getAuditAnchor(): AuditAnchor? {
+            val ctx = appContext ?: return null
+            val prefs = getEncryptedPrefs(ctx)
+            if (!prefs.contains(KEY_AUDIT_ANCHOR_COUNT)) return null
+            val count = prefs.getLong(KEY_AUDIT_ANCHOR_COUNT, -1L)
+            if (count < 0L) return null
+            return AuditAnchor(prefs.getString(KEY_AUDIT_ANCHOR_HASH, "") ?: "", count)
+        }
+
+        fun setAuditAnchor(anchor: AuditAnchor) {
+            val ctx = appContext ?: return
+            getEncryptedPrefs(ctx).edit()
+                .putString(KEY_AUDIT_ANCHOR_HASH, anchor.latestEntryHash)
+                .putLong(KEY_AUDIT_ANCHOR_COUNT, anchor.entryCount)
+                .commit()
+        }
+
         fun getInstance(context: Context): Nip55Database {
             return INSTANCE ?: synchronized(this) {
                 INSTANCE ?: run {
+                    appContext = context.applicationContext
                     val passphrase = getOrCreateDbKey(context.applicationContext)
                     getOrCreateHmacKey(context.applicationContext)
                     val factory = SupportOpenHelperFactory(passphrase)

--- a/app/src/main/kotlin/io/privkey/keep/nip55/PermissionDatabase.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/PermissionDatabase.kt
@@ -29,12 +29,16 @@ abstract class Nip55Database : RoomDatabase() {
         private const val KEY_HMAC_SECRET = "hmac_secret"
         private const val KEY_AUDIT_ANCHOR_HASH = "audit_anchor_hash"
         private const val KEY_AUDIT_ANCHOR_COUNT = "audit_anchor_count"
+        private const val KEY_AUDIT_TAMPER = "audit_tamper_detected"
 
         @Volatile
         private var hmacKey: ByteArray? = null
 
         @Volatile
         private var appContext: Context? = null
+
+        @Volatile
+        private var auditPrefs: android.content.SharedPreferences? = null
 
         private val MIGRATION_1_2 = object : Migration(1, 2) {
             override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
@@ -131,7 +135,9 @@ abstract class Nip55Database : RoomDatabase() {
         private val MIGRATIONS = arrayOf(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9)
 
         private fun getEncryptedPrefs(context: Context) =
-            KeystoreEncryptedPrefs.create(context, PREFS_NAME)
+            auditPrefs ?: synchronized(this) {
+                auditPrefs ?: KeystoreEncryptedPrefs.create(context, PREFS_NAME).also { auditPrefs = it }
+            }
 
         private fun getOrCreateKey(context: Context, prefKey: String, commit: Boolean = false): ByteArray {
             val prefs = getEncryptedPrefs(context)
@@ -178,6 +184,28 @@ abstract class Nip55Database : RoomDatabase() {
             getEncryptedPrefs(ctx).edit()
                 .putString(KEY_AUDIT_ANCHOR_HASH, anchor.latestEntryHash)
                 .putLong(KEY_AUDIT_ANCHOR_COUNT, anchor.entryCount)
+                .commit()
+        }
+
+        // Sticky evidence that the audit table was mutated out-of-band between two
+        // sanctioned writes; once set it stays set until a full clearAuditLog reset.
+        fun isAuditTamperDetected(): Boolean {
+            val ctx = appContext ?: return false
+            return getEncryptedPrefs(ctx).getBoolean(KEY_AUDIT_TAMPER, false)
+        }
+
+        fun setAuditTamperDetected() {
+            val ctx = appContext ?: return
+            getEncryptedPrefs(ctx).edit().putBoolean(KEY_AUDIT_TAMPER, true).commit()
+        }
+
+        // Single commit so the anchor and the sticky flag can never diverge on reset.
+        fun resetAuditAnchor() {
+            val ctx = appContext ?: return
+            getEncryptedPrefs(ctx).edit()
+                .putString(KEY_AUDIT_ANCHOR_HASH, "")
+                .putLong(KEY_AUDIT_ANCHOR_COUNT, 0L)
+                .putBoolean(KEY_AUDIT_TAMPER, false)
                 .commit()
         }
 

--- a/app/src/main/kotlin/io/privkey/keep/nip55/PermissionDatabase.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/PermissionDatabase.kt
@@ -30,6 +30,7 @@ abstract class Nip55Database : RoomDatabase() {
         private const val KEY_AUDIT_ANCHOR_HASH = "audit_anchor_hash"
         private const val KEY_AUDIT_ANCHOR_COUNT = "audit_anchor_count"
         private const val KEY_AUDIT_TAMPER = "audit_tamper_detected"
+        private const val KEY_AUDIT_CLEAR_PENDING = "audit_clear_pending"
 
         @Volatile
         private var hmacKey: ByteArray? = null
@@ -199,13 +200,34 @@ abstract class Nip55Database : RoomDatabase() {
             getEncryptedPrefs(ctx).edit().putBoolean(KEY_AUDIT_TAMPER, true).commit()
         }
 
-        // Single commit so the anchor and the sticky flag can never diverge on reset.
+        // Recoverable intent marker for clear(): the tail goes empty, which is otherwise
+        // indistinguishable from total truncation, so a crash between the clear commit and
+        // the anchor reset needs a Keystore-backed (attacker-unforgeable) breadcrumb to
+        // prove the empty DB is a sanctioned clear rather than a wipe.
+        fun isAuditClearPending(): Boolean {
+            val ctx = appContext ?: return false
+            return getEncryptedPrefs(ctx).getBoolean(KEY_AUDIT_CLEAR_PENDING, false)
+        }
+
+        fun setAuditClearPending() {
+            val ctx = appContext ?: return
+            getEncryptedPrefs(ctx).edit().putBoolean(KEY_AUDIT_CLEAR_PENDING, true).commit()
+        }
+
+        fun clearAuditClearPending() {
+            val ctx = appContext ?: return
+            getEncryptedPrefs(ctx).edit().putBoolean(KEY_AUDIT_CLEAR_PENDING, false).commit()
+        }
+
+        // Single commit so the anchor, the sticky flag and the clear-pending marker can
+        // never diverge on reset.
         fun resetAuditAnchor() {
             val ctx = appContext ?: return
             getEncryptedPrefs(ctx).edit()
                 .putString(KEY_AUDIT_ANCHOR_HASH, "")
                 .putLong(KEY_AUDIT_ANCHOR_COUNT, 0L)
                 .putBoolean(KEY_AUDIT_TAMPER, false)
+                .putBoolean(KEY_AUDIT_CLEAR_PENDING, false)
                 .commit()
         }
 

--- a/app/src/main/kotlin/io/privkey/keep/nip55/PermissionStore.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/PermissionStore.kt
@@ -223,8 +223,11 @@ class PermissionStore(private val database: Nip55Database) {
         var rustResult = walk(entries)
         var anchor = Nip55Database.getAuditAnchor()
         // A concurrent append landing between the row read and the anchor read shows up
-        // as a single-step shortfall; re-read once to avoid a false Truncated.
-        if (!tamperDetected && anchor != null && entries.size.toLong() == anchor.entryCount - 1L) {
+        // as a single-step skew either way; re-read once to avoid a false result.
+        if (!tamperDetected && anchor != null &&
+            (entries.size.toLong() == anchor.entryCount - 1L ||
+                entries.size.toLong() == anchor.entryCount + 1L)
+        ) {
             entries = auditDao.getAllOrdered()
             rustResult = walk(entries)
             anchor = Nip55Database.getAuditAnchor()
@@ -238,6 +241,16 @@ class PermissionStore(private val database: Nip55Database) {
             if (shouldSeed(anchor, rustResult)) {
                 Nip55Database.setAuditAnchor(AuditAnchor(latestHash, entries.size.toLong()))
             }
+            return rustResult
+        }
+        // A crash between the row insert and the post-commit anchor advance leaves a legit
+        // row durable with the anchor trailing by one; heal it rather than report Tampered.
+        val rustIntact = rustResult is ChainVerificationResult.Valid ||
+            rustResult is ChainVerificationResult.PartiallyVerified
+        if (!tamperDetected &&
+            isResumableAppend(anchor, entries.size.toLong(), entries.lastOrNull()?.previousHash, rustIntact)
+        ) {
+            Nip55Database.setAuditAnchor(AuditAnchor(latestHash, entries.size.toLong()))
             return rustResult
         }
         return resolveChainVerification(

--- a/app/src/main/kotlin/io/privkey/keep/nip55/PermissionStore.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/PermissionStore.kt
@@ -216,8 +216,8 @@ class PermissionStore(private val database: Nip55Database) {
         val tamperDetected = Nip55Database.isAuditTamperDetected()
         val hmacKey = Nip55Database.getHmacKey()
             ?: throw IllegalStateException("HMAC key not initialized - cannot verify audit chain")
-        val walk: (List<Nip55AuditLog>) -> ChainVerificationResult = { es ->
-            nip55VerifyAuditChain(es.map { it.toRustAuditEntry() }, hmacKey).toChainVerificationResult()
+        val walk: (List<Nip55AuditLog>) -> ChainVerificationResult = { rows ->
+            nip55VerifyAuditChain(rows.map { it.toRustAuditEntry() }, hmacKey).toChainVerificationResult()
         }
         var entries = auditDao.getAllOrdered()
         var rustResult = walk(entries)
@@ -232,6 +232,7 @@ class PermissionStore(private val database: Nip55Database) {
             rustResult = walk(entries)
             anchor = Nip55Database.getAuditAnchor()
         }
+        val count = entries.size.toLong()
         val latestHash = entries.lastOrNull()?.entryHash ?: ""
         val latestId = entries.lastOrNull()?.id ?: 0L
         if (anchor == null) {
@@ -239,7 +240,7 @@ class PermissionStore(private val database: Nip55Database) {
             // First verify on an upgraded/fresh install: trust-on-first-use seed the
             // anchor from the current intact tail rather than flagging it.
             if (shouldSeed(anchor, rustResult)) {
-                Nip55Database.setAuditAnchor(AuditAnchor(latestHash, entries.size.toLong()))
+                Nip55Database.setAuditAnchor(AuditAnchor(latestHash, count))
             }
             return rustResult
         }
@@ -248,15 +249,15 @@ class PermissionStore(private val database: Nip55Database) {
         val rustIntact = rustResult is ChainVerificationResult.Valid ||
             rustResult is ChainVerificationResult.PartiallyVerified
         if (!tamperDetected &&
-            isResumableAppend(anchor, entries.size.toLong(), entries.lastOrNull()?.previousHash, rustIntact)
+            isResumableAppend(anchor, count, entries.lastOrNull()?.previousHash, rustIntact)
         ) {
-            Nip55Database.setAuditAnchor(AuditAnchor(latestHash, entries.size.toLong()))
+            Nip55Database.setAuditAnchor(AuditAnchor(latestHash, count))
             return rustResult
         }
         return resolveChainVerification(
             tamperDetected,
             anchor,
-            entries.size.toLong(),
+            count,
             latestHash,
             latestId,
             rustResult

--- a/app/src/main/kotlin/io/privkey/keep/nip55/PermissionStore.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/PermissionStore.kt
@@ -216,22 +216,13 @@ class PermissionStore(private val database: Nip55Database) {
         val tamperDetected = Nip55Database.isAuditTamperDetected()
         val hmacKey = Nip55Database.getHmacKey()
             ?: throw IllegalStateException("HMAC key not initialized - cannot verify audit chain")
-        val walk: (List<Nip55AuditLog>) -> ChainVerificationResult = { rows ->
-            nip55VerifyAuditChain(rows.map { it.toRustAuditEntry() }, hmacKey).toChainVerificationResult()
-        }
-        var entries = auditDao.getAllOrdered()
-        var rustResult = walk(entries)
-        var anchor = Nip55Database.getAuditAnchor()
-        // A concurrent append landing between the row read and the anchor read shows up
-        // as a single-step skew either way; re-read once to avoid a false result.
-        if (!tamperDetected && anchor != null &&
-            (entries.size.toLong() == anchor.entryCount - 1L ||
-                entries.size.toLong() == anchor.entryCount + 1L)
-        ) {
-            entries = auditDao.getAllOrdered()
-            rustResult = walk(entries)
-            anchor = Nip55Database.getAuditAnchor()
-        }
+        // Read rows + anchor atomically under the audit write lock so no concurrent
+        // append/prune/clear can interleave between the two reads. The Rust walk and all
+        // reconciliation then run outside the lock on this consistent snapshot.
+        val (entries, anchor) = auditWriter.snapshot()
+        val rustResult = nip55VerifyAuditChain(
+            entries.map { it.toRustAuditEntry() }, hmacKey
+        ).toChainVerificationResult()
         val count = entries.size.toLong()
         val latestHash = entries.lastOrNull()?.entryHash ?: ""
         val latestId = entries.lastOrNull()?.id ?: 0L
@@ -244,13 +235,20 @@ class PermissionStore(private val database: Nip55Database) {
             }
             return rustResult
         }
-        // A crash between the row insert and the post-commit anchor advance leaves a legit
-        // row durable with the anchor trailing by one; heal it rather than report Tampered.
         val rustIntact = rustResult is ChainVerificationResult.Valid ||
             rustResult is ChainVerificationResult.PartiallyVerified
+        // A crash between the row insert and the post-commit anchor advance leaves a legit
+        // row durable with the anchor trailing by one; heal it rather than report Tampered.
         if (!tamperDetected &&
             isResumableAppend(anchor, count, entries.lastOrNull()?.previousHash, rustIntact)
         ) {
+            Nip55Database.setAuditAnchor(AuditAnchor(latestHash, count))
+            return rustResult
+        }
+        // A crash between a head prune commit and its anchor advance leaves fewer rows with
+        // the tail unchanged; re-pin to the lower count. Tail truncation changes the tail
+        // hash, so it falls through to resolveChainVerification and is still flagged.
+        if (!tamperDetected && isResumablePrune(anchor, count, latestHash, rustIntact)) {
             Nip55Database.setAuditAnchor(AuditAnchor(latestHash, count))
             return rustResult
         }

--- a/app/src/main/kotlin/io/privkey/keep/nip55/PermissionStore.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/PermissionStore.kt
@@ -25,32 +25,22 @@ class PermissionStore(private val database: Nip55Database) {
     private val auditDao = database.auditLogDao()
     private val appSettingsDao = database.appSettingsDao()
     private val velocityDao = database.velocityDao()
+    private val auditWriter = AuditLogWriter(database)
 
     val riskAssessor: RiskAssessor by lazy { RiskAssessor(auditDao, appSettingsDao) }
 
     suspend fun cleanupExpired() {
         val now = System.currentTimeMillis()
         val nowElapsed = SystemClock.elapsedRealtime()
-        database.withTransaction {
+        auditWriter.prune(now - 30 * DAY_MS) {
             dao.deleteExpired(now, nowElapsed)
             dao.deleteNip46Permissions()
-            auditDao.deleteOlderThan(now - 30 * DAY_MS)
-            updateAuditAnchor()
             val expiredPackages = appSettingsDao.getExpiredPackages(now, nowElapsed)
             expiredPackages.forEach { pkg ->
                 dao.deleteForCaller(pkg)
             }
             appSettingsDao.deleteExpired(now, nowElapsed)
         }
-    }
-
-    // Re-pins the tail anchor to the chain's current state after any legitimate
-    // mutation (append/prune), so the verifier can tell sanctioned changes from an
-    // attacker editing Room directly. Must run inside the audit-log transaction.
-    private suspend fun updateAuditAnchor() {
-        Nip55Database.setAuditAnchor(
-            AuditAnchor(auditDao.getLastEntryHash() ?: "", auditDao.getCount().toLong())
-        )
     }
 
     // Decision resolution (incl. the rule that sensitive kinds never fall back
@@ -148,34 +138,41 @@ class PermissionStore(private val database: Nip55Database) {
         eventKind: Int?,
         decision: String,
         wasAutomatic: Boolean
+    ) = logOperation(callerPackage, requestType, eventKind, decision, wasAutomatic, null)
+
+    // [extraInTransaction] lets a related permission write commit atomically with the
+    // audit row in a single Room transaction; the anchor is advanced only once that
+    // transaction durably commits.
+    private suspend fun logOperation(
+        callerPackage: String,
+        requestType: Nip55RequestType,
+        eventKind: Int?,
+        decision: String,
+        wasAutomatic: Boolean,
+        extraInTransaction: (suspend () -> Unit)?
     ) {
         val normalizedEventKind = eventKind ?: EVENT_KIND_GENERIC
-        database.withTransaction {
-            val previousHash = auditDao.getLastEntryHash()
-            val timestamp = System.currentTimeMillis()
-            val entryHash = calculateEntryHash(
-                previousHash = previousHash,
+        val timestamp = System.currentTimeMillis()
+        auditWriter.append({ previousHash ->
+            Nip55AuditLog(
+                timestamp = timestamp,
                 callerPackage = callerPackage,
                 requestType = requestType.name,
                 eventKind = normalizedEventKind,
                 decision = decision,
-                timestamp = timestamp,
-                wasAutomatic = wasAutomatic
-            )
-            auditDao.insert(
-                Nip55AuditLog(
-                    timestamp = timestamp,
+                wasAutomatic = wasAutomatic,
+                previousHash = previousHash,
+                entryHash = calculateEntryHash(
+                    previousHash = previousHash,
                     callerPackage = callerPackage,
                     requestType = requestType.name,
                     eventKind = normalizedEventKind,
                     decision = decision,
-                    wasAutomatic = wasAutomatic,
-                    previousHash = previousHash,
-                    entryHash = entryHash
+                    timestamp = timestamp,
+                    wasAutomatic = wasAutomatic
                 )
             )
-            updateAuditAnchor()
-        }
+        }, extraInTransaction)
     }
 
     // The hourly/daily/weekly limit thresholds + block decision live in Rust;
@@ -216,27 +213,39 @@ class PermissionStore(private val database: Nip55Database) {
     // Chain verification (keyed-HMAC walk: legacy/truncated/broken/tampered) lives
     // in Rust; Android supplies the ordered rows and the keystore HMAC key.
     suspend fun verifyAuditChain(): ChainVerificationResult {
-        val entries = auditDao.getAllOrdered()
+        val tamperDetected = Nip55Database.isAuditTamperDetected()
         val hmacKey = Nip55Database.getHmacKey()
             ?: throw IllegalStateException("HMAC key not initialized - cannot verify audit chain")
-        val rustResult = nip55VerifyAuditChain(entries.map { it.toRustAuditEntry() }, hmacKey)
-            .toChainVerificationResult()
-        val anchor = Nip55Database.getAuditAnchor()
+        val walk: (List<Nip55AuditLog>) -> ChainVerificationResult = { es ->
+            nip55VerifyAuditChain(es.map { it.toRustAuditEntry() }, hmacKey).toChainVerificationResult()
+        }
+        var entries = auditDao.getAllOrdered()
+        var rustResult = walk(entries)
+        var anchor = Nip55Database.getAuditAnchor()
+        // A concurrent append landing between the row read and the anchor read shows up
+        // as a single-step shortfall; re-read once to avoid a false Truncated.
+        if (!tamperDetected && anchor != null && entries.size.toLong() == anchor.entryCount - 1L) {
+            entries = auditDao.getAllOrdered()
+            rustResult = walk(entries)
+            anchor = Nip55Database.getAuditAnchor()
+        }
         val latestHash = entries.lastOrNull()?.entryHash ?: ""
+        val latestId = entries.lastOrNull()?.id ?: 0L
         if (anchor == null) {
+            if (tamperDetected) return ChainVerificationResult.Tampered(latestId)
             // First verify on an upgraded/fresh install: trust-on-first-use seed the
             // anchor from the current intact tail rather than flagging it.
-            if (rustResult is ChainVerificationResult.Valid ||
-                rustResult is ChainVerificationResult.PartiallyVerified) {
+            if (shouldSeed(anchor, rustResult)) {
                 Nip55Database.setAuditAnchor(AuditAnchor(latestHash, entries.size.toLong()))
             }
             return rustResult
         }
         return resolveChainVerification(
+            tamperDetected,
             anchor,
             entries.size.toLong(),
             latestHash,
-            entries.lastOrNull()?.id ?: 0L,
+            latestId,
             rustResult
         )
     }
@@ -313,9 +322,8 @@ class PermissionStore(private val database: Nip55Database) {
         }
         val storedRequestType = findRequestType(permission.requestType)
             ?: throw IllegalArgumentException("Unknown requestType in permission $id: ${permission.requestType}")
-        database.withTransaction {
+        logOperation(permission.callerPackage, storedRequestType, permission.eventKind, decision.toString(), wasAutomatic = false) {
             dao.updateDecision(id, decision.toString())
-            logOperation(permission.callerPackage, storedRequestType, permission.eventKind, decision.toString(), wasAutomatic = false)
         }
     }
 
@@ -326,7 +334,7 @@ class PermissionStore(private val database: Nip55Database) {
     ) {
         val now = System.currentTimeMillis()
         val nowElapsed = SystemClock.elapsedRealtime()
-        database.withTransaction {
+        logOperation(callerPackage, requestType, eventKind, PermissionDecision.ASK.toString(), wasAutomatic = false) {
             dao.insertPermission(
                 Nip55Permission(
                     callerPackage = callerPackage,
@@ -339,7 +347,6 @@ class PermissionStore(private val database: Nip55Database) {
                     durationMs = null
                 )
             )
-            logOperation(callerPackage, requestType, eventKind, PermissionDecision.ASK.toString(), wasAutomatic = false)
         }
     }
 
@@ -351,10 +358,7 @@ class PermissionStore(private val database: Nip55Database) {
 
     suspend fun clearAllVelocity() = velocityDao.deleteAll()
 
-    suspend fun clearAuditLog() {
-        auditDao.deleteAll()
-        Nip55Database.setAuditAnchor(AuditAnchor("", 0L))
-    }
+    suspend fun clearAuditLog() = auditWriter.clear()
 
     suspend fun getDistinctPermissionCallers(): List<String> = dao.getDistinctCallers()
 

--- a/app/src/main/kotlin/io/privkey/keep/nip55/PermissionStore.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/PermissionStore.kt
@@ -35,12 +35,22 @@ class PermissionStore(private val database: Nip55Database) {
             dao.deleteExpired(now, nowElapsed)
             dao.deleteNip46Permissions()
             auditDao.deleteOlderThan(now - 30 * DAY_MS)
+            updateAuditAnchor()
             val expiredPackages = appSettingsDao.getExpiredPackages(now, nowElapsed)
             expiredPackages.forEach { pkg ->
                 dao.deleteForCaller(pkg)
             }
             appSettingsDao.deleteExpired(now, nowElapsed)
         }
+    }
+
+    // Re-pins the tail anchor to the chain's current state after any legitimate
+    // mutation (append/prune), so the verifier can tell sanctioned changes from an
+    // attacker editing Room directly. Must run inside the audit-log transaction.
+    private suspend fun updateAuditAnchor() {
+        Nip55Database.setAuditAnchor(
+            AuditAnchor(auditDao.getLastEntryHash() ?: "", auditDao.getCount().toLong())
+        )
     }
 
     // Decision resolution (incl. the rule that sensitive kinds never fall back
@@ -164,6 +174,7 @@ class PermissionStore(private val database: Nip55Database) {
                     entryHash = entryHash
                 )
             )
+            updateAuditAnchor()
         }
     }
 
@@ -208,8 +219,26 @@ class PermissionStore(private val database: Nip55Database) {
         val entries = auditDao.getAllOrdered()
         val hmacKey = Nip55Database.getHmacKey()
             ?: throw IllegalStateException("HMAC key not initialized - cannot verify audit chain")
-        return nip55VerifyAuditChain(entries.map { it.toRustAuditEntry() }, hmacKey)
+        val rustResult = nip55VerifyAuditChain(entries.map { it.toRustAuditEntry() }, hmacKey)
             .toChainVerificationResult()
+        val anchor = Nip55Database.getAuditAnchor()
+        val latestHash = entries.lastOrNull()?.entryHash ?: ""
+        if (anchor == null) {
+            // First verify on an upgraded/fresh install: trust-on-first-use seed the
+            // anchor from the current intact tail rather than flagging it.
+            if (rustResult is ChainVerificationResult.Valid ||
+                rustResult is ChainVerificationResult.PartiallyVerified) {
+                Nip55Database.setAuditAnchor(AuditAnchor(latestHash, entries.size.toLong()))
+            }
+            return rustResult
+        }
+        return resolveChainVerification(
+            anchor,
+            entries.size.toLong(),
+            latestHash,
+            entries.lastOrNull()?.id ?: 0L,
+            rustResult
+        )
     }
 
     suspend fun getAuditLogCount(): Int = auditDao.getCount()
@@ -322,7 +351,10 @@ class PermissionStore(private val database: Nip55Database) {
 
     suspend fun clearAllVelocity() = velocityDao.deleteAll()
 
-    suspend fun clearAuditLog() = auditDao.deleteAll()
+    suspend fun clearAuditLog() {
+        auditDao.deleteAll()
+        Nip55Database.setAuditAnchor(AuditAnchor("", 0L))
+    }
 
     suspend fun getDistinctPermissionCallers(): List<String> = dao.getDistinctCallers()
 

--- a/app/src/main/kotlin/io/privkey/keep/nip55/PermissionStore.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/PermissionStore.kt
@@ -213,13 +213,12 @@ class PermissionStore(private val database: Nip55Database) {
     // Chain verification (keyed-HMAC walk: legacy/truncated/broken/tampered) lives
     // in Rust; Android supplies the ordered rows and the keystore HMAC key.
     suspend fun verifyAuditChain(): ChainVerificationResult {
-        val tamperDetected = Nip55Database.isAuditTamperDetected()
         val hmacKey = Nip55Database.getHmacKey()
             ?: throw IllegalStateException("HMAC key not initialized - cannot verify audit chain")
-        // Read rows + anchor atomically under the audit write lock so no concurrent
-        // append/prune/clear can interleave between the two reads. The Rust walk and all
-        // reconciliation then run outside the lock on this consistent snapshot.
-        val (entries, anchor) = auditWriter.snapshot()
+        // Read rows + anchor + tamper flag atomically under the audit write lock so no
+        // concurrent append/prune/clear can interleave between the reads. The Rust walk and
+        // all reconciliation then run outside the lock on this consistent snapshot.
+        val (entries, anchor, tamperDetected) = auditWriter.snapshot()
         val rustResult = nip55VerifyAuditChain(
             entries.map { it.toRustAuditEntry() }, hmacKey
         ).toChainVerificationResult()
@@ -231,7 +230,7 @@ class PermissionStore(private val database: Nip55Database) {
             // First verify on an upgraded/fresh install: trust-on-first-use seed the
             // anchor from the current intact tail rather than flagging it.
             if (shouldSeed(anchor, rustResult)) {
-                Nip55Database.setAuditAnchor(AuditAnchor(latestHash, count))
+                auditWriter.reconcileAnchor(count, latestHash)
             }
             return rustResult
         }
@@ -240,16 +239,16 @@ class PermissionStore(private val database: Nip55Database) {
         // A crash between the row insert and the post-commit anchor advance leaves a legit
         // row durable with the anchor trailing by one; heal it rather than report Tampered.
         if (!tamperDetected &&
-            isResumableAppend(anchor, count, entries.lastOrNull()?.previousHash, rustIntact)
+            isResumableAppend(anchor, count, entries.lastOrNull()?.previousHash, latestHash, rustIntact)
         ) {
-            Nip55Database.setAuditAnchor(AuditAnchor(latestHash, count))
+            auditWriter.reconcileAnchor(count, latestHash)
             return rustResult
         }
         // A crash between a head prune commit and its anchor advance leaves fewer rows with
         // the tail unchanged; re-pin to the lower count. Tail truncation changes the tail
         // hash, so it falls through to resolveChainVerification and is still flagged.
         if (!tamperDetected && isResumablePrune(anchor, count, latestHash, rustIntact)) {
-            Nip55Database.setAuditAnchor(AuditAnchor(latestHash, count))
+            auditWriter.reconcileAnchor(count, latestHash)
             return rustResult
         }
         return resolveChainVerification(

--- a/app/src/main/kotlin/io/privkey/keep/nip55/PermissionStore.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/PermissionStore.kt
@@ -222,9 +222,10 @@ class PermissionStore(private val database: Nip55Database) {
         val rustResult = nip55VerifyAuditChain(
             entries.map { it.toRustAuditEntry() }, hmacKey
         ).toChainVerificationResult()
+        val latest = entries.lastOrNull()
         val count = entries.size.toLong()
-        val latestHash = entries.lastOrNull()?.entryHash ?: ""
-        val latestId = entries.lastOrNull()?.id ?: 0L
+        val latestHash = latest?.entryHash ?: ""
+        val latestId = latest?.id ?: 0L
         if (anchor == null) {
             if (tamperDetected) return ChainVerificationResult.Tampered(latestId)
             // First verify on an upgraded/fresh install: trust-on-first-use seed the
@@ -239,7 +240,7 @@ class PermissionStore(private val database: Nip55Database) {
         // A crash between the row insert and the post-commit anchor advance leaves a legit
         // row durable with the anchor trailing by one; heal it rather than report Tampered.
         if (!tamperDetected &&
-            isResumableAppend(anchor, count, entries.lastOrNull()?.previousHash, latestHash, rustIntact)
+            isResumableAppend(anchor, count, latest?.previousHash, latestHash, rustIntact)
         ) {
             auditWriter.reconcileAnchor(count, latestHash)
             return rustResult

--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidSigningAuditStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidSigningAuditStorage.kt
@@ -2,8 +2,9 @@ package io.privkey.keep.storage
 
 import android.util.Log
 import io.privkey.keep.BuildConfig
+import io.privkey.keep.nip55.AuditLogWriter
 import io.privkey.keep.nip55.Nip55AuditLog
-import io.privkey.keep.nip55.Nip55AuditLogDao
+import io.privkey.keep.nip55.Nip55Database
 import io.privkey.keep.uniffi.KeepMobileException
 import io.privkey.keep.uniffi.SigningAuditStorage
 import kotlinx.coroutines.Dispatchers
@@ -15,8 +16,11 @@ private const val TAG = "SigningAuditStorage"
 private const val MAX_QUERY_LIMIT = 10_000
 
 class AndroidSigningAuditStorage(
-    private val auditDao: Nip55AuditLogDao
+    private val database: Nip55Database
 ) : SigningAuditStorage {
+
+    private val auditDao = database.auditLogDao()
+    private val auditWriter = AuditLogWriter(database)
 
     override fun storeEntry(entryJson: String) {
         val json = try {
@@ -44,7 +48,7 @@ class AndroidSigningAuditStorage(
             previousHash = prevHashBytes?.toHexString(),
             entryHash = hashBytes.toHexString()!!
         )
-        runBlocking(Dispatchers.IO) { auditDao.insert(log) }
+        runBlocking(Dispatchers.IO) { auditWriter.append({ log }) }
     }
 
     override fun loadEntries(limit: UInt?): List<String> {
@@ -82,7 +86,7 @@ class AndroidSigningAuditStorage(
     }
 
     override fun clearEntries(confirm: String) {
-        runBlocking(Dispatchers.IO) { auditDao.deleteAll() }
+        runBlocking(Dispatchers.IO) { auditWriter.clear() }
     }
 
     companion object {

--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidSigningAuditStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidSigningAuditStorage.kt
@@ -48,7 +48,16 @@ class AndroidSigningAuditStorage(
             previousHash = prevHashBytes?.toHexString(),
             entryHash = hashBytes.toHexString()!!
         )
-        runBlocking(Dispatchers.IO) { auditWriter.append({ log }) }
+        runBlocking(Dispatchers.IO) {
+            auditWriter.append({ roomPrev ->
+                // Invariant: Rust's chain tip (log.previousHash) must equal the Room tail the
+                // writer sees, or the anchor's resumable-append reconciliation would mis-fire.
+                check(log.previousHash == roomPrev) {
+                    "Signing-audit previousHash desync: rust=${log.previousHash} room=$roomPrev"
+                }
+                log
+            })
+        }
     }
 
     override fun loadEntries(limit: UInt?): List<String> {

--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidSigningAuditStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidSigningAuditStorage.kt
@@ -52,8 +52,12 @@ class AndroidSigningAuditStorage(
             auditWriter.append({ roomPrev ->
                 // Invariant: Rust's chain tip (log.previousHash) must equal the Room tail the
                 // writer sees, or the anchor's resumable-append reconciliation would mis-fire.
-                check(log.previousHash == roomPrev) {
-                    "Signing-audit previousHash desync: rust=${log.previousHash} room=$roomPrev"
+                // Throw the uniffi-declared StorageException (not check()'s IllegalStateException,
+                // which an attacker-triggered desync would surface as a fatal UnexpectedUniFFICallbackError).
+                if (log.previousHash != roomPrev) {
+                    throw KeepMobileException.StorageException(
+                        "Signing-audit previousHash desync: rust=${log.previousHash} room=$roomPrev"
+                    )
                 }
                 log
             })

--- a/app/src/test/kotlin/io/privkey/keep/nip55/AuditAnchorTest.kt
+++ b/app/src/test/kotlin/io/privkey/keep/nip55/AuditAnchorTest.kt
@@ -110,13 +110,42 @@ class AuditAnchorTest {
     }
 
     @Test
-    fun rustTruncatedPassesThroughWhenAnchorMatches() {
-        // Anchor is consistent but the keyed walk itself found a break: surface it.
+    fun sanctionedHeadPruneTruncatedIsDowngradedToValid() {
+        // FIX 4: anchor matches the DB EXACTLY (count + tail), but the head prune dropped
+        // the oldest rows so the new head's previousHash dangles and the Rust walk reports
+        // Truncated. The keystore anchor vouches this exact (count, tail) is the pruned
+        // state, so it must be trusted over the dangling-head walk: downgrade to Valid.
+        assertEquals(
+            ChainVerificationResult.Valid,
+            resolveChainVerification(
+                false, AuditAnchor("hashB", 3L), 3L, "hashB", 3L,
+                ChainVerificationResult.Truncated(3L)
+            )
+        )
+    }
+
+    @Test
+    fun truncatedNotDowngradedWhenCountBelowAnchor() {
+        // FIX 4 safety: a real tail truncation drops the count below the anchor. Even with
+        // a Rust Truncated this must stay Truncated, never be laundered into Valid.
         assertEquals(
             ChainVerificationResult.Truncated(2L),
             resolveChainVerification(
-                false, AuditAnchor("hashB", 2L), 2L, "hashB", 2L,
+                false, AuditAnchor("hashB", 3L), 2L, "hashA", 2L,
                 ChainVerificationResult.Truncated(2L)
+            )
+        )
+    }
+
+    @Test
+    fun truncatedNotDowngradedWhenTailHashDiffers() {
+        // FIX 4 safety: the count matches but the tail hash no longer matches the anchor
+        // (tail row swapped). The tail-mismatch branch must catch it before the downgrade.
+        assertEquals(
+            ChainVerificationResult.Truncated(3L),
+            resolveChainVerification(
+                false, AuditAnchor("hashB", 3L), 3L, "hashX", 3L,
+                ChainVerificationResult.Truncated(3L)
             )
         )
     }
@@ -162,33 +191,50 @@ class AuditAnchorTest {
     fun resumableAppendWhenOneAheadChainedAndIntact() {
         // DB one row ahead, newest row chained onto the anchored tail, Rust intact:
         // a legit append whose post-commit anchor advance was lost to a crash.
-        assertTrue(isResumableAppend(AuditAnchor("hashB", 2L), 3L, "hashB", rustIntact = true))
+        assertTrue(isResumableAppend(AuditAnchor("hashB", 2L), 3L, "hashB", "hashC", rustIntact = true))
     }
 
     @Test
     fun notResumableWhenNotChainedOntoAnchor() {
         // Newest row does not link to the anchored tail (e.g. head fabrication shifts it).
-        assertFalse(isResumableAppend(AuditAnchor("hashB", 2L), 3L, "hashX", rustIntact = true))
+        assertFalse(isResumableAppend(AuditAnchor("hashB", 2L), 3L, "hashX", "hashC", rustIntact = true))
     }
 
     @Test
     fun notResumableWhenRustNotIntact() {
         // A forged extra row that the Rust walk rejects must never be healed.
-        assertFalse(isResumableAppend(AuditAnchor("hashB", 2L), 3L, "hashB", rustIntact = false))
+        assertFalse(isResumableAppend(AuditAnchor("hashB", 2L), 3L, "hashB", "hashC", rustIntact = false))
     }
 
     @Test
     fun notResumableWhenNotExactlyOneAhead() {
-        assertFalse(isResumableAppend(AuditAnchor("hashB", 2L), 2L, "hashB", rustIntact = true))
-        assertFalse(isResumableAppend(AuditAnchor("hashB", 2L), 4L, "hashB", rustIntact = true))
-        assertFalse(isResumableAppend(AuditAnchor("hashB", 2L), 1L, "hashB", rustIntact = true))
+        assertFalse(isResumableAppend(AuditAnchor("hashB", 2L), 2L, "hashB", "hashC", rustIntact = true))
+        assertFalse(isResumableAppend(AuditAnchor("hashB", 2L), 4L, "hashB", "hashC", rustIntact = true))
+        assertFalse(isResumableAppend(AuditAnchor("hashB", 2L), 1L, "hashB", "hashC", rustIntact = true))
     }
 
     @Test
     fun resumableFirstAppendAfterResetWithNullPreviousHash() {
         // After a clear/reset the zero anchor holds "" as the tail; the first real row
-        // chains onto it with a null previousHash, which must read as resumable.
-        assertTrue(isResumableAppend(AuditAnchor("", 0L), 1L, null, rustIntact = true))
+        // chains onto it with a null previousHash and a real (non-empty) HMAC hash,
+        // which must read as resumable.
+        assertTrue(isResumableAppend(AuditAnchor("", 0L), 1L, null, "hashA", rustIntact = true))
+    }
+
+    @Test
+    fun notResumableWhenEmptyTailLegacyInjectionAgainstZeroAnchor() {
+        // FIX 1: a single attacker-injected legacy row against the empty zero anchor has
+        // an empty entryHash. It otherwise looks like a first post-reset append (count 1,
+        // null previousHash, Rust excuses it as legacy), so the empty-tail guard is the
+        // only thing stopping the forged history from being anchored. Must be rejected.
+        assertFalse(isResumableAppend(AuditAnchor("", 0L), 1L, null, "", rustIntact = true))
+    }
+
+    @Test
+    fun resumableWhenNonEmptyTailFirstAppendStillHeals() {
+        // The legit crash-resumed first append carries a real HMAC tail, so the FIX 1
+        // guard does not disturb the healing path.
+        assertTrue(isResumableAppend(AuditAnchor("", 0L), 1L, null, "realHmac", rustIntact = true))
     }
 
     @Test

--- a/app/src/test/kotlin/io/privkey/keep/nip55/AuditAnchorTest.kt
+++ b/app/src/test/kotlin/io/privkey/keep/nip55/AuditAnchorTest.kt
@@ -1,6 +1,8 @@
 package io.privkey.keep.nip55
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -8,7 +10,7 @@ import org.junit.Test
  * keyed-HMAC walk against tail truncation (newest rows deleted) and head
  * fabrication (legacy rows prepended) by an attacker with Room write access.
  * Anchor persistence is Keystore-backed and native-bound; only the pure
- * reconciliation decision is unit-tested here.
+ * reconciliation/seed/tamper decisions are unit-tested here.
  */
 class AuditAnchorTest {
 
@@ -18,7 +20,7 @@ class AuditAnchorTest {
     fun cleanChainMatchingAnchorIsValid() {
         assertEquals(
             ChainVerificationResult.Valid,
-            resolveChainVerification(AuditAnchor("hashB", 2L), 2L, "hashB", 2L, valid)
+            resolveChainVerification(false, AuditAnchor("hashB", 2L), 2L, "hashB", 2L, valid)
         )
     }
 
@@ -27,7 +29,7 @@ class AuditAnchorTest {
         // Newest row deleted: fewer rows than the anchor recorded.
         assertEquals(
             ChainVerificationResult.Truncated(1L),
-            resolveChainVerification(AuditAnchor("hashB", 2L), 1L, "hashA", 1L, valid)
+            resolveChainVerification(false, AuditAnchor("hashB", 2L), 1L, "hashA", 1L, valid)
         )
     }
 
@@ -36,7 +38,7 @@ class AuditAnchorTest {
         // Same count but the most-recent hash no longer matches the anchor.
         assertEquals(
             ChainVerificationResult.Truncated(2L),
-            resolveChainVerification(AuditAnchor("hashB", 2L), 2L, "hashX", 2L, valid)
+            resolveChainVerification(false, AuditAnchor("hashB", 2L), 2L, "hashX", 2L, valid)
         )
     }
 
@@ -46,22 +48,32 @@ class AuditAnchorTest {
         assertEquals(
             ChainVerificationResult.Tampered(3L),
             resolveChainVerification(
-                AuditAnchor("hashB", 2L), 3L, "hashB", 3L,
+                false, AuditAnchor("hashB", 2L), 3L, "hashB", 3L,
                 ChainVerificationResult.PartiallyVerified(1)
             )
         )
     }
 
     @Test
+    fun headFabricationWithRustValidIsStillTampered() {
+        // Even when the walk reports a fully Valid chain, a count that outgrew the
+        // anchor means rows were inserted out-of-band.
+        assertEquals(
+            ChainVerificationResult.Tampered(3L),
+            resolveChainVerification(false, AuditAnchor("hashB", 2L), 3L, "hashB", 3L, valid)
+        )
+    }
+
+    @Test
     fun firstRunWithoutAnchorDefersToRust() {
-        assertEquals(valid, resolveChainVerification(null, 2L, "hashB", 2L, valid))
+        assertEquals(valid, resolveChainVerification(false, null, 2L, "hashB", 2L, valid))
     }
 
     @Test
     fun emptyDbWithZeroAnchorIsValid() {
         assertEquals(
             ChainVerificationResult.Valid,
-            resolveChainVerification(AuditAnchor("", 0L), 0L, "", 0L, valid)
+            resolveChainVerification(false, AuditAnchor("", 0L), 0L, "", 0L, valid)
         )
     }
 
@@ -71,7 +83,7 @@ class AuditAnchorTest {
         assertEquals(
             ChainVerificationResult.Tampered(2L),
             resolveChainVerification(
-                AuditAnchor("hashB", 2L), 2L, "hashB", 2L,
+                false, AuditAnchor("hashB", 2L), 2L, "hashB", 2L,
                 ChainVerificationResult.Tampered(2L)
             )
         )
@@ -82,7 +94,7 @@ class AuditAnchorTest {
         assertEquals(
             ChainVerificationResult.Broken(2L),
             resolveChainVerification(
-                AuditAnchor("hashB", 2L), 1L, "hashA", 1L,
+                false, AuditAnchor("hashB", 2L), 1L, "hashA", 1L,
                 ChainVerificationResult.Broken(2L)
             )
         )
@@ -93,7 +105,56 @@ class AuditAnchorTest {
         val partial = ChainVerificationResult.PartiallyVerified(1)
         assertEquals(
             partial,
-            resolveChainVerification(AuditAnchor("hashB", 3L), 3L, "hashB", 3L, partial)
+            resolveChainVerification(false, AuditAnchor("hashB", 3L), 3L, "hashB", 3L, partial)
         )
+    }
+
+    @Test
+    fun rustTruncatedPassesThroughWhenAnchorMatches() {
+        // Anchor is consistent but the keyed walk itself found a break: surface it.
+        assertEquals(
+            ChainVerificationResult.Truncated(2L),
+            resolveChainVerification(
+                false, AuditAnchor("hashB", 2L), 2L, "hashB", 2L,
+                ChainVerificationResult.Truncated(2L)
+            )
+        )
+    }
+
+    @Test
+    fun stickyTamperFlagOverridesConsistentChain() {
+        // Out-of-band mutation was caught at append/prune time and re-laundered into a
+        // now-consistent chain; the sticky flag must still report tampering.
+        assertEquals(
+            ChainVerificationResult.Tampered(2L),
+            resolveChainVerification(true, AuditAnchor("hashB", 2L), 2L, "hashB", 2L, valid)
+        )
+    }
+
+    @Test
+    fun stickyTamperFlagOverridesNullAnchor() {
+        assertEquals(
+            ChainVerificationResult.Tampered(2L),
+            resolveChainVerification(true, null, 2L, "hashB", 2L, valid)
+        )
+    }
+
+    @Test
+    fun seedOnlyWhenAnchorNullAndRustValid() {
+        assertTrue(shouldSeed(null, valid))
+        assertTrue(shouldSeed(null, ChainVerificationResult.PartiallyVerified(2)))
+    }
+
+    @Test
+    fun noSeedWhenRustChainIsBad() {
+        assertFalse(shouldSeed(null, ChainVerificationResult.Broken(1L)))
+        assertFalse(shouldSeed(null, ChainVerificationResult.Tampered(1L)))
+        assertFalse(shouldSeed(null, ChainVerificationResult.Truncated(1L)))
+    }
+
+    @Test
+    fun noSeedWhenAnchorPresent() {
+        assertFalse(shouldSeed(AuditAnchor("hashB", 2L), valid))
+        assertFalse(shouldSeed(AuditAnchor("", 0L), valid))
     }
 }

--- a/app/src/test/kotlin/io/privkey/keep/nip55/AuditAnchorTest.kt
+++ b/app/src/test/kotlin/io/privkey/keep/nip55/AuditAnchorTest.kt
@@ -157,4 +157,30 @@ class AuditAnchorTest {
         assertFalse(shouldSeed(AuditAnchor("hashB", 2L), valid))
         assertFalse(shouldSeed(AuditAnchor("", 0L), valid))
     }
+
+    @Test
+    fun resumableAppendWhenOneAheadChainedAndIntact() {
+        // DB one row ahead, newest row chained onto the anchored tail, Rust intact:
+        // a legit append whose post-commit anchor advance was lost to a crash.
+        assertTrue(isResumableAppend(AuditAnchor("hashB", 2L), 3L, "hashB", rustIntact = true))
+    }
+
+    @Test
+    fun notResumableWhenNotChainedOntoAnchor() {
+        // Newest row does not link to the anchored tail (e.g. head fabrication shifts it).
+        assertFalse(isResumableAppend(AuditAnchor("hashB", 2L), 3L, "hashX", rustIntact = true))
+    }
+
+    @Test
+    fun notResumableWhenRustNotIntact() {
+        // A forged extra row that the Rust walk rejects must never be healed.
+        assertFalse(isResumableAppend(AuditAnchor("hashB", 2L), 3L, "hashB", rustIntact = false))
+    }
+
+    @Test
+    fun notResumableWhenNotExactlyOneAhead() {
+        assertFalse(isResumableAppend(AuditAnchor("hashB", 2L), 2L, "hashB", rustIntact = true))
+        assertFalse(isResumableAppend(AuditAnchor("hashB", 2L), 4L, "hashB", rustIntact = true))
+        assertFalse(isResumableAppend(AuditAnchor("hashB", 2L), 1L, "hashB", rustIntact = true))
+    }
 }

--- a/app/src/test/kotlin/io/privkey/keep/nip55/AuditAnchorTest.kt
+++ b/app/src/test/kotlin/io/privkey/keep/nip55/AuditAnchorTest.kt
@@ -183,4 +183,41 @@ class AuditAnchorTest {
         assertFalse(isResumableAppend(AuditAnchor("hashB", 2L), 4L, "hashB", rustIntact = true))
         assertFalse(isResumableAppend(AuditAnchor("hashB", 2L), 1L, "hashB", rustIntact = true))
     }
+
+    @Test
+    fun resumableFirstAppendAfterResetWithNullPreviousHash() {
+        // After a clear/reset the zero anchor holds "" as the tail; the first real row
+        // chains onto it with a null previousHash, which must read as resumable.
+        assertTrue(isResumableAppend(AuditAnchor("", 0L), 1L, null, rustIntact = true))
+    }
+
+    @Test
+    fun resumablePruneWhenFewerRowsSameTailAndIntact() {
+        // Crash-interrupted head prune: oldest rows gone, tail unchanged, Rust intact.
+        assertTrue(isResumablePrune(AuditAnchor("hashB", 5L), 3L, "hashB", rustIntact = true))
+    }
+
+    @Test
+    fun notResumablePruneWhenTailChanged() {
+        // Tail truncation deletes the newest rows, so the tail hash differs: never excused.
+        assertFalse(isResumablePrune(AuditAnchor("hashB", 5L), 3L, "hashA", rustIntact = true))
+    }
+
+    @Test
+    fun notResumablePruneWhenRustNotIntact() {
+        assertFalse(isResumablePrune(AuditAnchor("hashB", 5L), 3L, "hashB", rustIntact = false))
+    }
+
+    @Test
+    fun notResumablePruneWhenCountNotLower() {
+        assertFalse(isResumablePrune(AuditAnchor("hashB", 5L), 5L, "hashB", rustIntact = true))
+        assertFalse(isResumablePrune(AuditAnchor("hashB", 5L), 6L, "hashB", rustIntact = true))
+    }
+
+    @Test
+    fun notResumablePruneToEmpty() {
+        // Prune that empties the DB changes the tail to "": indistinguishable from a full
+        // wipe by state alone, so it is not excused here (the clear marker handles clears).
+        assertFalse(isResumablePrune(AuditAnchor("hashB", 5L), 0L, "", rustIntact = true))
+    }
 }

--- a/app/src/test/kotlin/io/privkey/keep/nip55/AuditAnchorTest.kt
+++ b/app/src/test/kotlin/io/privkey/keep/nip55/AuditAnchorTest.kt
@@ -1,0 +1,99 @@
+package io.privkey.keep.nip55
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Coverage for the audit-chain tail anchor (gh #308), which hardens the Rust
+ * keyed-HMAC walk against tail truncation (newest rows deleted) and head
+ * fabrication (legacy rows prepended) by an attacker with Room write access.
+ * Anchor persistence is Keystore-backed and native-bound; only the pure
+ * reconciliation decision is unit-tested here.
+ */
+class AuditAnchorTest {
+
+    private val valid = ChainVerificationResult.Valid
+
+    @Test
+    fun cleanChainMatchingAnchorIsValid() {
+        assertEquals(
+            ChainVerificationResult.Valid,
+            resolveChainVerification(AuditAnchor("hashB", 2L), 2L, "hashB", 2L, valid)
+        )
+    }
+
+    @Test
+    fun tailTruncationByCountIsTruncated() {
+        // Newest row deleted: fewer rows than the anchor recorded.
+        assertEquals(
+            ChainVerificationResult.Truncated(1L),
+            resolveChainVerification(AuditAnchor("hashB", 2L), 1L, "hashA", 1L, valid)
+        )
+    }
+
+    @Test
+    fun tailTruncationByHashIsTruncated() {
+        // Same count but the most-recent hash no longer matches the anchor.
+        assertEquals(
+            ChainVerificationResult.Truncated(2L),
+            resolveChainVerification(AuditAnchor("hashB", 2L), 2L, "hashX", 2L, valid)
+        )
+    }
+
+    @Test
+    fun headFabricationGrowingCountIsTampered() {
+        // Prepended legacy rows: count grows; the Rust walk excuses them as legacy.
+        assertEquals(
+            ChainVerificationResult.Tampered(3L),
+            resolveChainVerification(
+                AuditAnchor("hashB", 2L), 3L, "hashB", 3L,
+                ChainVerificationResult.PartiallyVerified(1)
+            )
+        )
+    }
+
+    @Test
+    fun firstRunWithoutAnchorDefersToRust() {
+        assertEquals(valid, resolveChainVerification(null, 2L, "hashB", 2L, valid))
+    }
+
+    @Test
+    fun emptyDbWithZeroAnchorIsValid() {
+        assertEquals(
+            ChainVerificationResult.Valid,
+            resolveChainVerification(AuditAnchor("", 0L), 0L, "", 0L, valid)
+        )
+    }
+
+    @Test
+    fun rustTamperedIsNotDowngraded() {
+        // An anchor match must not mask a tamper the Rust walk already found.
+        assertEquals(
+            ChainVerificationResult.Tampered(2L),
+            resolveChainVerification(
+                AuditAnchor("hashB", 2L), 2L, "hashB", 2L,
+                ChainVerificationResult.Tampered(2L)
+            )
+        )
+    }
+
+    @Test
+    fun rustBrokenIsNotDowngraded() {
+        assertEquals(
+            ChainVerificationResult.Broken(2L),
+            resolveChainVerification(
+                AuditAnchor("hashB", 2L), 1L, "hashA", 1L,
+                ChainVerificationResult.Broken(2L)
+            )
+        )
+    }
+
+    @Test
+    fun partiallyVerifiedWithMatchingAnchorIsPreserved() {
+        val partial = ChainVerificationResult.PartiallyVerified(1)
+        assertEquals(
+            partial,
+            resolveChainVerification(AuditAnchor("hashB", 3L), 3L, "hashB", 3L, partial)
+        )
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened NIP-55 audit log integrity with persistent tail anchoring (hash + count) plus sticky tamper detection.
  * Improved crash recovery and safe continuation of audit logging during append/prune/clear operations, including trust-on-first-use behavior.
* **Tests**
  * Added comprehensive coverage for anchor verification, resumable append/prune decisions, tamper precedence, and edge cases (null/empty/truncated chains).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->