### PR TITLE
nip55: drop internal error="rejected" magic string

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/nip55/Nip55Activity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/Nip55Activity.kt
@@ -842,7 +842,7 @@ class Nip55Activity : FragmentActivity() {
             }
             if (nip55Handler != null) {
                 val rejected = items.map {
-                    Nip55Response(result = "", event = null, error = "rejected", id = it.requestId, rejected = true)
+                    Nip55Response(result = "", event = null, error = null, id = it.requestId, rejected = true)
                 }
                 finishWithBatchResults(nip55Handler, rejected)
             } else {


### PR DESCRIPTION
The real `rejected` field on `Nip55Response` now drives batch-result serialization, so the overloaded `error = "rejected"` marker at `Nip55Activity.kt:845` is redundant. Set `error = null`; `rejected = true` is the source of truth. Behavior-equivalent (the `error` string was never serialized to clients).

Resolves the keep-android half of #355. The serializer's `|| r.error.is_some()` is intentionally left in place — it is load-bearing for keep's genuine-error paths (`nip55.rs:418/432`) which set `rejected: false`; dropping it would require a separate cross-repo keep PR.

Closes #355

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated batch rejection handling to set error field to `null` instead of "rejected" text for rejected items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->