### PR TITLE
F-Droid metadata: target reproducible release v1.1.2

### DIFF
--- a/metadata/io.privkey.keep.yml
+++ b/metadata/io.privkey.keep.yml
@@ -13,9 +13,9 @@ Repo: https://github.com/privkeyio/keep-android
 Binaries: https://github.com/privkeyio/keep-android/releases/download/v%v/keep-android-v%v.apk
 
 Builds:
-  - versionName: 1.1.1
-    versionCode: 19
-    commit: v1.1.1
+  - versionName: 1.1.2
+    versionCode: 20
+    commit: v1.1.2
     sudo:
       - apt-get update
       - apt-get install -y --no-install-recommends pkg-config cmake make ninja-build gcc g++
@@ -50,5 +50,5 @@ AllowedAPKSigningKeys: 3eb0e6f6f4e0962ebd717f84eea47428b73087b686c956633d6a9fcc4
 
 AutoUpdateMode: Version v%v
 UpdateCheckMode: Tags
-CurrentVersion: 1.1.1
-CurrentVersionCode: 19
+CurrentVersion: 1.1.2
+CurrentVersionCode: 20


### PR DESCRIPTION
Point `metadata/io.privkey.keep.yml` at v1.1.2 (versionCode 20) — the first release verified reproducible end-to-end (the reproducibility workflow's apksigcopier compare passed: "Container build reproduces the published v1.1.2 APK (payload identical)").

- `versionName 1.1.2`, `versionCode 20`, `commit v1.1.2`, `CurrentVersion 1.1.2/20`
- v1.1.2 APK exists at the `Binaries:` URL, gradle-signed (v2) with the release key matching `AllowedAPKSigningKeys` (`3eb0e6f6…`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Version 1.1.2 (build `#20`) is now available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->