### PR TITLE
nip55: test batch accumulation + approval double-submit guard (#326 items 1 & 4)

### DIFF
--- a/app/src/androidTest/kotlin/io/privkey/keep/nip55/Nip55ApprovalScreenTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/nip55/Nip55ApprovalScreenTest.kt
@@ -103,6 +103,67 @@ class Nip55ApprovalScreenTest {
     }
 
     @Test
+    fun approve_hidesBothButtons_soASecondTapCannotDoubleSubmit() {
+        var approveCount = 0
+        var rejectCount = 0
+
+        compose.setContent {
+            KeepAndroidTheme {
+                ApprovalScreen(
+                    request = signEventRequest(),
+                    callerPackage = "com.example.client",
+                    callerVerified = false,
+                    onApprove = { _, _, _ -> approveCount++ },
+                    onReject = { _, _ -> rejectCount++ }
+                )
+            }
+        }
+
+        compose.onNodeWithText(context.getString(R.string.connections_nip55_approve))
+            .performClick()
+        compose.waitForIdle()
+
+        // isLoading flips true on the first tap and the footer swaps to a progress
+        // spinner, so neither button remains in the tree: a second tap (or a Reject
+        // after an Approve) can never commit a second decision.
+        compose.onNodeWithText(context.getString(R.string.connections_nip55_approve))
+            .assertDoesNotExist()
+        compose.onNodeWithText(context.getString(R.string.connections_nip55_reject))
+            .assertDoesNotExist()
+        assertEquals("Approve fires exactly once", 1, approveCount)
+        assertEquals("Reject must not fire after Approve", 0, rejectCount)
+    }
+
+    @Test
+    fun reject_hidesBothButtons_soASecondTapCannotDoubleSubmit() {
+        var approveCount = 0
+        var rejectCount = 0
+
+        compose.setContent {
+            KeepAndroidTheme {
+                ApprovalScreen(
+                    request = signEventRequest(),
+                    callerPackage = "com.example.client",
+                    callerVerified = false,
+                    onApprove = { _, _, _ -> approveCount++ },
+                    onReject = { _, _ -> rejectCount++ }
+                )
+            }
+        }
+
+        compose.onNodeWithText(context.getString(R.string.connections_nip55_reject))
+            .performClick()
+        compose.waitForIdle()
+
+        compose.onNodeWithText(context.getString(R.string.connections_nip55_reject))
+            .assertDoesNotExist()
+        compose.onNodeWithText(context.getString(R.string.connections_nip55_approve))
+            .assertDoesNotExist()
+        assertEquals("Reject fires exactly once", 1, rejectCount)
+        assertEquals("Approve must not fire after Reject", 0, approveCount)
+    }
+
+    @Test
     fun firstUseCaller_canRememberChoice_showsDurationSelector() {
         compose.setContent {
             KeepAndroidTheme {

--- a/app/src/main/kotlin/io/privkey/keep/nip55/Nip55ApprovalScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/Nip55ApprovalScreen.kt
@@ -240,13 +240,21 @@ fun ApprovalScreen(
             approveLabel = stringResource(R.string.connections_nip55_approve),
             isLoading = isLoading,
             onReject = {
-                isLoading = true
-                onReject(effectiveDuration, if (relayAuthHost != null) relayScope else null)
+                // Idempotency guard: a same-frame second tap (or an approve-then-reject)
+                // landing before the footer recomposes to a spinner must not commit a
+                // second decision. Protects the consent-integrity boundary independent of
+                // recomposition timing.
+                if (!isLoading) {
+                    isLoading = true
+                    onReject(effectiveDuration, if (relayAuthHost != null) relayScope else null)
+                }
             },
             onApprove = {
-                isLoading = true
-                val granted = declaredPermissions.filterIndexed { i, _ -> permissionChecked.getOrElse(i) { false } }
-                onApprove(effectiveDuration, granted, if (relayAuthHost != null) relayScope else null)
+                if (!isLoading) {
+                    isLoading = true
+                    val granted = declaredPermissions.filterIndexed { i, _ -> permissionChecked.getOrElse(i) { false } }
+                    onApprove(effectiveDuration, granted, if (relayAuthHost != null) relayScope else null)
+                }
             }
         )
     }

--- a/app/src/test/kotlin/io/privkey/keep/nip55/BatchAccumulationTest.kt
+++ b/app/src/test/kotlin/io/privkey/keep/nip55/BatchAccumulationTest.kt
@@ -98,4 +98,25 @@ class BatchAccumulationTest {
             decide(nearFull, app, Nip55RequestType.SIGN_EVENT)
         )
     }
+
+    @Test
+    fun beyondCapStillDrops() {
+        // Defensive: a pending list that has somehow exceeded the cap must keep dropping,
+        // not wrap back to accumulating.
+        val overFull = List(cap + 1) { Nip55RequestType.SIGN_EVENT }
+        assertEquals(
+            BatchAccumulation.DROP_OVER_CAP,
+            decide(overFull, app, Nip55RequestType.SIGN_EVENT)
+        )
+    }
+
+    @Test
+    fun pendingBatchContainingGetPublicKeyIsNeverBatchedInto() {
+        // The all{} guard must reject a new request even when get_public_key is not the
+        // sole pending item, so a stray get_public_key can never be co-signed in a batch.
+        assertEquals(
+            BatchAccumulation.RESET,
+            decide(listOf(Nip55RequestType.SIGN_EVENT, Nip55RequestType.GET_PUBLIC_KEY), app, Nip55RequestType.SIGN_EVENT)
+        )
+    }
 }


### PR DESCRIPTION
Test coverage for NIP-55 batch-signing security logic (#326), items 1 & 4. The consent-integrity invariant under test: "the signed set == the displayed set the user approved."

### Changes
- **Item 1 — accumulation rules + cap** (`BatchAccumulationTest.kt`): edge cases for the pure `batchAccumulationDecision` helper — cap boundary (19 accumulate / 20 drop / 21 drop), `get_public_key` never folded in either direction (incl. the `.all{}` predicate, not just the sole-item case), and different-caller-reset winning over the cap.
- **Item 4 — approval double-submit** (`Nip55ApprovalScreenTest.kt`): tapping either Approve or Reject swaps the footer to a spinner so both buttons leave the tree; asserts exactly one decision commits.
- **Security hardening** (`Nip55ApprovalScreen.kt`): `if (!isLoading)` idempotency guard on the click handlers so the same-frame double-tap window no longer depends on recomposition timing. Surfaced by security-review.

### Verification
- `testDebugUnitTest`: 11/11 pass.
- `compileDebugKotlin` + `compileDebugAndroidTestKotlin`: clean (JDK 21).
- Instrumented tests compile; require an emulator to execute (consistent with the rest of `androidTest`).

### Reviews
- security-review: 0 critical / 0 high / 0 medium.
- pr-review: production-ready, no blockers.

### Not in scope
Items 2 & 3 (`decisionLocked` re-entry + displayed-snapshot binding) are `Nip55Activity`-bound and need an Activity harness with faked native handler/biometric. Tracked in #354.