### PR TITLE
Add Compose UI flow tests for approval, unlock, and launch

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -198,6 +198,9 @@ dependencies {
     androidTestImplementation("androidx.test:runner:1.7.0")
     androidTestImplementation("androidx.room:room-testing:$roomVersion")
     androidTestImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
+    androidTestImplementation(platform("androidx.compose:compose-bom:2026.05.01"))
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
 
     debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
 }

--- a/app/src/androidTest/kotlin/io/privkey/keep/BiometricUnlockScreenTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/BiometricUnlockScreenTest.kt
@@ -21,6 +21,9 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class BiometricUnlockScreenTest {
 
+    // createComposeRule() is deprecated in favor of the v2 API; the classic rule
+    // is intentional here, and the project builds with -Werror.
+    @Suppress("DEPRECATION")
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/androidTest/kotlin/io/privkey/keep/BiometricUnlockScreenTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/BiometricUnlockScreenTest.kt
@@ -21,7 +21,6 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class BiometricUnlockScreenTest {
 
-    @Suppress("DEPRECATION") // classic rule: UnconfinedTestDispatcher, immediate effect execution
     @get:Rule
     val compose = createComposeRule()
 
@@ -75,5 +74,23 @@ class BiometricUnlockScreenTest {
 
         compose.onNodeWithText(context.getString(R.string.biometric_unlock_lockout))
             .assertIsDisplayed()
+    }
+
+    @Test
+    fun permanentLockout_showsPermanentMessageAndStaysLocked() {
+        var unlocked = false
+
+        compose.setContent {
+            KeepAndroidTheme {
+                BiometricUnlockScreen(
+                    onAuthenticate = { BiometricHelper.AuthResult.LOCKOUT_PERMANENT },
+                    onUnlocked = { unlocked = true }
+                )
+            }
+        }
+
+        compose.onNodeWithText(context.getString(R.string.biometric_unlock_lockout_permanent))
+            .assertIsDisplayed()
+        assertFalse("A permanent lockout must not unlock", unlocked)
     }
 }

--- a/app/src/androidTest/kotlin/io/privkey/keep/BiometricUnlockScreenTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/BiometricUnlockScreenTest.kt
@@ -1,0 +1,79 @@
+package io.privkey.keep
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import io.privkey.keep.ui.theme.KeepAndroidTheme
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * User-flow tests for the lock screen. The screen hoists its authentication via
+ * [BiometricUnlockScreen]'s `onAuthenticate`/`onUnlocked` callbacks, so the real
+ * unlock branch is exercised here with a fake authenticator. No system biometric
+ * prompt and no production bypass flag are needed.
+ */
+@RunWith(AndroidJUnit4::class)
+class BiometricUnlockScreenTest {
+
+    @Suppress("DEPRECATION") // classic rule: UnconfinedTestDispatcher, immediate effect execution
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun successfulAuth_unlocks() {
+        var unlocked = false
+
+        compose.setContent {
+            KeepAndroidTheme {
+                BiometricUnlockScreen(
+                    onAuthenticate = { BiometricHelper.AuthResult.SUCCESS },
+                    onUnlocked = { unlocked = true }
+                )
+            }
+        }
+
+        compose.waitUntil(timeoutMillis = 2_000) { unlocked }
+        assertTrue("A successful auth should unlock", unlocked)
+    }
+
+    @Test
+    fun failedAuth_staysLockedAndOffersRetry() {
+        var unlocked = false
+
+        compose.setContent {
+            KeepAndroidTheme {
+                BiometricUnlockScreen(
+                    onAuthenticate = { BiometricHelper.AuthResult.FAILED },
+                    onUnlocked = { unlocked = true }
+                )
+            }
+        }
+
+        compose.onNodeWithText(context.getString(R.string.biometric_unlock_try_again))
+            .assertIsDisplayed()
+        assertFalse("A failed auth must not unlock", unlocked)
+    }
+
+    @Test
+    fun lockout_showsLockoutMessage() {
+        compose.setContent {
+            KeepAndroidTheme {
+                BiometricUnlockScreen(
+                    onAuthenticate = { BiometricHelper.AuthResult.LOCKOUT },
+                    onUnlocked = { }
+                )
+            }
+        }
+
+        compose.onNodeWithText(context.getString(R.string.biometric_unlock_lockout))
+            .assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/kotlin/io/privkey/keep/MainActivityLaunchTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/MainActivityLaunchTest.kt
@@ -1,0 +1,25 @@
+package io.privkey.keep
+
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Smoke test for the launcher flow: starting the app must initialize the native
+ * core, storage, and Compose tree without crashing. Catches regressions in
+ * application/DI/native-library setup before the user sees any screen.
+ */
+@RunWith(AndroidJUnit4::class)
+class MainActivityLaunchTest {
+
+    @Test
+    fun launches_reachesResumed_withoutCrashing() {
+        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+            scenario.moveToState(Lifecycle.State.RESUMED)
+            assertEquals(Lifecycle.State.RESUMED, scenario.state)
+        }
+    }
+}

--- a/app/src/androidTest/kotlin/io/privkey/keep/MainActivityLaunchTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/MainActivityLaunchTest.kt
@@ -3,7 +3,6 @@ package io.privkey.keep
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -18,8 +17,9 @@ class MainActivityLaunchTest {
     @Test
     fun launches_reachesResumed_withoutCrashing() {
         ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+            // moveToState throws if RESUMED is unreachable, so reaching this line
+            // means launch + native/DI/Compose setup succeeded without crashing.
             scenario.moveToState(Lifecycle.State.RESUMED)
-            assertEquals(Lifecycle.State.RESUMED, scenario.state)
         }
     }
 }

--- a/app/src/androidTest/kotlin/io/privkey/keep/nip55/Nip55ApprovalScreenTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/nip55/Nip55ApprovalScreenTest.kt
@@ -25,7 +25,6 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class Nip55ApprovalScreenTest {
 
-    @Suppress("DEPRECATION") // classic rule: UnconfinedTestDispatcher, immediate effect execution
     @get:Rule
     val compose = createComposeRule()
 
@@ -70,7 +69,8 @@ class Nip55ApprovalScreenTest {
 
         assertTrue("onApprove should fire when Approve is tapped", approved)
         assertEquals(
-            "An unverified caller cannot persist a grant",
+            "Duration is forced to JUST_THIS_TIME when remember-choice is gated off " +
+                "(here callerVerified=false and showFirstUseWarning=false)",
             PermissionDuration.JUST_THIS_TIME,
             duration
         )
@@ -99,6 +99,25 @@ class Nip55ApprovalScreenTest {
         compose.waitForIdle()
 
         assertTrue("onReject should fire when Reject is tapped", rejected)
+    }
+
+    @Test
+    fun firstUseCaller_canRememberChoice_showsDurationSelector() {
+        compose.setContent {
+            KeepAndroidTheme {
+                ApprovalScreen(
+                    request = signEventRequest(),
+                    callerPackage = "com.example.client",
+                    callerVerified = false,
+                    showFirstUseWarning = true,
+                    onApprove = { _, _, _ -> },
+                    onReject = { _, _ -> }
+                )
+            }
+        }
+
+        compose.onNodeWithText(context.getString(R.string.connections_nip55_remember_choice))
+            .assertIsDisplayed()
     }
 
     @Test

--- a/app/src/androidTest/kotlin/io/privkey/keep/nip55/Nip55ApprovalScreenTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/nip55/Nip55ApprovalScreenTest.kt
@@ -1,0 +1,121 @@
+package io.privkey.keep.nip55
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import io.privkey.keep.R
+import io.privkey.keep.ui.theme.KeepAndroidTheme
+import io.privkey.keep.uniffi.Nip55DeclaredPermission
+import io.privkey.keep.uniffi.Nip55Request
+import io.privkey.keep.uniffi.Nip55RequestType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * User-flow tests for the NIP-55 approval screen: the screen a user sees when an
+ * external app asks Keep to sign. Guards against the approve/reject controls
+ * disappearing, being renamed, or wiring to the wrong callback.
+ */
+@RunWith(AndroidJUnit4::class)
+class Nip55ApprovalScreenTest {
+
+    @Suppress("DEPRECATION") // classic rule: UnconfinedTestDispatcher, immediate effect execution
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private fun signEventRequest(
+        content: String = """{"kind":1,"content":"gm","tags":[]}"""
+    ) = Nip55Request(
+        requestType = Nip55RequestType.SIGN_EVENT,
+        content = content,
+        pubkey = null,
+        returnType = "signature",
+        compressionType = "none",
+        callbackUrl = null,
+        id = "req-1",
+        currentUser = null,
+        permissions = null
+    )
+
+    @Test
+    fun signEvent_approve_invokesCallbackWithJustThisTime() {
+        var approved = false
+        var duration: PermissionDuration? = null
+        var bundle: List<Nip55DeclaredPermission>? = null
+
+        compose.setContent {
+            KeepAndroidTheme {
+                ApprovalScreen(
+                    request = signEventRequest(),
+                    callerPackage = "com.example.client",
+                    callerVerified = false,
+                    onApprove = { d, b, _ -> approved = true; duration = d; bundle = b },
+                    onReject = { _, _ -> }
+                )
+            }
+        }
+
+        compose.onNodeWithText(context.getString(R.string.connections_nip55_approve))
+            .assertIsDisplayed()
+            .performClick()
+        compose.waitForIdle()
+
+        assertTrue("onApprove should fire when Approve is tapped", approved)
+        assertEquals(
+            "An unverified caller cannot persist a grant",
+            PermissionDuration.JUST_THIS_TIME,
+            duration
+        )
+        assertTrue("No declared permissions to grant for a bare sign_event", bundle!!.isEmpty())
+    }
+
+    @Test
+    fun signEvent_reject_invokesCallback() {
+        var rejected = false
+
+        compose.setContent {
+            KeepAndroidTheme {
+                ApprovalScreen(
+                    request = signEventRequest(),
+                    callerPackage = "com.example.client",
+                    callerVerified = false,
+                    onApprove = { _, _, _ -> },
+                    onReject = { _, _ -> rejected = true }
+                )
+            }
+        }
+
+        compose.onNodeWithText(context.getString(R.string.connections_nip55_reject))
+            .assertIsDisplayed()
+            .performClick()
+        compose.waitForIdle()
+
+        assertTrue("onReject should fire when Reject is tapped", rejected)
+    }
+
+    @Test
+    fun unverifiedCaller_showsWarning() {
+        compose.setContent {
+            KeepAndroidTheme {
+                ApprovalScreen(
+                    request = signEventRequest(),
+                    callerPackage = "com.example.client",
+                    callerVerified = false,
+                    onApprove = { _, _, _ -> },
+                    onReject = { _, _ -> }
+                )
+            }
+        }
+
+        compose.onNodeWithText(context.getString(R.string.nip55_unverified_caller_warning))
+            .assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/kotlin/io/privkey/keep/nip55/Nip55ApprovalScreenTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/nip55/Nip55ApprovalScreenTest.kt
@@ -25,16 +25,17 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class Nip55ApprovalScreenTest {
 
+    // createComposeRule() is deprecated in favor of the v2 API; the classic rule
+    // is intentional here, and the project builds with -Werror.
+    @Suppress("DEPRECATION")
     @get:Rule
     val compose = createComposeRule()
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
 
-    private fun signEventRequest(
-        content: String = """{"kind":1,"content":"gm","tags":[]}"""
-    ) = Nip55Request(
+    private fun signEventRequest() = Nip55Request(
         requestType = Nip55RequestType.SIGN_EVENT,
-        content = content,
+        content = """{"kind":1,"content":"gm","tags":[]}""",
         pubkey = null,
         returnType = "signature",
         compressionType = "none",


### PR DESCRIPTION
## What

Adds the first user-flow UI tests. They cover the screens a user actually drives, which until now had zero coverage (protocol/crypto core was well-tested, the Compose UI was not).

New instrumented tests in `app/src/androidTest/`:

- **`Nip55ApprovalScreenTest`** — the NIP-55 approval screen (the screen shown when an external app asks Keep to sign): Approve/Reject render and are tappable, fire their callbacks with the expected args (`JUST_THIS_TIME` + empty bundle for an unverified caller), and the unverified-caller warning shows.
- **`BiometricUnlockScreenTest`** — the lock screen: a successful auth unlocks, a failed auth stays locked and offers retry, and lockout shows the lockout message.
- **`MainActivityLaunchTest`** — launcher smoke: the app reaches `RESUMED` without crashing (catches app-init / native-load / DI regressions).

## How

- These ride the existing `instrumented-tests` emulator job in `ci.yml` — no workflow changes.
- Adds `androidx.compose.ui:ui-test-junit4` (androidTest) and `ui-test-manifest` (debug).
- **No production code change for the biometric gate:** it is off by default, and `BiometricUnlockScreen` already hoists `onAuthenticate`/`onUnlocked`, so the real unlock branch is exercised with a fake authenticator. No system prompt, no test bypass flag.
- Kept the classic `createComposeRule` (immediate effect execution) with a one-line `@Suppress`; the v2 rule's queued dispatcher would change the `LaunchedEffect` timing the unlock test relies on.

## Verification

`./gradlew :app:compileDebugAndroidTestKotlin` passes on JDK 21. Tests execute in the CI emulator job.

## Follow-up

A handler-level `sign_event` -> verify-signature instrumented test is still missing (today's Frost test only round-trips `get_public_key`). Tracked separately.