### PR TITLE
nip46: run global rate-limit check after denylist/authorization gate

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/nip46/BunkerService.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip46/BunkerService.kt
@@ -537,11 +537,6 @@ class BunkerService : Service() {
             return REJECTED
         }
 
-        if (isRateLimited(clientPubkey)) {
-            if (BuildConfig.DEBUG) Log.w(TAG, "Request from ${truncatePubkey(clientPubkey)} rate limited")
-            return REJECTED
-        }
-
         val mobile = keepMobileRef
         val pk = clientPubkey.lowercase()
         val denylisted = runCatching { Nip46ClientStore.isDenylisted(this, pk) }.getOrDefault(true)
@@ -550,8 +545,13 @@ class BunkerService : Service() {
         }.getOrDefault(false)))
         val isConnectRequest = request.method == "connect"
 
-        if (!isAuthorized && !isConnectRequest) {
+        if (requestGateDecision(isAuthorized, isConnectRequest) == RequestGate.REJECT_UNAUTHORIZED) {
             if (BuildConfig.DEBUG) Log.w(TAG, "Unauthorized client ${truncatePubkey(clientPubkey)} attempted ${request.method}")
+            return REJECTED
+        }
+
+        if (isRateLimited(clientPubkey)) {
+            if (BuildConfig.DEBUG) Log.w(TAG, "Request from ${truncatePubkey(clientPubkey)} rate limited")
             return REJECTED
         }
 

--- a/app/src/main/kotlin/io/privkey/keep/nip46/BunkerService.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip46/BunkerService.kt
@@ -97,6 +97,13 @@ class BunkerService : Service() {
         // so a connect flood cannot drain the signing budget.
         private val bunkerRateLimiter by lazy { Nip46BunkerRateLimiter() }
         private val connectRateLimiter by lazy { Nip46BunkerRateLimiter() }
+
+        private fun limiterFor(isConnectRequest: Boolean): Nip46BunkerRateLimiter =
+            when (rateLimitBudgetFor(isConnectRequest)) {
+                RateLimitBudget.CONNECT -> connectRateLimiter
+                RateLimitBudget.SIGNING -> bunkerRateLimiter
+            }
+
         private val serviceInstanceRef = AtomicReference<BunkerService?>(null)
         private val pendingNostrConnectRequests = ArrayBlockingQueue<NostrConnectRequest>(MAX_PENDING_NOSTR_CONNECT_REQUESTS)
 
@@ -158,11 +165,7 @@ class BunkerService : Service() {
                 val pubkey = clientPubkey ?: approval.request.appPubkey
                 clientPendingCounts[pubkey]?.decrementAndGet()
                 if (approved) {
-                    val limiter = when (rateLimitBudgetFor(approval.isConnectRequest)) {
-                        RateLimitBudget.CONNECT -> connectRateLimiter
-                        RateLimitBudget.SIGNING -> bunkerRateLimiter
-                    }
-                    limiter.resetConsecutive(pubkey.lowercase())
+                    limiterFor(approval.isConnectRequest).resetConsecutive(pubkey.lowercase())
                 }
                 approval.respond(
                     BunkerApprovalResult(
@@ -202,11 +205,7 @@ class BunkerService : Service() {
         // supplies the monotonic clock. Key on the lowercased pubkey so case-variant
         // hex can't mint fresh per-client buckets (matches the authorization path).
         internal fun isRateLimited(clientPubkey: String, isConnectRequest: Boolean): Boolean {
-            val limiter = when (rateLimitBudgetFor(isConnectRequest)) {
-                RateLimitBudget.CONNECT -> connectRateLimiter
-                RateLimitBudget.SIGNING -> bunkerRateLimiter
-            }
-            val limited = limiter.isRateLimited(clientPubkey.lowercase(), SystemClock.elapsedRealtime().toULong())
+            val limited = limiterFor(isConnectRequest).isRateLimited(clientPubkey.lowercase(), SystemClock.elapsedRealtime().toULong())
             // Bounds the concurrency map (clientPendingCounts); rate-limit state is bounded in Rust.
             if (clientPendingCounts.size > MAX_TRACKED_CLIENTS) {
                 evictStaleMaps()

--- a/app/src/main/kotlin/io/privkey/keep/nip46/BunkerService.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip46/BunkerService.kt
@@ -93,8 +93,10 @@ class BunkerService : Service() {
         private val clientPendingCounts = ConcurrentHashMap<String, AtomicInteger>()
         // Global + per-client request rate limiting (window + exponential backoff)
         // lives in Rust; the in-flight concurrency cap above stays here (it bounds
-        // pending approval UI, not a request rate).
+        // pending approval UI, not a request rate). The connect limiter is isolated
+        // so a connect flood cannot drain the signing budget.
         private val bunkerRateLimiter by lazy { Nip46BunkerRateLimiter() }
+        private val connectRateLimiter by lazy { Nip46BunkerRateLimiter() }
         private val serviceInstanceRef = AtomicReference<BunkerService?>(null)
         private val pendingNostrConnectRequests = ArrayBlockingQueue<NostrConnectRequest>(MAX_PENDING_NOSTR_CONNECT_REQUESTS)
 
@@ -156,7 +158,11 @@ class BunkerService : Service() {
                 val pubkey = clientPubkey ?: approval.request.appPubkey
                 clientPendingCounts[pubkey]?.decrementAndGet()
                 if (approved) {
-                    bunkerRateLimiter.resetConsecutive(pubkey.lowercase())
+                    val limiter = when (rateLimitBudgetFor(approval.isConnectRequest)) {
+                        RateLimitBudget.CONNECT -> connectRateLimiter
+                        RateLimitBudget.SIGNING -> bunkerRateLimiter
+                    }
+                    limiter.resetConsecutive(pubkey.lowercase())
                 }
                 approval.respond(
                     BunkerApprovalResult(
@@ -195,8 +201,12 @@ class BunkerService : Service() {
         // Global + per-client window + exponential backoff live in Rust; Android
         // supplies the monotonic clock. Key on the lowercased pubkey so case-variant
         // hex can't mint fresh per-client buckets (matches the authorization path).
-        internal fun isRateLimited(clientPubkey: String): Boolean {
-            val limited = bunkerRateLimiter.isRateLimited(clientPubkey.lowercase(), SystemClock.elapsedRealtime().toULong())
+        internal fun isRateLimited(clientPubkey: String, isConnectRequest: Boolean): Boolean {
+            val limiter = when (rateLimitBudgetFor(isConnectRequest)) {
+                RateLimitBudget.CONNECT -> connectRateLimiter
+                RateLimitBudget.SIGNING -> bunkerRateLimiter
+            }
+            val limited = limiter.isRateLimited(clientPubkey.lowercase(), SystemClock.elapsedRealtime().toULong())
             // Bounds the concurrency map (clientPendingCounts); rate-limit state is bounded in Rust.
             if (clientPendingCounts.size > MAX_TRACKED_CLIENTS) {
                 evictStaleMaps()
@@ -213,6 +223,7 @@ class BunkerService : Service() {
                 clientPendingCounts.clear()
             }
             bunkerRateLimiter.clear()
+            connectRateLimiter.clear()
         }
 
         internal fun evictStaleMaps() {
@@ -550,7 +561,7 @@ class BunkerService : Service() {
             return REJECTED
         }
 
-        if (isRateLimited(clientPubkey)) {
+        if (isRateLimited(clientPubkey, isConnectRequest)) {
             if (BuildConfig.DEBUG) Log.w(TAG, "Request from ${truncatePubkey(clientPubkey)} rate limited")
             return REJECTED
         }

--- a/app/src/main/kotlin/io/privkey/keep/nip46/RateLimitBudget.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip46/RateLimitBudget.kt
@@ -1,0 +1,8 @@
+package io.privkey.keep.nip46
+
+internal enum class RateLimitBudget { CONNECT, SIGNING }
+
+// Isolates the unauthenticated `connect` budget from authorized signing so a
+// connect flood (rotating pubkeys) cannot drain the signing budget.
+internal fun rateLimitBudgetFor(isConnectRequest: Boolean): RateLimitBudget =
+    if (isConnectRequest) RateLimitBudget.CONNECT else RateLimitBudget.SIGNING

--- a/app/src/main/kotlin/io/privkey/keep/nip46/RequestGate.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip46/RequestGate.kt
@@ -1,0 +1,24 @@
+package io.privkey.keep.nip46
+
+internal enum class RequestGate { REJECT_UNAUTHORIZED, RATE_LIMIT_THEN_PROCEED }
+
+/**
+ * Orders the NIP-46 request gates (gh #316): the denylist/authorization gate runs
+ * before the shared global rate limiter so denylisted/unauthorized traffic cannot
+ * burn the global budget. `connect` is the legitimate unauthenticated path, so it
+ * passes the authorization gate but is still subject to rate limiting.
+ *
+ * - [RequestGate.REJECT_UNAUTHORIZED] — reject without consulting the rate limiter.
+ * - [RequestGate.RATE_LIMIT_THEN_PROCEED] — apply the global rate limit, then proceed.
+ *
+ * Pure function: no Service state, no native calls, fully unit-testable.
+ */
+internal fun requestGateDecision(
+    isAuthorized: Boolean,
+    isConnectRequest: Boolean
+): RequestGate =
+    if (!isAuthorized && !isConnectRequest) {
+        RequestGate.REJECT_UNAUTHORIZED
+    } else {
+        RequestGate.RATE_LIMIT_THEN_PROCEED
+    }

--- a/app/src/test/kotlin/io/privkey/keep/nip46/RateLimitBudgetTest.kt
+++ b/app/src/test/kotlin/io/privkey/keep/nip46/RateLimitBudgetTest.kt
@@ -1,0 +1,32 @@
+package io.privkey.keep.nip46
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class RateLimitBudgetTest {
+
+    @Test
+    fun connectUsesConnectBudget() {
+        assertEquals(
+            RateLimitBudget.CONNECT,
+            rateLimitBudgetFor(isConnectRequest = true)
+        )
+    }
+
+    @Test
+    fun nonConnectUsesSigningBudget() {
+        assertEquals(
+            RateLimitBudget.SIGNING,
+            rateLimitBudgetFor(isConnectRequest = false)
+        )
+    }
+
+    @Test
+    fun connectAndSigningDrawFromDifferentBudgets() {
+        assertNotEquals(
+            rateLimitBudgetFor(isConnectRequest = true),
+            rateLimitBudgetFor(isConnectRequest = false)
+        )
+    }
+}

--- a/app/src/test/kotlin/io/privkey/keep/nip46/RequestGateTest.kt
+++ b/app/src/test/kotlin/io/privkey/keep/nip46/RequestGateTest.kt
@@ -1,0 +1,49 @@
+package io.privkey.keep.nip46
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Regression coverage for the NIP-46 gate ordering (gh #316): the global rate
+ * limiter must only be consulted after the denylist/authorization gate, so
+ * denylisted/unauthorized traffic cannot consume the shared global budget. The
+ * Service flow (approval Activity, native signing) is out of unit scope.
+ */
+class RequestGateTest {
+
+    @Test
+    fun unauthorizedNonConnectRejectsWithoutRateLimiting() {
+        // Denylisted/unauthorized requests are rejected before the limiter, so a
+        // key-rotating attacker cannot burn the global budget.
+        assertEquals(
+            RequestGate.REJECT_UNAUTHORIZED,
+            requestGateDecision(isAuthorized = false, isConnectRequest = false)
+        )
+    }
+
+    @Test
+    fun connectIsRateLimitedEvenWhenUnauthorized() {
+        // connect is the legitimate unauthenticated path; it passes the auth gate
+        // but must still be rate limited to avoid a new unauthenticated DoS hole.
+        assertEquals(
+            RequestGate.RATE_LIMIT_THEN_PROCEED,
+            requestGateDecision(isAuthorized = false, isConnectRequest = true)
+        )
+    }
+
+    @Test
+    fun authorizedRequestIsRateLimited() {
+        assertEquals(
+            RequestGate.RATE_LIMIT_THEN_PROCEED,
+            requestGateDecision(isAuthorized = true, isConnectRequest = false)
+        )
+    }
+
+    @Test
+    fun authorizedConnectIsRateLimited() {
+        assertEquals(
+            RequestGate.RATE_LIMIT_THEN_PROCEED,
+            requestGateDecision(isAuthorized = true, isConnectRequest = true)
+        )
+    }
+}


### PR DESCRIPTION
- Run the global rate-limit check after the denylist/authorization gate, so unauthorized/denylisted traffic can't drain the global budget (Closes #316).
- Isolate the unauthenticated `connect` rate-limit budget from authorized signing, so a connect flood can't starve legitimate signing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved rate limiting system to distinguish between connection and signing requests, ensuring more effective request handling and resource management.

* **Tests**
  * Added comprehensive test coverage for rate limiting budget allocation and request authorization decision logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->