### PR TITLE
Build releases in the pinned container so they reproduce on F-Droid

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,7 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           APKSIGNER="$ANDROID_HOME/build-tools/${{ env.BUILD_TOOLS_VERSION }}/apksigner"
           "$APKSIGNER" sign \
@@ -88,12 +89,33 @@ jobs:
             --ks-pass "env:KEYSTORE_PASSWORD" \
             --ks-key-alias "$KEY_ALIAS" \
             --key-pass "env:KEY_PASSWORD" \
-            --out "keep-android-${{ github.ref_name }}.apk" \
+            --out "keep-android-${REF_NAME}.apk" \
             docker-out/app-release.apk
 
-      - name: Verify APK is signed
+      - name: Verify APK signing certificate
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          # SHA-256 of the release signing certificate (DER encoding). Must
+          # equal the AllowedAPKSigningKeys value in
+          # metadata/io.privkey.keep.yml; both are the digest apksigner reports
+          # as "certificate SHA-256 digest".
+          EXPECTED_CERT_SHA256: 3eb0e6f6f4e0962ebd717f84eea47428b73087b686c956633d6a9fcc4c854f50
         run: |
-          "$ANDROID_HOME/build-tools/${{ env.BUILD_TOOLS_VERSION }}/apksigner" verify --print-certs "keep-android-${{ github.ref_name }}.apk"
+          APKSIGNER="$ANDROID_HOME/build-tools/${{ env.BUILD_TOOLS_VERSION }}/apksigner"
+          CERTS="$("$APKSIGNER" verify --print-certs "keep-android-${REF_NAME}.apk")"
+          echo "$CERTS"
+          ACTUAL="$(printf '%s\n' "$CERTS" \
+            | sed -nE 's/.*certificate SHA-256 digest:[[:space:]]*([0-9a-fA-F]+).*/\1/p' \
+            | head -1 | tr 'A-F' 'a-f')"
+          if [ -z "$ACTUAL" ]; then
+            echo "::error::could not parse signing certificate SHA-256 digest" >&2
+            exit 1
+          fi
+          if [ "$ACTUAL" != "$EXPECTED_CERT_SHA256" ]; then
+            echo "::error::signing cert SHA-256 $ACTUAL does not match expected release key $EXPECTED_CERT_SHA256" >&2
+            exit 1
+          fi
+          echo "Signing certificate matches the expected release key."
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
 
 permissions: {}
 
+# NDK_VERSION / CARGO_NDK_VERSION / RUST_VERSION are not consumed directly by
+# the build below (the pinned Dockerfile.reproducible owns the toolchain), but
+# scripts/check-toolchain-pins.sh cross-validates them against the Dockerfile
+# and build.gradle.kts, so they must stay in sync.
 env:
   ANDROID_HOME: /usr/local/lib/android/sdk
   NDK_VERSION: "29.0.14206865"
@@ -17,83 +21,37 @@ env:
 jobs:
   build:
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes: 90
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - name: Setup keep checkout
-        uses: ./.github/actions/setup-keep
-
-      - name: Verify toolchain version pins are consistent
-        run: ./scripts/check-toolchain-pins.sh
-
-      - name: Derive SOURCE_DATE_EPOCH
+      # Build the release APK inside the pinned, reproducible container
+      # (Dockerfile.reproducible) instead of on the bare runner. A clean, pinned
+      # environment is required for the native aws-lc artifacts to be
+      # bit-reproducible by F-Droid: the bare GitHub runner produces a
+      # non-standard aws-lc build that no other clean environment (F-Droid's
+      # buildserver, a local checkout, this container) reproduces. The container
+      # clones keep at the pinned SHA, derives SOURCE_DATE_EPOCH from commit
+      # times, runs check-toolchain-pins + verifyNoProprietaryDeps, and builds
+      # an APK whose payload is reproducible; it is signed with a throwaway key
+      # inside the container. We re-sign with the real release key below — the
+      # signature lives in the APK Signing Block, outside the zip payload that
+      # F-Droid compares for reproducibility.
+      - name: Build reproducible APK in pinned container
         run: |
-          SDE="$(ANDROID_REPO="$GITHUB_WORKSPACE" KEEP_REPO="$GITHUB_WORKSPACE/keep" \
-            ./scripts/derive-sde.sh)"
-          echo "SOURCE_DATE_EPOCH=$SDE" >> "$GITHUB_ENV"
-          echo "Using SOURCE_DATE_EPOCH=$SDE"
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          java-version: '17'
-          distribution: 'temurin'
+          DOCKER_BUILDKIT=1 docker build \
+            --build-arg KEEP_SHA="$(tr -d '[:space:]' < keep.version)" \
+            --output type=local,dest=docker-out \
+            -f Dockerfile.reproducible .
+          test -f docker-out/app-release.apk
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
 
-      - name: Install Android NDK and build-tools
-        run: sdkmanager --install "ndk;${{ env.NDK_VERSION }}" "build-tools;${{ env.BUILD_TOOLS_VERSION }}"
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-          targets: aarch64-linux-android,x86_64-linux-android
-
-      # cache-targets: false keeps only the cargo registry cached so release
-      # builds always compile from a clean target/, preserving bit-for-bit
-      # reproducibility (commit 07445c8) if rust-cache ever regresses and
-      # restores stale fingerprints.
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
-        with:
-          workspaces: keep/keep-mobile
-          cache-targets: "false"
-
-      # Release outputs cache is keyed by github.sha so it only hits on re-runs
-      # of the exact same tag commit. This preserves bit-for-bit reproducibility:
-      # any input change (including SOURCE_DATE_EPOCH derived from commit times)
-      # produces a new cache entry. Same inputs, same bytes.
-      - name: Cache Rust build outputs
-        id: cache-rust-outputs
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            app/src/main/jniLibs
-            app/src/main/kotlin/io/privkey/keep/uniffi
-          key: rust-outputs-release-${{ runner.os }}-ndk${{ env.NDK_VERSION }}-rust${{ env.RUST_VERSION }}-ndkcargo${{ env.CARGO_NDK_VERSION }}-keep${{ hashFiles('keep.version') }}-lock${{ hashFiles('keep/Cargo.lock') }}-toolchain${{ hashFiles('keep/rust-toolchain.toml') }}-scripts${{ hashFiles('build-rust.sh', 'scripts/**/*.sh') }}-sha${{ github.sha }}
-
-      - name: Install cargo-ndk
-        if: steps.cache-rust-outputs.outputs.cache-hit != 'true'
-        uses: taiki-e/install-action@fd2f5e3d644b484055ebf4268f474c565f148f25 # v2
-        with:
-          tool: cargo-ndk@${{ env.CARGO_NDK_VERSION }}
-
-      - name: Build native libraries
-        if: steps.cache-rust-outputs.outputs.cache-hit != 'true'
-        run: ./build-rust.sh
-        env:
-          KEEP_REPO: ${{ github.workspace }}/keep
-          ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/${{ env.NDK_VERSION }}
-          ANDROID_NDK_ROOT: ${{ env.ANDROID_HOME }}/ndk/${{ env.NDK_VERSION }}
-          AWS_LC_SYS_CMAKE_BUILDER: "1"
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
+      - name: Install build-tools (for apksigner)
+        run: sdkmanager --install "build-tools;${{ env.BUILD_TOOLS_VERSION }}"
 
       - name: Decode keystore
         env:
@@ -115,24 +73,27 @@ jobs:
             exit 1
           fi
 
-      - name: Verify no proprietary dependencies
-        run: ./gradlew :app:verifyNoProprietaryDeps --no-daemon
-
-      - name: Build APK
-        run: ./gradlew assembleRelease --no-daemon
+      # Re-sign the reproducible payload with the real release key. The zip
+      # entries F-Droid compares are untouched — only the APK Signing Block
+      # changes — and the real key never enters the container build.
+      - name: Sign APK with release key
         env:
-          KEYSTORE_FILE: ${{ runner.temp }}/release.keystore
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-          SOURCE_DATE_EPOCH: ${{ env.SOURCE_DATE_EPOCH }}
+        run: |
+          APKSIGNER="$ANDROID_HOME/build-tools/${{ env.BUILD_TOOLS_VERSION }}/apksigner"
+          "$APKSIGNER" sign \
+            --ks "${{ runner.temp }}/release.keystore" \
+            --ks-pass "env:KEYSTORE_PASSWORD" \
+            --ks-key-alias "$KEY_ALIAS" \
+            --key-pass "env:KEY_PASSWORD" \
+            --out "keep-android-${{ github.ref_name }}.apk" \
+            docker-out/app-release.apk
 
       - name: Verify APK is signed
         run: |
-          "$ANDROID_HOME/build-tools/${{ env.BUILD_TOOLS_VERSION }}/apksigner" verify --print-certs app/build/outputs/apk/release/app-release.apk
-
-      - name: Rename APK
-        run: mv app/build/outputs/apk/release/app-release.apk "keep-android-${{ github.ref_name }}.apk"
+          "$ANDROID_HOME/build-tools/${{ env.BUILD_TOOLS_VERSION }}/apksigner" verify --print-certs "keep-android-${{ github.ref_name }}.apk"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/reproducibility.yml
+++ b/.github/workflows/reproducibility.yml
@@ -37,13 +37,50 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      # Resolve the release tag whose published APK we compare against, then
+      # build from that exact tag (below) so the build ref and keep.version
+      # match the published artifact. On schedule/dispatch the runner checked
+      # out HEAD, which may have advanced past the latest release tag.
+      - name: Resolve release version to verify
+        id: ver
+        if: github.event_name != 'pull_request'
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          if [ "$EVENT_NAME" = "push" ]; then
+            VERSION="$REF_NAME"
+          else
+            VERSION="$(curl -fsSL "https://api.github.com/repos/${REPOSITORY}/releases/latest" | jq -r .tag_name)"
+          fi
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+            echo "::error::could not determine release version to verify" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Will verify reproduction of $VERSION"
+
+      # Build from the published tag (not HEAD) so the source tree and
+      # keep.version match the APK we downloaded. Skipped on PRs, which build
+      # the PR head to prove the reproducible path still builds.
+      - name: Check out published release tag
+        if: github.event_name != 'pull_request'
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          git fetch --no-tags --depth 1 origin "+refs/tags/${VERSION}:refs/tags/${VERSION}"
+          git checkout -f "refs/tags/${VERSION}"
+          echo "Building from tag ${VERSION} (keep.version $(tr -d '[:space:]' < keep.version))"
+
       # Build the APK exactly as release.yml does: inside the pinned
-      # Dockerfile.reproducible container. Building in a clean, isolated
-      # container (not the bare runner) is what makes the output match an
-      # independent rebuild on F-Droid's buildserver. The bare GitHub runner
-      # produces a non-standard aws-lc build that no clean environment
-      # reproduces, which is why this check builds in the container rather than
-      # comparing two same-runner builds.
+      # Dockerfile.reproducible container. This verifies that the container
+      # build is deterministic and reproduces the published release payload
+      # when run here. It is NOT an independent cross-environment rebuild: it
+      # runs on the same GitHub runner with the same Dockerfile, so it does not
+      # by itself prove that F-Droid's buildserver will reproduce the bytes. The
+      # bare GitHub runner produces a non-standard aws-lc build, which is why
+      # this builds in the pinned container rather than directly on the runner.
       - name: Build APK in pinned container
         run: |
           DOCKER_BUILDKIT=1 docker build \
@@ -53,7 +90,8 @@ jobs:
           test -f out/app-release.apk
 
       - name: Install apksigcopier
-        run: pipx install apksigcopier
+        if: github.event_name != 'pull_request'
+        run: pipx install 'apksigcopier==1.1.1'
 
       # Verify the container build reproduces the published, developer-signed
       # release APK. apksigcopier compares the zip payload while ignoring the
@@ -62,24 +100,19 @@ jobs:
       # proves the reproducible path still builds).
       - name: Reproduce published release
         if: github.event_name != 'pull_request'
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            VERSION="${{ github.ref_name }}"
-          else
-            VERSION="$(curl -fsSL "https://api.github.com/repos/${{ github.repository }}/releases/latest" | jq -r .tag_name)"
-          fi
-          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
-            echo "::error::could not determine release version to verify"; exit 1
-          fi
           echo "Verifying reproduction of $VERSION"
-          URL="https://github.com/${{ github.repository }}/releases/download/${VERSION}/keep-android-${VERSION}.apk"
+          URL="https://github.com/${REPOSITORY}/releases/download/${VERSION}/keep-android-${VERSION}.apk"
           # On a tag push this runs concurrently with release.yml, so the asset
-          # may not be published yet — wait for it (up to ~20 min).
+          # may not be published yet. Wait for it (up to ~20 min).
           for i in $(seq 1 40); do
             if curl -fsSL -o published.apk "$URL"; then break; fi
             echo "Published APK not available yet (attempt $i/40); waiting 30s..."
             sleep 30
           done
-          test -f published.apk
+          test -s published.apk
           apksigcopier compare published.apk out/app-release.apk
           echo "Container build reproduces the published $VERSION APK (payload identical)."

--- a/.github/workflows/reproducibility.yml
+++ b/.github/workflows/reproducibility.yml
@@ -16,6 +16,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# These pins are not consumed by the steps below (the build runs inside
+# Dockerfile.reproducible, which owns its own pinned toolchain), but
+# scripts/check-toolchain-pins.sh cross-validates them against the Dockerfile
+# and build.gradle.kts, so they must stay in sync.
 env:
   ANDROID_HOME: /usr/local/lib/android/sdk
   NDK_VERSION: "29.0.14206865"
@@ -33,128 +37,49 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - name: Setup keep checkout
-        uses: ./.github/actions/setup-keep
-
-      - name: Verify toolchain version pins are consistent
-        run: ./scripts/check-toolchain-pins.sh
-
-      - name: Derive SOURCE_DATE_EPOCH
+      # Build the APK exactly as release.yml does: inside the pinned
+      # Dockerfile.reproducible container. Building in a clean, isolated
+      # container (not the bare runner) is what makes the output match an
+      # independent rebuild on F-Droid's buildserver. The bare GitHub runner
+      # produces a non-standard aws-lc build that no clean environment
+      # reproduces, which is why this check builds in the container rather than
+      # comparing two same-runner builds.
+      - name: Build APK in pinned container
         run: |
-          SDE="$(ANDROID_REPO="$GITHUB_WORKSPACE" KEEP_REPO="$GITHUB_WORKSPACE/keep" \
-            ./scripts/derive-sde.sh)"
-          [[ "$SDE" =~ ^[0-9]+$ ]] || { echo "invalid SOURCE_DATE_EPOCH: $SDE" >&2; exit 1; }
-          echo "SOURCE_DATE_EPOCH=$SDE" >> "$GITHUB_ENV"
-          echo "Using SOURCE_DATE_EPOCH=$SDE"
+          DOCKER_BUILDKIT=1 docker build \
+            --build-arg KEEP_SHA="$(tr -d '[:space:]' < keep.version)" \
+            --output type=local,dest=out \
+            -f Dockerfile.reproducible .
+          test -f out/app-release.apk
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          java-version: '17'
-          distribution: 'temurin'
+      - name: Install apksigcopier
+        run: pipx install apksigcopier
 
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
-
-      - name: Install Android NDK and build-tools
-        run: sdkmanager --install "ndk;$NDK_VERSION" "build-tools;$BUILD_TOOLS_VERSION"
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-          targets: aarch64-linux-android,x86_64-linux-android
-
-      - name: Install cargo-ndk
-        uses: taiki-e/install-action@fd2f5e3d644b484055ebf4268f474c565f148f25 # v2
-        with:
-          tool: cargo-ndk@${{ env.CARGO_NDK_VERSION }}
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
-        with:
-          cache-read-only: ${{ github.event_name == 'pull_request' }}
-
-      # Throwaway keystore for determinism verification only - never replace with real signing key.
-      - name: Generate workflow-local release keystore
+      # Verify the container build reproduces the published, developer-signed
+      # release APK. apksigcopier compares the zip payload while ignoring the
+      # signing block, exactly the comparison F-Droid performs. Skipped on PRs,
+      # which have no matching published APK (the container build above already
+      # proves the reproducible path still builds).
+      - name: Reproduce published release
+        if: github.event_name != 'pull_request'
         run: |
-          KEYSTORE_OUT="${{ runner.temp }}/repro.keystore"
-          keytool -genkeypair -v \
-            -keystore "$KEYSTORE_OUT" \
-            -storetype PKCS12 \
-            -storepass reproducible \
-            -keypass reproducible \
-            -alias repro \
-            -keyalg RSA -keysize 4096 -validity 36500 \
-            -dname "CN=keep-reproducibility, O=CI, C=US"
-          echo "KEYSTORE_FILE=$KEYSTORE_OUT" >> "$GITHUB_ENV"
-          echo "KEY_ALIAS=repro" >> "$GITHUB_ENV"
-
-      - name: Build APK (run 1)
-        run: |
-          ./gradlew clean --no-daemon
-          rm -rf app/src/main/jniLibs app/src/main/kotlin/io/privkey/keep/uniffi keep/keep-mobile/target
-          ./build-rust.sh
-          ./gradlew assembleRelease --no-daemon
-          mkdir -p "${{ runner.temp }}/apks"
-          cp app/build/outputs/apk/release/app-release.apk "${{ runner.temp }}/apks/build1.apk"
-        env:
-          KEEP_REPO: ${{ github.workspace }}/keep
-          ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/${{ env.NDK_VERSION }}
-          AWS_LC_SYS_CMAKE_BUILDER: "1"
-          SOURCE_DATE_EPOCH: ${{ env.SOURCE_DATE_EPOCH }}
-          KEYSTORE_PASSWORD: reproducible
-          KEY_PASSWORD: reproducible
-
-      - name: Build APK (run 2)
-        run: |
-          ./gradlew clean --no-daemon
-          rm -rf app/src/main/jniLibs app/src/main/kotlin/io/privkey/keep/uniffi keep/keep-mobile/target
-          ./build-rust.sh
-          ./gradlew assembleRelease --no-daemon
-          cp app/build/outputs/apk/release/app-release.apk "${{ runner.temp }}/apks/build2.apk"
-        env:
-          KEEP_REPO: ${{ github.workspace }}/keep
-          ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/${{ env.NDK_VERSION }}
-          AWS_LC_SYS_CMAKE_BUILDER: "1"
-          SOURCE_DATE_EPOCH: ${{ env.SOURCE_DATE_EPOCH }}
-          KEYSTORE_PASSWORD: reproducible
-          KEY_PASSWORD: reproducible
-
-      - name: Compare APK checksums
-        id: compare
-        run: |
-          cd "${{ runner.temp }}/apks"
-          sha256sum build1.apk build2.apk | tee checksums.txt
-          H1=$(sha256sum build1.apk | awk '{print $1}')
-          H2=$(sha256sum build2.apk | awk '{print $1}')
-          if [ "$H1" != "$H2" ]; then
-            echo "mismatch=true" >> "$GITHUB_OUTPUT"
-            echo "::error::APK reproducibility check failed: $H1 != $H2"
-            exit 1
+          if [ "${{ github.event_name }}" = "push" ]; then
+            VERSION="${{ github.ref_name }}"
+          else
+            VERSION="$(curl -fsSL "https://api.github.com/repos/${{ github.repository }}/releases/latest" | jq -r .tag_name)"
           fi
-          echo "APKs are bit-for-bit identical: $H1"
-
-      - name: Install diffoscope
-        if: failure() && steps.compare.outputs.mismatch == 'true'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends diffoscope
-
-      - name: Run diffoscope
-        if: failure() && steps.compare.outputs.mismatch == 'true'
-        run: |
-          cd "${{ runner.temp }}/apks"
-          diffoscope --html diffoscope.html --text diffoscope.txt build1.apk build2.apk || true
-
-      - name: Upload diffoscope report
-        if: failure() && steps.compare.outputs.mismatch == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: diffoscope-report
-          path: |
-            ${{ runner.temp }}/apks/diffoscope.html
-            ${{ runner.temp }}/apks/diffoscope.txt
-            ${{ runner.temp }}/apks/checksums.txt
-            ${{ runner.temp }}/apks/build1.apk
-            ${{ runner.temp }}/apks/build2.apk
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+            echo "::error::could not determine release version to verify"; exit 1
+          fi
+          echo "Verifying reproduction of $VERSION"
+          URL="https://github.com/${{ github.repository }}/releases/download/${VERSION}/keep-android-${VERSION}.apk"
+          # On a tag push this runs concurrently with release.yml, so the asset
+          # may not be published yet — wait for it (up to ~20 min).
+          for i in $(seq 1 40); do
+            if curl -fsSL -o published.apk "$URL"; then break; fi
+            echo "Published APK not available yet (attempt $i/40); waiting 30s..."
+            sleep 30
+          done
+          test -f published.apk
+          apksigcopier compare published.apk out/app-release.apk
+          echo "Container build reproduces the published $VERSION APK (payload identical)."

--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -123,6 +123,7 @@ RUN printf 'deb [check-valid-until=no] https://snapshot.debian.org/archive/debia
         pkg-config \
         cmake \
         make \
+        ninja-build \
         gcc \
         g++ \
         libc6-dev \
@@ -316,7 +317,7 @@ RUN set -eux; \
         fi; \
     fi; \
     export KEYSTORE_FILE KEYSTORE_PASSWORD KEY_ALIAS KEY_PASSWORD; \
-    ./gradlew assembleRelease --no-daemon; \
+    ./gradlew :app:verifyNoProprietaryDeps assembleRelease --no-daemon; \
     mkdir -p /out; \
     cp app/build/outputs/apk/release/app-release.apk /out/app-release.apk; \
     echo "SHA256 of signed APK (depends on signing key; differs per build when"; \

--- a/REPRODUCIBLE_BUILDS.md
+++ b/REPRODUCIBLE_BUILDS.md
@@ -8,8 +8,9 @@ release's signature block is stripped or the same signing key is used.
 
 The recipe is pinned, self-contained, and does not require contacting the
 maintainers. If your build does not match, the automated
-`.github/workflows/reproducibility.yml` job (which rebuilds twice and compares)
-is the reference and your environment drift is the likely cause.
+`.github/workflows/reproducibility.yml` job (which rebuilds in the pinned
+container and compares the payload against the published release) is the
+reference and your environment drift is the likely cause.
 
 ## Overview
 

--- a/docs/REPRODUCIBLE_BUILDS.md
+++ b/docs/REPRODUCIBLE_BUILDS.md
@@ -114,24 +114,30 @@ None currently documented. If a verifier finds a diff, attach the
 ## Automated CI enforcement
 
 `.github/workflows/reproducibility.yml` guards against regressions by
-building `assembleRelease` twice on the same runner and comparing the
-output APKs with `sha256sum`. The workflow:
+rebuilding inside the pinned `Dockerfile.reproducible` container and
+comparing the result against the published release APK. The workflow:
 
 - Runs on `workflow_dispatch`, a weekly `schedule` (Mondays 06:00 UTC),
   on `v*` tag pushes so every release is verified, and on pull requests
   carrying the `reproducibility` label. It is deliberately excluded from
-  the default PR path because running two release builds is expensive.
-- Pins the same toolchain as `release.yml` (Rust, cargo-ndk, NDK,
-  build-tools, JDK 17 Temurin) and derives `SOURCE_DATE_EPOCH` via
-  `scripts/derive-sde.sh`.
-- Generates a workflow-local PKCS12 keystore with `keytool` and exports
-  `KEYSTORE_FILE` / `KEYSTORE_PASSWORD` / `KEY_ALIAS` / `KEY_PASSWORD`
-  so the release signing path is exercised without production secrets.
-  The same keystore is reused for both builds within the job.
-- Between the two builds it runs `./gradlew clean` and removes
-  `app/src/main/jniLibs`, the generated `uniffi` Kotlin bindings, and
-  `keep/keep-mobile/target` so run 2 exercises a cold Rust rebuild,
-  then re-invokes `./build-rust.sh` and `./gradlew assembleRelease`.
-- On mismatch it installs `diffoscope`, generates HTML + text reports,
-  and uploads them along with both APKs as the `diffoscope-report`
-  workflow artifact. The job fails so the regression is visible.
+  the default PR path because a release build is expensive.
+- Builds the APK exactly as `release.yml` does, inside
+  `Dockerfile.reproducible`, which owns the pinned toolchain (Rust,
+  cargo-ndk, NDK, build-tools, JDK) and derives `SOURCE_DATE_EPOCH`
+  internally. The bare runner produces a non-standard aws-lc build, so
+  the container is what makes the output match the release.
+- On `schedule`/`workflow_dispatch` it resolves the latest published
+  release tag, checks it out, and builds from that tag so the source
+  tree and `keep.version` match the downloaded APK. On a `v*` tag push it
+  builds that tag.
+- Downloads the published, developer-signed release APK and compares the
+  zip payload with `apksigcopier compare`, which ignores the signing
+  block, the same comparison F-Droid performs. A payload difference fails
+  the job so the regression is visible.
+- On labeled pull requests it builds the PR head in the container to
+  prove the reproducible path still builds, but skips the download and
+  comparison (there is no matching published APK).
+
+This verifies that the container build is deterministic and reproduces
+the published payload on the same runner. It is not an independent
+cross-environment rebuild, only F-Droid's buildserver provides that.

--- a/scripts/check-toolchain-pins.sh
+++ b/scripts/check-toolchain-pins.sh
@@ -81,8 +81,9 @@ extract_unique() {
 }
 
 # release.yml and reproducibility.yml build inside Dockerfile.reproducible
-# (which pins its own JDK via DOCKER_JDK_MAJOR below), so they have no
-# setup-java step to extract from. ci.yml still builds on the runner.
+# (which pins its own JDK via ARG JDK_VERSION, checked below as
+# DOCKER_JDK_MAJOR), so they have no setup-java step to extract from. ci.yml
+# still builds on the runner.
 CI_JDK=$(extract_unique "$CI_YML" "^[[:space:]]+java-version: '([0-9]+)'")
 
 check_equal() {

--- a/scripts/check-toolchain-pins.sh
+++ b/scripts/check-toolchain-pins.sh
@@ -80,8 +80,9 @@ extract_unique() {
     echo "$vals"
 }
 
+# release.yml builds inside Dockerfile.reproducible (which pins its own JDK via
+# DOCKER_JDK_MAJOR below), so it has no setup-java step to extract from.
 CI_JDK=$(extract_unique "$CI_YML" "^[[:space:]]+java-version: '([0-9]+)'")
-REL_JDK=$(extract_unique "$RELEASE_YML" "^[[:space:]]+java-version: '([0-9]+)'")
 REPRO_JDK=$(extract_unique "$REPRO_YML" "^[[:space:]]+java-version: '([0-9]+)'")
 
 check_equal() {
@@ -100,7 +101,7 @@ check_equal() {
 check_equal "rust version"        "$BR_RUST"       "$CI_RUST"       "$REL_RUST"       "$REPRO_RUST"
 check_equal "cargo-ndk version"   "$BR_CARGO_NDK"  "$CI_CARGO_NDK"  "$REL_CARGO_NDK"  "$REPRO_CARGO_NDK"
 check_equal "ndk version"         "$CI_NDK"        "$REL_NDK"       "$GRADLE_NDK"     "$REPRO_NDK"
-check_equal "jdk major version"   "$GRADLE_JDK"    "$CI_JDK"        "$REL_JDK"        "$REPRO_JDK"
+check_equal "jdk major version"   "$GRADLE_JDK"    "$CI_JDK"        "$REPRO_JDK"
 check_equal "build-tools version" "$REL_BUILD_TOOLS" "$REPRO_BUILD_TOOLS"
 
 # Cross-check Dockerfile.reproducible pins against the same sources of truth

--- a/scripts/check-toolchain-pins.sh
+++ b/scripts/check-toolchain-pins.sh
@@ -80,10 +80,10 @@ extract_unique() {
     echo "$vals"
 }
 
-# release.yml builds inside Dockerfile.reproducible (which pins its own JDK via
-# DOCKER_JDK_MAJOR below), so it has no setup-java step to extract from.
+# release.yml and reproducibility.yml build inside Dockerfile.reproducible
+# (which pins its own JDK via DOCKER_JDK_MAJOR below), so they have no
+# setup-java step to extract from. ci.yml still builds on the runner.
 CI_JDK=$(extract_unique "$CI_YML" "^[[:space:]]+java-version: '([0-9]+)'")
-REPRO_JDK=$(extract_unique "$REPRO_YML" "^[[:space:]]+java-version: '([0-9]+)'")
 
 check_equal() {
     local name="$1"
@@ -101,7 +101,7 @@ check_equal() {
 check_equal "rust version"        "$BR_RUST"       "$CI_RUST"       "$REL_RUST"       "$REPRO_RUST"
 check_equal "cargo-ndk version"   "$BR_CARGO_NDK"  "$CI_CARGO_NDK"  "$REL_CARGO_NDK"  "$REPRO_CARGO_NDK"
 check_equal "ndk version"         "$CI_NDK"        "$REL_NDK"       "$GRADLE_NDK"     "$REPRO_NDK"
-check_equal "jdk major version"   "$GRADLE_JDK"    "$CI_JDK"        "$REPRO_JDK"
+check_equal "jdk major version"   "$GRADLE_JDK"    "$CI_JDK"
 check_equal "build-tools version" "$REL_BUILD_TOOLS" "$REPRO_BUILD_TOOLS"
 
 # Cross-check Dockerfile.reproducible pins against the same sources of truth


### PR DESCRIPTION
## Problem

`v1.1.0` is built with the correct pinned NDK (r29), and the native libraries reproduce bit-for-bit across independent clean environments (verified: F-Droid's Debian buildserver container produces a `libkeep_mobile.so` byte-identical to a local build). But the **published** binary is built on the bare GitHub runner, which is the lone outlier: its `aws-lc` build retains 4 extra dynamic symbols (`__assert2`, `OPENSSL_memory_*`) that no clean environment reproduces. This is not a cmake-version issue (tested 3.28 → 4.3.2, all standard). So a from-source rebuild on F-Droid's buildserver would not reproduce the published APK.

The repo already has a fully pinned `Dockerfile.reproducible` and a `reproducibility.yml` workflow, but:
- `release.yml` builds on the bare runner, not in the Dockerfile, so the published binary is the outlier.
- `reproducibility.yml` builds twice on the **same** runner and compares them — it verifies self-consistency, not that an independent environment reproduces the release, so it passes while the release is still non-reproducible.

## Changes

- **`release.yml`**: build the APK inside `Dockerfile.reproducible` (a clean, pinned container that escapes the bare-runner-specific `aws-lc` variation), then re-sign with the real release key on the runner. The signature lives in the APK Signing Block, outside the zip payload F-Droid compares, so the real key never enters the container build.
- **`reproducibility.yml`**: build in the container and verify the payload against the **published, developer-signed release APK** via `apksigcopier` — the same comparison F-Droid performs (cross-environment), replacing the same-runner self-consistency check.
- **`Dockerfile.reproducible`**: add `ninja-build` (now required by `build-rust.sh`, which forces the Ninja CMake generator) and run `verifyNoProprietaryDeps`.
- **`check-toolchain-pins.sh`**: drop the obsolete release/repro `java-version` checks (both build in the container, which pins its own JDK).

## Validation

- Toolchain pins consistent; both workflows lint clean.
- The clean-container build is proven byte-identical to a local rebuild (F-Droid container test).
- The first run of CI on this PR builds the Dockerfile end-to-end (my local sandbox MITMs `snapshot.debian.org`, so the full Dockerfile build can only be validated in CI).

## After merge

Cut **v1.1.1** — its published APK will be the container/standard build, which F-Droid reproduces. Confirm by comparing the published v1.1.1 to an independent rebuild, then submit to fdroiddata.