### PR TITLE
nip55: add round-trip test for AndroidSigningRateLimiterStorage

### DIFF
--- a/app/src/androidTest/kotlin/io/privkey/keep/nip55/AndroidSigningRateLimiterStorageTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/nip55/AndroidSigningRateLimiterStorageTest.kt
@@ -7,6 +7,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -107,9 +108,14 @@ class AndroidSigningRateLimiterStorageTest {
         storage.save("com.example.app", "counter=3;cooloff=0")
 
         val basePrefs = context.getSharedPreferences("nip55_rate_limiter", Context.MODE_PRIVATE)
+        assertTrue(
+            "backing prefs must receive encrypted entries; empty means prefs-name drift or a no-write regression",
+            basePrefs.all.isNotEmpty()
+        )
         for ((key, value) in basePrefs.all) {
             assertFalse(key.contains("com.example.app"))
             assertFalse(value.toString().contains("com.example.app"))
+            assertFalse(value.toString().contains("counter=3;cooloff=0"))
             assertFalse(value.toString().contains("counter=3"))
         }
     }

--- a/app/src/androidTest/kotlin/io/privkey/keep/nip55/AndroidSigningRateLimiterStorageTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/nip55/AndroidSigningRateLimiterStorageTest.kt
@@ -1,0 +1,67 @@
+package io.privkey.keep.nip55
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AndroidSigningRateLimiterStorageTest {
+
+    private lateinit var context: Context
+    private lateinit var storage: AndroidSigningRateLimiterStorage
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        storage = AndroidSigningRateLimiterStorage(context)
+        storage.clear()
+    }
+
+    @After
+    fun teardown() {
+        storage.clear()
+    }
+
+    @Test
+    fun saveThenLoadReturnsStoredValue() {
+        storage.save("com.example.app", "counter=3;cooloff=0")
+        assertEquals("counter=3;cooloff=0", storage.load("com.example.app"))
+    }
+
+    @Test
+    fun loadOfAbsentKeyReturnsNull() {
+        assertNull(storage.load("com.example.missing"))
+    }
+
+    @Test
+    fun removeThenLoadReturnsNull() {
+        storage.save("com.example.app", "counter=1")
+        storage.remove("com.example.app")
+        assertNull(storage.load("com.example.app"))
+    }
+
+    @Test
+    fun clearWipesAllEntries() {
+        storage.save("com.example.a", "counter=1")
+        storage.save("com.example.b", "counter=2")
+
+        storage.clear()
+
+        assertNull(storage.load("com.example.a"))
+        assertNull(storage.load("com.example.b"))
+    }
+
+    @Test
+    fun savedValueSurvivesFreshAdapterInstance() {
+        storage.save("com.example.app", "counter=7")
+
+        val reopened = AndroidSigningRateLimiterStorage(context)
+        assertEquals("counter=7", reopened.load("com.example.app"))
+    }
+}

--- a/app/src/androidTest/kotlin/io/privkey/keep/nip55/AndroidSigningRateLimiterStorageTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/nip55/AndroidSigningRateLimiterStorageTest.kt
@@ -35,6 +35,22 @@ class AndroidSigningRateLimiterStorageTest {
     }
 
     @Test
+    fun saveOverwritesExistingValue() {
+        storage.save("com.example.app", "counter=3")
+        storage.save("com.example.app", "counter=4")
+        assertEquals("counter=4", storage.load("com.example.app"))
+    }
+
+    @Test
+    fun distinctKeysRoundTripIndependently() {
+        storage.save("com.example.a", "counter=1")
+        storage.save("com.example.b", "counter=2")
+
+        assertEquals("counter=1", storage.load("com.example.a"))
+        assertEquals("counter=2", storage.load("com.example.b"))
+    }
+
+    @Test
     fun loadOfAbsentKeyReturnsNull() {
         assertNull(storage.load("com.example.missing"))
     }
@@ -47,9 +63,29 @@ class AndroidSigningRateLimiterStorageTest {
     }
 
     @Test
+    fun removeLeavesOtherKeysIntact() {
+        storage.save("com.example.a", "counter=1")
+        storage.save("com.example.b", "counter=2")
+
+        storage.remove("com.example.a")
+
+        assertNull(storage.load("com.example.a"))
+        assertEquals("counter=2", storage.load("com.example.b"))
+    }
+
+    @Test
+    fun removeOfAbsentKeyIsNoOp() {
+        storage.save("com.example.a", "counter=1")
+        storage.remove("com.example.missing")
+        assertEquals("counter=1", storage.load("com.example.a"))
+    }
+
+    @Test
     fun clearWipesAllEntries() {
         storage.save("com.example.a", "counter=1")
         storage.save("com.example.b", "counter=2")
+        assertEquals("counter=1", storage.load("com.example.a"))
+        assertEquals("counter=2", storage.load("com.example.b"))
 
         storage.clear()
 

--- a/app/src/androidTest/kotlin/io/privkey/keep/nip55/AndroidSigningRateLimiterStorageTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/nip55/AndroidSigningRateLimiterStorageTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
@@ -99,5 +100,32 @@ class AndroidSigningRateLimiterStorageTest {
 
         val reopened = AndroidSigningRateLimiterStorage(context)
         assertEquals("counter=7", reopened.load("com.example.app"))
+    }
+
+    @Test
+    fun storedEntriesAreEncryptedAtRest() {
+        storage.save("com.example.app", "counter=3;cooloff=0")
+
+        val basePrefs = context.getSharedPreferences("nip55_rate_limiter", Context.MODE_PRIVATE)
+        for ((key, value) in basePrefs.all) {
+            assertFalse(key.contains("com.example.app"))
+            assertFalse(value.toString().contains("com.example.app"))
+            assertFalse(value.toString().contains("counter=3"))
+        }
+    }
+
+    @Test
+    fun emptyValueRoundTripsAsEmptyNotNull() {
+        storage.save("com.example.app", "")
+        assertEquals("", storage.load("com.example.app"))
+    }
+
+    @Test
+    fun clearPersistsAcrossInstances() {
+        storage.save("com.example.app", "counter=1")
+        storage.clear()
+
+        val reopened = AndroidSigningRateLimiterStorage(context)
+        assertNull(reopened.load("com.example.app"))
     }
 }


### PR DESCRIPTION
Closes #313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded Android instrumentation coverage for the signing rate-limiter storage.
  * Added assertions for overwrite behavior, independent handling of multiple keys, key removal (including no-op for missing keys), and full clearing.
  * Verified persistence across newly created storage instances and correct `null`/empty-string round-trips for absent vs empty values.
  * Confirmed stored entries are not written in plaintext by checking underlying preference contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->