### PR TITLE
nip55: add batch TOCTOU consent-bypass regression test (#372)

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/nip55/BatchConsentGate.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/BatchConsentGate.kt
@@ -14,7 +14,7 @@ import io.privkey.keep.uniffi.Nip55RequestType
  * [BatchToctouRegressionTest] drives the real wiring: dropping a guard here fails the
  * test. Pure Kotlin, no Android or native dependencies, fully unit-testable.
  */
-internal class BatchConsentGate<T>(
+internal class BatchConsentGate<T, C>(
     private val maxBatchSize: Int,
     private val typeOf: (T) -> Nip55RequestType,
 ) {
@@ -29,6 +29,15 @@ internal class BatchConsentGate<T>(
 
     /** The exact set captured at the last [render]; what a decision must act on. */
     var displayed: List<T> = emptyList()
+        private set
+
+    /**
+     * The caller identity captured alongside [displayed] at the last [render]. A
+     * decision must bind to this, never the live caller state, so a late
+     * different-caller intent that swaps the live caller between render and the tap
+     * cannot redirect the grant/trust/sign to the attacker's package (gh #372).
+     */
+    var displayedCaller: C? = null
         private set
 
     /** Set once [commit] succeeds; every later action is then ignored. */
@@ -68,13 +77,15 @@ internal class BatchConsentGate<T>(
     }
 
     /**
-     * Mirrors [Nip55Activity.setupContent]: capture the pending list as the displayed
-     * snapshot and return it. Returns `null` (leaving [displayed] untouched) once a
-     * decision is locked, so a late async render cannot re-capture a grown batch.
+     * Mirrors [Nip55Activity.setupContent]: capture the pending list (and the [caller]
+     * that owns it) as the displayed snapshot and return it. Returns `null` (leaving
+     * [displayed]/[displayedCaller] untouched) once a decision is locked, so a late
+     * async render cannot re-capture a grown batch or a swapped caller.
      */
-    fun render(): List<T>? {
+    fun render(caller: C): List<T>? {
         if (!admitsAction) return null
         displayed = items.toList()
+        displayedCaller = caller
         return displayed
     }
 

--- a/app/src/main/kotlin/io/privkey/keep/nip55/BatchConsentGate.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/BatchConsentGate.kt
@@ -1,0 +1,92 @@
+package io.privkey.keep.nip55
+
+import io.privkey.keep.uniffi.Nip55RequestType
+
+/**
+ * Owns the singleTop batch-consent state machine for [Nip55Activity]: the pending
+ * accumulation, the snapshot last displayed to the user, and the commit lock. It is
+ * the single production home of the three TOCTOU guards (accumulate / render /
+ * commit) that fix the HIGH consent-bypass finding (gh #372, commit `9a9bf6c`): the
+ * signed/rejected set must equal the set the user saw on screen, so a request that
+ * races in (via onNewIntent) after render but before the tap can never be folded in.
+ *
+ * The Activity delegates to this class rather than re-checking the guards inline, so
+ * [BatchToctouRegressionTest] drives the real wiring: dropping a guard here fails the
+ * test. Pure Kotlin, no Android or native dependencies, fully unit-testable.
+ */
+internal class BatchConsentGate<T>(
+    private val maxBatchSize: Int,
+    private val typeOf: (T) -> Nip55RequestType,
+) {
+    private val items = mutableListOf<T>()
+
+    /** Requests accumulated for the current batch, in arrival order. Read-only. */
+    val pending: List<T> get() = items
+
+    /** Caller the current batch is bound to; a different caller resets the batch. */
+    var batchCaller: String? = null
+        private set
+
+    /** The exact set captured at the last [render]; what a decision must act on. */
+    var displayed: List<T> = emptyList()
+        private set
+
+    /** Set once [commit] succeeds; every later action is then ignored. */
+    var decisionLocked = false
+        private set
+
+    /** True while the activity may still accumulate/render (no committed decision). */
+    val admitsAction: Boolean get() = consentActionAdmitted(decisionLocked)
+
+    /**
+     * Mirrors [Nip55Activity.handleIntent] accumulation. Returns the taken
+     * [BatchAccumulation] decision, or `null` when a committed decision has already
+     * locked the batch (the item is not accumulated). On [BatchAccumulation.RESET]
+     * [onReset] runs before the pending list is cleared, so callers can cancel
+     * notifications for the requests being discarded while they are still present.
+     */
+    fun accumulate(item: T, caller: String, onReset: () -> Unit = {}): BatchAccumulation? {
+        if (!admitsAction) return null
+        val decision = batchAccumulationDecision(
+            pendingTypes = items.map(typeOf),
+            pendingCaller = batchCaller,
+            newType = typeOf(item),
+            newCaller = caller,
+            maxBatchSize = maxBatchSize,
+        )
+        when (decision) {
+            BatchAccumulation.DROP_OVER_CAP -> return decision
+            BatchAccumulation.RESET -> {
+                onReset()
+                items.clear()
+            }
+            BatchAccumulation.ACCUMULATE -> {}
+        }
+        items.add(item)
+        batchCaller = caller
+        return decision
+    }
+
+    /**
+     * Mirrors [Nip55Activity.setupContent]: capture the pending list as the displayed
+     * snapshot and return it. Returns `null` (leaving [displayed] untouched) once a
+     * decision is locked, so a late async render cannot re-capture a grown batch.
+     */
+    fun render(): List<T>? {
+        if (!admitsAction) return null
+        displayed = items.toList()
+        return displayed
+    }
+
+    /**
+     * Mirrors [Nip55Activity.handleApprove]/[Nip55Activity.handleReject]: lock the
+     * batch and return the set the decision acts on, always the [displayed] snapshot
+     * and never the live pending list. Returns `null` if a decision was already
+     * committed, so a decision can never run twice.
+     */
+    fun commit(): List<T>? {
+        if (!admitsAction) return null
+        decisionLocked = true
+        return consentBoundSet(displayed, items)
+    }
+}

--- a/app/src/main/kotlin/io/privkey/keep/nip55/Nip55Activity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/Nip55Activity.kt
@@ -54,19 +54,13 @@ class Nip55Activity : FragmentActivity() {
     private var isNotificationOriginated: Boolean = false
     private var riskAssessment: RiskAssessment? = null
 
-    // Accumulated requests for batch / multi-event signing. Sign requests from the
-    // same caller that arrive (via onNewIntent) before the user acts are collected
-    // here; size 1 renders the single-request UI, size >1 the multi-event UI.
-    private val pending = mutableListOf<PendingNip55Request>()
-    private var batchCaller: String? = null
-
-    // The exact set last rendered to the user. The approve/reject decision acts on
-    // this snapshot (never the live `pending` list), so a request that races in
-    // between render and the user's tap can never be folded into the signed set.
-    private var displayed: List<PendingNip55Request> = emptyList()
-    // Set once the user approves/rejects; further intents are ignored so the
-    // committed decision can only ever apply to what was on screen.
-    private var decisionLocked = false
+    // Batch / multi-event signing state machine. Sign requests from the same caller
+    // that arrive (via onNewIntent) before the user acts are accumulated here; size 1
+    // renders the single-request UI, size >1 the multi-event UI. The gate owns the
+    // pending list, the displayed snapshot the decision binds to, and the commit lock,
+    // and enforces the three TOCTOU guards so a late-racing request can never be folded
+    // into the signed set (gh #372).
+    private val gate = BatchConsentGate<PendingNip55Request>(MAX_BATCH_SIZE) { it.request.requestType }
 
     private class PendingNip55Request(
         val request: Nip55Request,
@@ -122,7 +116,7 @@ class Nip55Activity : FragmentActivity() {
         if (pinStore?.requiresAuthentication() == true) return finishWithError("locked")
         // The user has already committed a decision on the displayed set; do not
         // fold a late-arriving request into it. The activity is finishing.
-        if (!consentActionAdmitted(decisionLocked)) {
+        if (!gate.admitsAction) {
             if (BuildConfig.DEBUG) Log.w(TAG, "Ignoring intent after decision was committed")
             return
         }
@@ -145,30 +139,19 @@ class Nip55Activity : FragmentActivity() {
         val parsed = parseRequest(intent, uriStr) ?: return finishWithError("Invalid request")
         val parsedId = rawId?.takeIf { it.isNotBlank() } ?: parsed.id
 
-        // Accumulate only same-caller operation requests (never get_public_key) up to the cap.
-        when (
-            batchAccumulationDecision(
-                pendingTypes = pending.map { it.request.requestType },
-                pendingCaller = batchCaller,
-                newType = parsed.requestType,
-                newCaller = caller,
-                maxBatchSize = MAX_BATCH_SIZE
-            )
-        ) {
+        // Accumulate only same-caller operation requests (never get_public_key) up to
+        // the cap. On RESET the old batch's notifications are cancelled before the gate
+        // clears it, so no stale notification is left behind.
+        val item = PendingNip55Request(parsed, parsedId, uriStr ?: "")
+        when (gate.accumulate(item, caller, onReset = { cancelAllNotifications() })) {
             BatchAccumulation.DROP_OVER_CAP -> {
                 if (BuildConfig.DEBUG) Log.w(TAG, "Dropping batch request beyond cap of $MAX_BATCH_SIZE")
                 return
             }
-            BatchAccumulation.RESET -> {
-                cancelAllNotifications()
-                pending.clear()
-            }
-            BatchAccumulation.ACCUMULATE -> {} // keep pending; the new item is appended below
+            // null (a committed decision locked the batch) is already excluded by the
+            // guard above; RESET/ACCUMULATE both accumulated the item.
+            else -> {}
         }
-
-        val item = PendingNip55Request(parsed, parsedId, uriStr ?: "")
-        pending.add(item)
-        batchCaller = caller
 
         // Legacy single-request fields drive the single-request path and UI.
         request = parsed
@@ -177,12 +160,12 @@ class Nip55Activity : FragmentActivity() {
 
         // One notification per batch: the first request raises it; accumulated
         // requests arrive while the approval UI is already up.
-        if (pending.size == 1) showNotificationFor(item)
+        if (gate.pending.size == 1) showNotificationFor(item)
         calculateRiskAndSetupContent()
     }
 
     private fun calculateRiskAndSetupContent() {
-        val item = pending.lastOrNull() ?: return
+        val item = gate.pending.lastOrNull() ?: return
         val pkg = callerPackage
         val store = permissionStore
 
@@ -205,7 +188,7 @@ class Nip55Activity : FragmentActivity() {
             riskAssessment = assessment
             // The user may have already decided while this assessment was running;
             // do not resurrect the approval UI.
-            if (!consentActionAdmitted(decisionLocked)) return@launch
+            if (!gate.admitsAction) return@launch
             setupContent()
         }
     }
@@ -280,15 +263,14 @@ class Nip55Activity : FragmentActivity() {
 
     private fun cancelAllNotifications() {
         notificationManager?.cancelNotification(notificationRequestId)
-        pending.forEach { it.notificationRequestId?.let { id -> notificationManager?.cancelNotification(id) } }
+        gate.pending.forEach { it.notificationRequestId?.let { id -> notificationManager?.cancelNotification(id) } }
     }
 
     private fun setupContent() {
         // A late async render must not re-display (and re-enable) the approval UI
-        // after the user has already committed a decision.
-        if (!consentActionAdmitted(decisionLocked)) return
-        val items = pending.toList()
-        displayed = items
+        // after the user has already committed a decision; the gate returns null and
+        // leaves the displayed snapshot untouched once a decision is locked.
+        val items = gate.render() ?: return
         if (items.size > 1) {
             setupBatchContent(items)
             return
@@ -416,13 +398,13 @@ class Nip55Activity : FragmentActivity() {
     private fun handleApprove(duration: PermissionDuration, declaredBundle: List<Nip55DeclaredPermission>, relayScope: RelayAuthScope? = null) {
         // Re-entry guard: a second tap, or an async render that re-enabled the
         // buttons, must not commit a second decision.
-        if (!consentActionAdmitted(decisionLocked)) return
+        if (!gate.admitsAction) return
         if (keepApp?.isSigningKilled() == true) {
             return finishWithError("signing_disabled")
         }
-        // Lock in the decision and act on exactly the snapshot the user saw.
-        decisionLocked = true
-        val shown = consentBoundSet(displayed, pending)
+        // Lock in the decision and act on exactly the snapshot the user saw. commit()
+        // locks the batch after the kill-switch check and returns the displayed set.
+        val shown = gate.commit() ?: return
         if (shown.size > 1) return handleApproveBatch(duration, shown)
         // Re-bind the single-request fields to the displayed request so a request
         // that raced in after render (overwriting the fields) is never signed.
@@ -432,8 +414,8 @@ class Nip55Activity : FragmentActivity() {
             riskAssessment = it.risk
         }
 
-        // decisionLocked is set above, so finish rather than bare-return to avoid
-        // soft-locking the screen if there is somehow no displayed request.
+        // The batch is locked by commit() above, so finish rather than bare-return to
+        // avoid soft-locking the screen if there is somehow no displayed request.
         val req = request ?: return finishWithError("Invalid request")
         val nip55Handler = handler ?: return finishWithError("Handler not initialized")
         val keystoreStorage = storage
@@ -799,9 +781,8 @@ class Nip55Activity : FragmentActivity() {
     private fun handleReject(duration: PermissionDuration, relayScope: RelayAuthScope? = null) {
         // Re-entry guard: mirrors handleApprove so neither path can run twice or
         // after the other has already committed.
-        if (!consentActionAdmitted(decisionLocked)) return
-        decisionLocked = true
-        val shown = consentBoundSet(displayed, pending)
+        if (!gate.admitsAction) return
+        val shown = gate.commit() ?: return
         if (shown.size > 1) return handleRejectBatch(duration, shown)
         shown.firstOrNull()?.let {
             request = it.request

--- a/app/src/main/kotlin/io/privkey/keep/nip55/Nip55Activity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/Nip55Activity.kt
@@ -60,7 +60,7 @@ class Nip55Activity : FragmentActivity() {
     // pending list, the displayed snapshot the decision binds to, and the commit lock,
     // and enforces the three TOCTOU guards so a late-racing request can never be folded
     // into the signed set (gh #372).
-    private val gate = BatchConsentGate<PendingNip55Request>(MAX_BATCH_SIZE) { it.request.requestType }
+    private val gate = BatchConsentGate<PendingNip55Request, DisplayedCaller>(MAX_BATCH_SIZE) { it.request.requestType }
 
     private class PendingNip55Request(
         val request: Nip55Request,
@@ -69,6 +69,30 @@ class Nip55Activity : FragmentActivity() {
     ) {
         var risk: RiskAssessment? = null
         var notificationRequestId: String? = null
+    }
+
+    // Caller identity captured with the displayed batch so a late different-caller
+    // intent that swaps the live caller state between render and the tap cannot
+    // redirect the grant/trust/sign to the attacker's package (gh #372).
+    private data class DisplayedCaller(
+        val packageName: String?,
+        val verified: Boolean,
+        val signatureHash: String?,
+        val pendingFirstUse: Boolean,
+    )
+
+    private fun currentDisplayedCaller() =
+        DisplayedCaller(callerPackage, callerVerified, callerSignatureHash, callerPendingFirstUse)
+
+    // Re-bind the mutable caller fields to the snapshot the decision was displayed
+    // with, mirroring the request-field re-bind in handleApprove. All downstream sign
+    // /grant/trust/audit reads then use the caller the user actually saw.
+    private fun rebindDisplayedCaller() {
+        val bound = gate.displayedCaller ?: return
+        callerPackage = bound.packageName
+        callerVerified = bound.verified
+        callerSignatureHash = bound.signatureHash
+        callerPendingFirstUse = bound.pendingFirstUse
     }
 
     private class PreApproveFailedException : Exception()
@@ -269,8 +293,9 @@ class Nip55Activity : FragmentActivity() {
     private fun setupContent() {
         // A late async render must not re-display (and re-enable) the approval UI
         // after the user has already committed a decision; the gate returns null and
-        // leaves the displayed snapshot untouched once a decision is locked.
-        val items = gate.render() ?: return
+        // leaves the displayed snapshot untouched once a decision is locked. The caller
+        // is captured with the batch so the decision binds to who the user saw.
+        val items = gate.render(currentDisplayedCaller()) ?: return
         if (items.size > 1) {
             setupBatchContent(items)
             return
@@ -403,8 +428,10 @@ class Nip55Activity : FragmentActivity() {
             return finishWithError("signing_disabled")
         }
         // Lock in the decision and act on exactly the snapshot the user saw. commit()
-        // locks the batch after the kill-switch check and returns the displayed set.
+        // locks the batch after the kill-switch check and returns the displayed set;
+        // rebind the caller to the one displayed with it before any grant/trust/sign.
         val shown = gate.commit() ?: return
+        rebindDisplayedCaller()
         if (shown.size > 1) return handleApproveBatch(duration, shown)
         // Re-bind the single-request fields to the displayed request so a request
         // that raced in after render (overwriting the fields) is never signed.
@@ -783,6 +810,7 @@ class Nip55Activity : FragmentActivity() {
         // after the other has already committed.
         if (!gate.admitsAction) return
         val shown = gate.commit() ?: return
+        rebindDisplayedCaller()
         if (shown.size > 1) return handleRejectBatch(duration, shown)
         shown.firstOrNull()?.let {
             request = it.request

--- a/app/src/test/kotlin/io/privkey/keep/nip55/BatchToctouRegressionTest.kt
+++ b/app/src/test/kotlin/io/privkey/keep/nip55/BatchToctouRegressionTest.kt
@@ -7,79 +7,46 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 
 /**
- * Composition-level regression test for the NIP-55 batch TOCTOU consent-bypass
- * (gh #372, guarding the HIGH finding fixed in 9a9bf6c). The per-helper tests
- * ([ConsentGuardTest], [BatchAccumulationTest]) prove each guard in isolation;
- * this test wires the same three pure guards
- * ([batchAccumulationDecision], [consentActionAdmitted], [consentBoundSet]) into a
- * faithful model of the [Nip55Activity] singleTop batch state machine and drives
- * the actual attack: a request delivered via a late onNewIntent between render and
- * the user's tap must never join the signed/rejected set.
+ * Regression test for the NIP-55 batch TOCTOU consent-bypass (gh #372, guarding the
+ * HIGH finding fixed in 9a9bf6c). It drives the real [BatchConsentGate] that
+ * [Nip55Activity] delegates to, so the three guards are exercised at their production
+ * call-sites: dropping the lock check from [BatchConsentGate.render]/[commit], or
+ * binding a decision to the live pending list instead of the displayed snapshot, fails
+ * these tests. The invariant locked in: the signed/rejected set is exactly what was
+ * rendered, and a request delivered via a late onNewIntent between render and the
+ * user's tap can never join it.
  *
- * The model mirrors the Activity transitions exactly:
- * - deliverIntent -> handleIntent (decisionLocked re-entry guard + accumulation)
- * - render        -> setupContent (captures the displayed snapshot)
- * - approve/reject -> handleApprove/handleReject (locks, binds to displayed)
+ * The gate transitions mirror the Activity's:
+ * - accumulate -> handleIntent (decisionLocked re-entry guard + accumulation)
+ * - render     -> setupContent (captures the displayed snapshot)
+ * - commit     -> handleApprove/handleReject (locks, binds to displayed)
  */
 class BatchToctouRegressionTest {
 
     private val app = "com.test.app"
+    private val other = "com.other.app"
     private val cap = 20
 
-    /** Minimal mirror of the Activity's batch state, driven only by the real guards. */
-    private class BatchGate(private val cap: Int) {
-        val pending = mutableListOf<Pair<String, Nip55RequestType>>()
-        var batchCaller: String? = null
-        var displayed: List<Pair<String, Nip55RequestType>> = emptyList()
-            private set
-        var decisionLocked = false
-            private set
+    private fun gate() =
+        BatchConsentGate<Pair<String, Nip55RequestType>>(cap) { it.second }
 
-        /** Mirrors handleIntent: ignored once locked, else accumulate/reset/drop. */
-        fun deliverIntent(id: String, type: Nip55RequestType, caller: String) {
-            if (!consentActionAdmitted(decisionLocked)) return
-            when (
-                batchAccumulationDecision(
-                    pendingTypes = pending.map { it.second },
-                    pendingCaller = batchCaller,
-                    newType = type,
-                    newCaller = caller,
-                    maxBatchSize = cap
-                )
-            ) {
-                BatchAccumulation.DROP_OVER_CAP -> return
-                BatchAccumulation.RESET -> pending.clear()
-                BatchAccumulation.ACCUMULATE -> {}
-            }
-            pending.add(id to type)
-            batchCaller = caller
-        }
-
-        /** Mirrors setupContent: captures what the user sees, guarded by the lock. */
-        fun render() {
-            if (!consentActionAdmitted(decisionLocked)) return
-            displayed = pending.toList()
-        }
-
-        /** Mirrors handleApprove/handleReject: locks and binds to the displayed snapshot. */
-        fun commitDecision(): List<Pair<String, Nip55RequestType>>? {
-            if (!consentActionAdmitted(decisionLocked)) return null
-            decisionLocked = true
-            return consentBoundSet(displayed, pending)
-        }
-    }
+    private fun BatchConsentGate<Pair<String, Nip55RequestType>>.deliver(
+        id: String,
+        type: Nip55RequestType = Nip55RequestType.SIGN_EVENT,
+        caller: String = app,
+    ) = accumulate(id to type, caller)
 
     @Test
     fun lateIntentBetweenRenderAndTapIsNeverSigned() {
-        val gate = BatchGate(cap)
-        gate.deliverIntent("r1", Nip55RequestType.SIGN_EVENT, app)
-        gate.deliverIntent("r2", Nip55RequestType.SIGN_EVENT, app)
+        val gate = gate()
+        gate.deliver("r1")
+        gate.deliver("r2")
         gate.render()
 
         // Attacker races a request in after the user has seen {r1, r2}.
-        gate.deliverIntent("late", Nip55RequestType.SIGN_EVENT, app)
+        gate.deliver("late")
 
-        val signed = gate.commitDecision()
+        val signed = gate.commit()
 
         assertEquals(listOf("r1", "r2"), signed?.map { it.first })
         assertFalse(signed!!.any { it.first == "late" })
@@ -87,26 +54,26 @@ class BatchToctouRegressionTest {
 
     @Test
     fun intentDeliveredAfterDecisionIsIgnored() {
-        val gate = BatchGate(cap)
-        gate.deliverIntent("r1", Nip55RequestType.SIGN_EVENT, app)
+        val gate = gate()
+        gate.deliver("r1")
         gate.render()
-        gate.commitDecision()
+        gate.commit()
 
         // Once locked, a late intent must not mutate pending at all.
-        gate.deliverIntent("late", Nip55RequestType.SIGN_EVENT, app)
+        gate.deliver("late")
 
         assertEquals(listOf("r1"), gate.pending.map { it.first })
     }
 
     @Test
     fun secondDecisionAfterLockIsIgnored() {
-        val gate = BatchGate(cap)
-        gate.deliverIntent("r1", Nip55RequestType.SIGN_EVENT, app)
+        val gate = gate()
+        gate.deliver("r1")
         gate.render()
-        val first = gate.commitDecision()
+        val first = gate.commit()
 
         // A committed decision can never run twice.
-        val second = gate.commitDecision()
+        val second = gate.commit()
 
         assertEquals(listOf("r1"), first?.map { it.first })
         assertNull(second)
@@ -114,15 +81,15 @@ class BatchToctouRegressionTest {
 
     @Test
     fun deferredAsyncRenderAfterDecisionDoesNotRecaptureGrownPending() {
-        val gate = BatchGate(cap)
-        gate.deliverIntent("r1", Nip55RequestType.SIGN_EVENT, app)
+        val gate = gate()
+        gate.deliver("r1")
         gate.render()
 
         // The late intent lands before the tap, so it accumulates into pending, but
         // its setupContent is deferred (calculateRiskAndSetupContent launches async)
         // and only fires after the user has already committed the decision.
-        gate.deliverIntent("late", Nip55RequestType.SIGN_EVENT, app)
-        gate.commitDecision()
+        gate.deliver("late")
+        gate.commit()
 
         // That deferred render must be blocked by the lock: it cannot re-capture the
         // grown [r1, late] pending into displayed. Without the guard it would.
@@ -133,15 +100,49 @@ class BatchToctouRegressionTest {
 
     @Test
     fun signedSetEqualsDisplayedSnapshotAcrossFullBatch() {
-        val gate = BatchGate(cap)
-        repeat(5) { gate.deliverIntent("r$it", Nip55RequestType.SIGN_EVENT, app) }
+        val gate = gate()
+        repeat(5) { gate.deliver("r$it") }
         gate.render()
         val displayedAtRender = gate.displayed.map { it.first }
 
-        gate.deliverIntent("late", Nip55RequestType.SIGN_EVENT, app)
-        val signed = gate.commitDecision()!!.map { it.first }
+        gate.deliver("late")
+        val signed = gate.commit()!!.map { it.first }
 
         // The invariant #372 locks in: the signed set is exactly what was rendered.
         assertEquals(displayedAtRender, signed)
+    }
+
+    @Test
+    fun lateDifferentCallerRaceResetsPendingButNotTheSignedSet() {
+        val gate = gate()
+        gate.deliver("r1")
+        gate.deliver("r2")
+        gate.render()
+
+        // A different-caller request resets the batch (pending is cleared and starts
+        // fresh), the most adversarial TOCTOU shape: the pending list the user saw is
+        // gone by decision time. The decision must still bind to the displayed {r1, r2}.
+        gate.deliver("evil", caller = other)
+        assertEquals(listOf("evil"), gate.pending.map { it.first })
+
+        val signed = gate.commit()
+
+        assertEquals(listOf("r1", "r2"), signed?.map { it.first })
+    }
+
+    @Test
+    fun lateGetPublicKeyRaceDoesNotJoinTheSignedSet() {
+        val gate = gate()
+        gate.deliver("r1")
+        gate.render()
+
+        // get_public_key never batches; it resets pending. The signed set is still the
+        // displayed snapshot, so the racing get_public_key can never be folded in.
+        gate.deliver("pk", type = Nip55RequestType.GET_PUBLIC_KEY)
+
+        val signed = gate.commit()
+
+        assertEquals(listOf("r1"), signed?.map { it.first })
+        assertFalse(signed!!.any { it.first == "pk" })
     }
 }

--- a/app/src/test/kotlin/io/privkey/keep/nip55/BatchToctouRegressionTest.kt
+++ b/app/src/test/kotlin/io/privkey/keep/nip55/BatchToctouRegressionTest.kt
@@ -28,20 +28,26 @@ class BatchToctouRegressionTest {
     private val cap = 20
 
     private fun gate() =
-        BatchConsentGate<Pair<String, Nip55RequestType>>(cap) { it.second }
+        BatchConsentGate<Pair<String, Nip55RequestType>, String>(cap) { it.second }
 
-    private fun BatchConsentGate<Pair<String, Nip55RequestType>>.deliver(
+    private fun BatchConsentGate<Pair<String, Nip55RequestType>, String>.deliver(
         id: String,
         type: Nip55RequestType = Nip55RequestType.SIGN_EVENT,
         caller: String = app,
     ) = accumulate(id to type, caller)
+
+    // Captures the current batch's caller with the displayed snapshot, mirroring the
+    // Activity passing its caller identity into render().
+    private fun BatchConsentGate<Pair<String, Nip55RequestType>, String>.renderAs(
+        caller: String = app,
+    ) = render(caller)
 
     @Test
     fun lateIntentBetweenRenderAndTapIsNeverSigned() {
         val gate = gate()
         gate.deliver("r1")
         gate.deliver("r2")
-        gate.render()
+        gate.renderAs()
 
         // Attacker races a request in after the user has seen {r1, r2}.
         gate.deliver("late")
@@ -56,7 +62,7 @@ class BatchToctouRegressionTest {
     fun intentDeliveredAfterDecisionIsIgnored() {
         val gate = gate()
         gate.deliver("r1")
-        gate.render()
+        gate.renderAs()
         gate.commit()
 
         // Once locked, a late intent must not mutate pending at all.
@@ -69,7 +75,7 @@ class BatchToctouRegressionTest {
     fun secondDecisionAfterLockIsIgnored() {
         val gate = gate()
         gate.deliver("r1")
-        gate.render()
+        gate.renderAs()
         val first = gate.commit()
 
         // A committed decision can never run twice.
@@ -83,7 +89,7 @@ class BatchToctouRegressionTest {
     fun deferredAsyncRenderAfterDecisionDoesNotRecaptureGrownPending() {
         val gate = gate()
         gate.deliver("r1")
-        gate.render()
+        gate.renderAs()
 
         // The late intent lands before the tap, so it accumulates into pending, but
         // its setupContent is deferred (calculateRiskAndSetupContent launches async)
@@ -93,7 +99,7 @@ class BatchToctouRegressionTest {
 
         // That deferred render must be blocked by the lock: it cannot re-capture the
         // grown [r1, late] pending into displayed. Without the guard it would.
-        gate.render()
+        gate.renderAs()
 
         assertEquals(listOf("r1"), gate.displayed.map { it.first })
     }
@@ -102,7 +108,7 @@ class BatchToctouRegressionTest {
     fun signedSetEqualsDisplayedSnapshotAcrossFullBatch() {
         val gate = gate()
         repeat(5) { gate.deliver("r$it") }
-        gate.render()
+        gate.renderAs()
         val displayedAtRender = gate.displayed.map { it.first }
 
         gate.deliver("late")
@@ -117,24 +123,30 @@ class BatchToctouRegressionTest {
         val gate = gate()
         gate.deliver("r1")
         gate.deliver("r2")
-        gate.render()
+        gate.renderAs(app)
 
         // A different-caller request resets the batch (pending is cleared and starts
-        // fresh), the most adversarial TOCTOU shape: the pending list the user saw is
-        // gone by decision time. The decision must still bind to the displayed {r1, r2}.
+        // fresh) and swaps the live batch caller to the attacker, the most adversarial
+        // TOCTOU shape: both the pending list and the caller the user saw are gone by
+        // decision time. Its render is deferred (never re-captures), so the decision
+        // must still bind to the displayed {r1, r2} AND to the original caller.
         gate.deliver("evil", caller = other)
         assertEquals(listOf("evil"), gate.pending.map { it.first })
+        assertEquals(other, gate.batchCaller)
 
         val signed = gate.commit()
 
         assertEquals(listOf("r1", "r2"), signed?.map { it.first })
+        // The caller binding, not just the request set: the committed decision is bound
+        // to the caller displayed with the batch, never the attacker who reset it.
+        assertEquals(app, gate.displayedCaller)
     }
 
     @Test
     fun lateGetPublicKeyRaceDoesNotJoinTheSignedSet() {
         val gate = gate()
         gate.deliver("r1")
-        gate.render()
+        gate.renderAs()
 
         // get_public_key never batches; it resets pending. The signed set is still the
         // displayed snapshot, so the racing get_public_key can never be folded in.

--- a/app/src/test/kotlin/io/privkey/keep/nip55/BatchToctouRegressionTest.kt
+++ b/app/src/test/kotlin/io/privkey/keep/nip55/BatchToctouRegressionTest.kt
@@ -113,14 +113,19 @@ class BatchToctouRegressionTest {
     }
 
     @Test
-    fun lateRenderAfterDecisionDoesNotResurrectPending() {
+    fun deferredAsyncRenderAfterDecisionDoesNotRecaptureGrownPending() {
         val gate = BatchGate(cap)
         gate.deliverIntent("r1", Nip55RequestType.SIGN_EVENT, app)
         gate.render()
+
+        // The late intent lands before the tap, so it accumulates into pending, but
+        // its setupContent is deferred (calculateRiskAndSetupContent launches async)
+        // and only fires after the user has already committed the decision.
+        gate.deliverIntent("late", Nip55RequestType.SIGN_EVENT, app)
         gate.commitDecision()
 
-        // A late async setupContent must not re-capture a grown pending list; even
-        // if a late intent had slipped through, the displayed snapshot stays fixed.
+        // That deferred render must be blocked by the lock: it cannot re-capture the
+        // grown [r1, late] pending into displayed. Without the guard it would.
         gate.render()
 
         assertEquals(listOf("r1"), gate.displayed.map { it.first })

--- a/app/src/test/kotlin/io/privkey/keep/nip55/BatchToctouRegressionTest.kt
+++ b/app/src/test/kotlin/io/privkey/keep/nip55/BatchToctouRegressionTest.kt
@@ -1,0 +1,142 @@
+package io.privkey.keep.nip55
+
+import io.privkey.keep.uniffi.Nip55RequestType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Composition-level regression test for the NIP-55 batch TOCTOU consent-bypass
+ * (gh #372, guarding the HIGH finding fixed in 9a9bf6c). The per-helper tests
+ * ([ConsentGuardTest], [BatchAccumulationTest]) prove each guard in isolation;
+ * this test wires the same three pure guards
+ * ([batchAccumulationDecision], [consentActionAdmitted], [consentBoundSet]) into a
+ * faithful model of the [Nip55Activity] singleTop batch state machine and drives
+ * the actual attack: a request delivered via a late onNewIntent between render and
+ * the user's tap must never join the signed/rejected set.
+ *
+ * The model mirrors the Activity transitions exactly:
+ * - deliverIntent -> handleIntent (decisionLocked re-entry guard + accumulation)
+ * - render        -> setupContent (captures the displayed snapshot)
+ * - approve/reject -> handleApprove/handleReject (locks, binds to displayed)
+ */
+class BatchToctouRegressionTest {
+
+    private val app = "com.test.app"
+    private val cap = 20
+
+    /** Minimal mirror of the Activity's batch state, driven only by the real guards. */
+    private class BatchGate(private val cap: Int) {
+        val pending = mutableListOf<Pair<String, Nip55RequestType>>()
+        var batchCaller: String? = null
+        var displayed: List<Pair<String, Nip55RequestType>> = emptyList()
+            private set
+        var decisionLocked = false
+            private set
+
+        /** Mirrors handleIntent: ignored once locked, else accumulate/reset/drop. */
+        fun deliverIntent(id: String, type: Nip55RequestType, caller: String) {
+            if (!consentActionAdmitted(decisionLocked)) return
+            when (
+                batchAccumulationDecision(
+                    pendingTypes = pending.map { it.second },
+                    pendingCaller = batchCaller,
+                    newType = type,
+                    newCaller = caller,
+                    maxBatchSize = cap
+                )
+            ) {
+                BatchAccumulation.DROP_OVER_CAP -> return
+                BatchAccumulation.RESET -> pending.clear()
+                BatchAccumulation.ACCUMULATE -> {}
+            }
+            pending.add(id to type)
+            batchCaller = caller
+        }
+
+        /** Mirrors setupContent: captures what the user sees, guarded by the lock. */
+        fun render() {
+            if (!consentActionAdmitted(decisionLocked)) return
+            displayed = pending.toList()
+        }
+
+        /** Mirrors handleApprove/handleReject: locks and binds to the displayed snapshot. */
+        fun commitDecision(): List<Pair<String, Nip55RequestType>>? {
+            if (!consentActionAdmitted(decisionLocked)) return null
+            decisionLocked = true
+            return consentBoundSet(displayed, pending)
+        }
+    }
+
+    @Test
+    fun lateIntentBetweenRenderAndTapIsNeverSigned() {
+        val gate = BatchGate(cap)
+        gate.deliverIntent("r1", Nip55RequestType.SIGN_EVENT, app)
+        gate.deliverIntent("r2", Nip55RequestType.SIGN_EVENT, app)
+        gate.render()
+
+        // Attacker races a request in after the user has seen {r1, r2}.
+        gate.deliverIntent("late", Nip55RequestType.SIGN_EVENT, app)
+
+        val signed = gate.commitDecision()
+
+        assertEquals(listOf("r1", "r2"), signed?.map { it.first })
+        assertFalse(signed!!.any { it.first == "late" })
+    }
+
+    @Test
+    fun intentDeliveredAfterDecisionIsIgnored() {
+        val gate = BatchGate(cap)
+        gate.deliverIntent("r1", Nip55RequestType.SIGN_EVENT, app)
+        gate.render()
+        gate.commitDecision()
+
+        // Once locked, a late intent must not mutate pending at all.
+        gate.deliverIntent("late", Nip55RequestType.SIGN_EVENT, app)
+
+        assertEquals(listOf("r1"), gate.pending.map { it.first })
+    }
+
+    @Test
+    fun secondDecisionAfterLockIsIgnored() {
+        val gate = BatchGate(cap)
+        gate.deliverIntent("r1", Nip55RequestType.SIGN_EVENT, app)
+        gate.render()
+        val first = gate.commitDecision()
+
+        // A committed decision can never run twice.
+        val second = gate.commitDecision()
+
+        assertEquals(listOf("r1"), first?.map { it.first })
+        assertNull(second)
+    }
+
+    @Test
+    fun lateRenderAfterDecisionDoesNotResurrectPending() {
+        val gate = BatchGate(cap)
+        gate.deliverIntent("r1", Nip55RequestType.SIGN_EVENT, app)
+        gate.render()
+        gate.commitDecision()
+
+        // A late async setupContent must not re-capture a grown pending list; even
+        // if a late intent had slipped through, the displayed snapshot stays fixed.
+        gate.render()
+
+        assertEquals(listOf("r1"), gate.displayed.map { it.first })
+    }
+
+    @Test
+    fun signedSetEqualsDisplayedSnapshotAcrossFullBatch() {
+        val gate = BatchGate(cap)
+        repeat(5) { gate.deliverIntent("r$it", Nip55RequestType.SIGN_EVENT, app) }
+        gate.render()
+        val displayedAtRender = gate.displayed.map { it.first }
+
+        gate.deliverIntent("late", Nip55RequestType.SIGN_EVENT, app)
+        val signed = gate.commitDecision()!!.map { it.first }
+
+        // The invariant #372 locks in: the signed set is exactly what was rendered.
+        assertEquals(displayedAtRender, signed)
+    }
+}


### PR DESCRIPTION
Adds a JVM unit test composing the ConsentGuard/BatchAccumulation helpers to lock in the batch TOCTOU invariant: a request delivered via late onNewIntent after render can never join the approved set. Closes #372.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened the NIP-55 batch consent/signing flow against timing/race edge cases so only the content shown at approval is eligible to be signed.
  * Late actions after rendering or after the user decision are now safely ignored rather than influencing the signed set.
* **Tests**
  * Added regression coverage for NIP-55 batch consent TOCTOU/race edge cases.
  * Verifies late intents are never signed, late updates don’t alter committed results, and a second commit has no additional effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->