### PR TITLE
nip55: return rejection result for null-handler batch reject (not RESULT_CANCELED)

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/nip55/Nip55Activity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/Nip55Activity.kt
@@ -846,7 +846,7 @@ class Nip55Activity : FragmentActivity() {
                 }
                 finishWithBatchResults(nip55Handler, rejected)
             } else {
-                finishWithError("User rejected")
+                finishWithRejection()
             }
         }
     }


### PR DESCRIPTION
Closes #333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of batch rejection scenarios to properly return rejection status instead of treating them as errors, ensuring more consistent behavior in signature request flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->