### PR TITLE
Reproducibility CI fix + F-Droid metadata to v1.1.1

### DIFF
--- a/.github/workflows/reproducibility.yml
+++ b/.github/workflows/reproducibility.yml
@@ -89,6 +89,14 @@ jobs:
             -f Dockerfile.reproducible .
           test -f out/app-release.apk
 
+      - name: Setup Android SDK
+        if: github.event_name != 'pull_request'
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
+
+      - name: Install build-tools (apksigcopier needs apksigner)
+        if: github.event_name != 'pull_request'
+        run: sdkmanager --install "build-tools;${{ env.BUILD_TOOLS_VERSION }}"
+
       - name: Install apksigcopier
         if: github.event_name != 'pull_request'
         run: pipx install 'apksigcopier==1.1.1'
@@ -103,6 +111,7 @@ jobs:
         env:
           VERSION: ${{ steps.ver.outputs.version }}
           REPOSITORY: ${{ github.repository }}
+          APKSIGNER: ${{ env.ANDROID_HOME }}/build-tools/${{ env.BUILD_TOOLS_VERSION }}/apksigner
         run: |
           echo "Verifying reproduction of $VERSION"
           URL="https://github.com/${REPOSITORY}/releases/download/${VERSION}/keep-android-${VERSION}.apk"

--- a/.github/workflows/reproducibility.yml
+++ b/.github/workflows/reproducibility.yml
@@ -93,9 +93,13 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
 
-      - name: Install build-tools (apksigcopier needs apksigner)
+      - name: Install build-tools and put apksigner on PATH
         if: github.event_name != 'pull_request'
-        run: sdkmanager --install "build-tools;${{ env.BUILD_TOOLS_VERSION }}"
+        run: |
+          sdkmanager --install "build-tools;${{ env.BUILD_TOOLS_VERSION }}"
+          # apksigcopier invokes `apksigner` from PATH; build-tools is not on
+          # PATH by default, so add it.
+          echo "${{ env.ANDROID_HOME }}/build-tools/${{ env.BUILD_TOOLS_VERSION }}" >> "$GITHUB_PATH"
 
       - name: Install apksigcopier
         if: github.event_name != 'pull_request'
@@ -111,7 +115,6 @@ jobs:
         env:
           VERSION: ${{ steps.ver.outputs.version }}
           REPOSITORY: ${{ github.repository }}
-          APKSIGNER: ${{ env.ANDROID_HOME }}/build-tools/${{ env.BUILD_TOOLS_VERSION }}/apksigner
         run: |
           echo "Verifying reproduction of $VERSION"
           URL="https://github.com/${REPOSITORY}/releases/download/${VERSION}/keep-android-${VERSION}.apk"

--- a/metadata/io.privkey.keep.yml
+++ b/metadata/io.privkey.keep.yml
@@ -13,9 +13,9 @@ Repo: https://github.com/privkeyio/keep-android
 Binaries: https://github.com/privkeyio/keep-android/releases/download/v%v/keep-android-v%v.apk
 
 Builds:
-  - versionName: 1.0.5
-    versionCode: 17
-    commit: v1.0.5
+  - versionName: 1.1.1
+    versionCode: 19
+    commit: v1.1.1
     sudo:
       - apt-get update
       - apt-get install -y --no-install-recommends pkg-config cmake make ninja-build gcc g++
@@ -50,5 +50,5 @@ AllowedAPKSigningKeys: 3eb0e6f6f4e0962ebd717f84eea47428b73087b686c956633d6a9fcc4
 
 AutoUpdateMode: Version v%v
 UpdateCheckMode: Tags
-CurrentVersion: 1.0.5
-CurrentVersionCode: 17
+CurrentVersion: 1.1.1
+CurrentVersionCode: 19


### PR DESCRIPTION
Two related follow-ups after v1.1.1 (the first reproducible release).

## 1. Reproducibility CI fix
The v1.1.1 reproducibility run failed at the compare step with `apksigner command not found`: `apksigcopier` shells out to `apksigner`, but the verify job never installed Android build-tools. The container build and the published-APK download both succeeded — only the comparison couldn't run. Fix: install build-tools and point `apksigcopier` at `apksigner` via the `APKSIGNER` env var.

## 2. F-Droid metadata → v1.1.1
Point `metadata/io.privkey.keep.yml` at the reproducible release: `versionName 1.1.1`, `versionCode 19`, `commit v1.1.1`, `CurrentVersion 1.1.1/19`. This is the artifact F-Droid will build against. Verified: the v1.1.1 release APK exists at the `Binaries:` URL and is signed with the declared `AllowedAPKSigningKeys` (`3eb0e6f6…`).

Note: v1.1.1 itself is already verified reproducible (published native lib byte-identical to an independent build, standard build not the bare-runner outlier). This PR fixes the automated check and bumps the metadata target.