### PR TITLE
nip55: extract consent guards into pure helpers with test coverage (#354)

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/nip55/ConsentGuard.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/ConsentGuard.kt
@@ -1,0 +1,33 @@
+package io.privkey.keep.nip55
+
+/**
+ * Decides whether an incoming action against a singleTop [Nip55Activity] is
+ * admitted, given whether the user has already committed an approve/reject
+ * decision ([decisionLocked]).
+ *
+ * Once a decision is committed the activity is finishing on exactly the set the
+ * user saw, so every later action — a second approve/reject tap, a late-arriving
+ * intent ([Nip55Activity.handleIntent]), or a late async risk render
+ * ([Nip55Activity.calculateRiskAndSetupContent] / [Nip55Activity.setupContent]) —
+ * must be ignored. The invariant: a committed decision can never run twice or be
+ * resurrected.
+ *
+ * Returns `true` to proceed, `false` to ignore.
+ *
+ * Pure function: no Activity state, no native calls, fully unit-testable.
+ */
+internal fun consentActionAdmitted(decisionLocked: Boolean): Boolean = !decisionLocked
+
+/**
+ * Returns the snapshot an approve/reject decision must act on: always the
+ * [displayed] set captured at render time, never the live [pending] list.
+ *
+ * A request that races in (via onNewIntent) after the UI was rendered but before
+ * the user taps lands in [pending], not in [displayed]. Binding the decision to
+ * [displayed] guarantees that late request can never be folded into the signed
+ * (or rejected) set. The [pending] parameter is accepted only to make the binding
+ * explicit and testable; it is intentionally not consulted.
+ *
+ * Pure function: no Activity state, no native calls, fully unit-testable.
+ */
+internal fun <T> consentBoundSet(displayed: List<T>, pending: List<T>): List<T> = displayed

--- a/app/src/main/kotlin/io/privkey/keep/nip55/Nip55Activity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/Nip55Activity.kt
@@ -122,7 +122,7 @@ class Nip55Activity : FragmentActivity() {
         if (pinStore?.requiresAuthentication() == true) return finishWithError("locked")
         // The user has already committed a decision on the displayed set; do not
         // fold a late-arriving request into it. The activity is finishing.
-        if (decisionLocked) {
+        if (!consentActionAdmitted(decisionLocked)) {
             if (BuildConfig.DEBUG) Log.w(TAG, "Ignoring intent after decision was committed")
             return
         }
@@ -205,7 +205,7 @@ class Nip55Activity : FragmentActivity() {
             riskAssessment = assessment
             // The user may have already decided while this assessment was running;
             // do not resurrect the approval UI.
-            if (decisionLocked) return@launch
+            if (!consentActionAdmitted(decisionLocked)) return@launch
             setupContent()
         }
     }
@@ -286,7 +286,7 @@ class Nip55Activity : FragmentActivity() {
     private fun setupContent() {
         // A late async render must not re-display (and re-enable) the approval UI
         // after the user has already committed a decision.
-        if (decisionLocked) return
+        if (!consentActionAdmitted(decisionLocked)) return
         val items = pending.toList()
         displayed = items
         if (items.size > 1) {
@@ -416,13 +416,13 @@ class Nip55Activity : FragmentActivity() {
     private fun handleApprove(duration: PermissionDuration, declaredBundle: List<Nip55DeclaredPermission>, relayScope: RelayAuthScope? = null) {
         // Re-entry guard: a second tap, or an async render that re-enabled the
         // buttons, must not commit a second decision.
-        if (decisionLocked) return
+        if (!consentActionAdmitted(decisionLocked)) return
         if (keepApp?.isSigningKilled() == true) {
             return finishWithError("signing_disabled")
         }
         // Lock in the decision and act on exactly the snapshot the user saw.
         decisionLocked = true
-        val shown = displayed
+        val shown = consentBoundSet(displayed, pending)
         if (shown.size > 1) return handleApproveBatch(duration, shown)
         // Re-bind the single-request fields to the displayed request so a request
         // that raced in after render (overwriting the fields) is never signed.
@@ -799,9 +799,9 @@ class Nip55Activity : FragmentActivity() {
     private fun handleReject(duration: PermissionDuration, relayScope: RelayAuthScope? = null) {
         // Re-entry guard: mirrors handleApprove so neither path can run twice or
         // after the other has already committed.
-        if (decisionLocked) return
+        if (!consentActionAdmitted(decisionLocked)) return
         decisionLocked = true
-        val shown = displayed
+        val shown = consentBoundSet(displayed, pending)
         if (shown.size > 1) return handleRejectBatch(duration, shown)
         shown.firstOrNull()?.let {
             request = it.request

--- a/app/src/test/kotlin/io/privkey/keep/nip55/ConsentGuardTest.kt
+++ b/app/src/test/kotlin/io/privkey/keep/nip55/ConsentGuardTest.kt
@@ -1,0 +1,63 @@
+package io.privkey.keep.nip55
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression coverage for the two Activity-bound NIP-55 consent guards (gh #354,
+ * follow-up to #326): the [decisionLocked] re-entry guard and the displayed-snapshot
+ * binding. Both are extracted as pure functions so the security invariants — a
+ * committed decision never runs twice, and the decision acts only on what was on
+ * screen — are testable without an instrumented Activity harness.
+ */
+class ConsentGuardTest {
+
+    @Test
+    fun actionAdmittedWhenNotLocked() {
+        assertTrue(consentActionAdmitted(decisionLocked = false))
+    }
+
+    @Test
+    fun actionIgnoredWhenLocked() {
+        // Once a decision is committed, every later action is ignored. This single
+        // predicate guards all locked-path call sites: a second approve/reject tap
+        // (handleApprove/handleReject), a late-arriving intent (handleIntent), and a
+        // late async render (calculateRiskAndSetupContent/setupContent).
+        assertFalse(consentActionAdmitted(decisionLocked = true))
+    }
+
+    @Test
+    fun boundSetIsTheDisplayedSnapshot() {
+        val displayed = listOf("a", "b")
+        val pending = listOf("a", "b")
+        assertEquals(displayed, consentBoundSet(displayed, pending))
+    }
+
+    @Test
+    fun boundSetIgnoresLatePendingMutation() {
+        // A request that races in after render is appended to the live pending list.
+        // The decision must still act on the displayed snapshot, never the grown list,
+        // so the late request can never be folded into the signed set.
+        val displayed = listOf("a", "b")
+        val pending = mutableListOf("a", "b")
+
+        val bound = consentBoundSet(displayed, pending)
+
+        pending.add("late")
+
+        assertEquals(listOf("a", "b"), bound)
+        assertFalse(bound.contains("late"))
+    }
+
+    @Test
+    fun boundSetReturnsDisplayedEvenWhenPendingDiverges() {
+        // Even when pending has already diverged at decision time, the bound set is
+        // exactly the displayed snapshot.
+        val displayed = listOf("a")
+        val pending = listOf("a", "b", "c")
+        assertSame(displayed, consentBoundSet(displayed, pending))
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consent handling so approval/reject actions can’t be processed after a decision is already locked.
  * Prevented late updates from reopening or re-displaying the consent flow after a choice has been made.
  * Ensured approve/reject actions are tied to the original displayed request set, avoiding changes from newer pending requests.
* **Tests**
  * Added regression coverage for consent gating and request-set binding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->