### PR TITLE
tests: NIP-46 rate-limit delegation wiring (gh#377)

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/nip46/BunkerService.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip46/BunkerService.kt
@@ -98,8 +98,8 @@ class BunkerService : Service() {
         private val bunkerRateLimiter by lazy { Nip46BunkerRateLimiter() }
         private val connectRateLimiter by lazy { Nip46BunkerRateLimiter() }
 
-        private fun limiterFor(isConnectRequest: Boolean): Nip46BunkerRateLimiter =
-            when (rateLimitBudgetFor(isConnectRequest)) {
+        private fun limiterFor(budget: RateLimitBudget): Nip46BunkerRateLimiter =
+            when (budget) {
                 RateLimitBudget.CONNECT -> connectRateLimiter
                 RateLimitBudget.SIGNING -> bunkerRateLimiter
             }
@@ -175,7 +175,7 @@ class BunkerService : Service() {
                 val pubkey = clientPubkey ?: approval.request.appPubkey
                 clientPendingCounts[pubkey]?.decrementAndGet()
                 if (approved) {
-                    limiterFor(approval.isConnectRequest).resetConsecutive(pubkey.lowercase())
+                    limiterFor(rateLimitBudgetFor(approval.isConnectRequest)).resetConsecutive(pubkey.lowercase())
                 }
                 approval.respond(
                     BunkerApprovalResult(
@@ -214,8 +214,8 @@ class BunkerService : Service() {
         // Global + per-client window + exponential backoff live in Rust; Android
         // supplies the monotonic clock. Key on the lowercased pubkey so case-variant
         // hex can't mint fresh per-client buckets (matches the authorization path).
-        internal fun isRateLimited(clientPubkey: String, isConnectRequest: Boolean): Boolean {
-            val limited = limiterFor(isConnectRequest).isRateLimited(clientPubkey.lowercase(), SystemClock.elapsedRealtime().toULong())
+        internal fun isRateLimited(clientPubkey: String, budget: RateLimitBudget): Boolean {
+            val limited = limiterFor(budget).isRateLimited(clientPubkey.lowercase(), SystemClock.elapsedRealtime().toULong())
             // Bounds the concurrency map (clientPendingCounts); rate-limit state is bounded in Rust.
             if (clientPendingCounts.size > MAX_TRACKED_CLIENTS) {
                 evictStaleMaps()
@@ -572,13 +572,15 @@ class BunkerService : Service() {
         val isAuthorized = !denylisted && (pendingAuthSaves.contains(pk) || authorizedClientsCache.contains(pk))
         val isConnectRequest = request.method == "connect"
 
-        // Gate before limiter ordering is contract-tested by RateLimitDelegationTest.
-        if (requestGateDecision(isAuthorized, isConnectRequest) == RequestGate.REJECT_UNAUTHORIZED) {
+        // Gate-then-budget ordering is contract-tested by RateLimitDelegationTest:
+        // a null budget means the gate rejected before any limiter is consulted.
+        val budget = rateLimitBudgetDecision(isAuthorized, isConnectRequest)
+        if (budget == null) {
             if (BuildConfig.DEBUG) Log.w(TAG, "Unauthorized client ${truncatePubkey(clientPubkey)} attempted ${request.method}")
             return REJECTED
         }
 
-        if (isRateLimited(clientPubkey, isConnectRequest)) {
+        if (isRateLimited(clientPubkey, budget)) {
             if (BuildConfig.DEBUG) Log.w(TAG, "Request from ${truncatePubkey(clientPubkey)} rate limited")
             return REJECTED
         }

--- a/app/src/main/kotlin/io/privkey/keep/nip46/BunkerService.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip46/BunkerService.kt
@@ -572,6 +572,7 @@ class BunkerService : Service() {
         val isAuthorized = !denylisted && (pendingAuthSaves.contains(pk) || authorizedClientsCache.contains(pk))
         val isConnectRequest = request.method == "connect"
 
+        // Gate before limiter ordering is contract-tested by RateLimitDelegationTest.
         if (requestGateDecision(isAuthorized, isConnectRequest) == RequestGate.REJECT_UNAUTHORIZED) {
             if (BuildConfig.DEBUG) Log.w(TAG, "Unauthorized client ${truncatePubkey(clientPubkey)} attempted ${request.method}")
             return REJECTED

--- a/app/src/main/kotlin/io/privkey/keep/nip46/RateLimitBudget.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip46/RateLimitBudget.kt
@@ -6,3 +6,16 @@ internal enum class RateLimitBudget { CONNECT, SIGNING }
 // connect flood (rotating pubkeys) cannot drain the signing budget.
 internal fun rateLimitBudgetFor(isConnectRequest: Boolean): RateLimitBudget =
     if (isConnectRequest) RateLimitBudget.CONNECT else RateLimitBudget.SIGNING
+
+// Single delegation seam shared by BunkerService and RateLimitDelegationTest:
+// runs the authorization gate before selecting a limiter budget so a reordering
+// regression (limiter consulted before the gate) is caught in one place.
+// null = gate rejected, no limiter must be consulted; non-null = apply that budget.
+internal fun rateLimitBudgetDecision(
+    isAuthorized: Boolean,
+    isConnectRequest: Boolean
+): RateLimitBudget? =
+    when (requestGateDecision(isAuthorized, isConnectRequest)) {
+        RequestGate.REJECT_UNAUTHORIZED -> null
+        RequestGate.RATE_LIMIT_THEN_PROCEED -> rateLimitBudgetFor(isConnectRequest)
+    }

--- a/app/src/test/kotlin/io/privkey/keep/nip46/RateLimitDelegationTest.kt
+++ b/app/src/test/kotlin/io/privkey/keep/nip46/RateLimitDelegationTest.kt
@@ -1,0 +1,52 @@
+package io.privkey.keep.nip46
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Wiring coverage for the non-batch NIP-46 signer path (gh #377): proves the
+ * Android layer composes the authorization gate and the budget selector so a
+ * request is either rejected before any limiter is consulted, or delegated to
+ * the correct Rust limiter budget. The limiter policy itself is unit-tested in
+ * the Rust core; this only asserts the delegation seam.
+ */
+class RateLimitDelegationTest {
+
+    // Mirrors BunkerService.handleApprovalRequest ordering: the gate runs first,
+    // and only a RATE_LIMIT_THEN_PROCEED outcome consults limiterFor(isConnectRequest).
+    private fun budgetConsulted(isAuthorized: Boolean, isConnectRequest: Boolean): RateLimitBudget? =
+        when (requestGateDecision(isAuthorized, isConnectRequest)) {
+            RequestGate.REJECT_UNAUTHORIZED -> null
+            RequestGate.RATE_LIMIT_THEN_PROCEED -> rateLimitBudgetFor(isConnectRequest)
+        }
+
+    @Test
+    fun unauthorizedNonConnectConsultsNoLimiter() {
+        assertNull(budgetConsulted(isAuthorized = false, isConnectRequest = false))
+    }
+
+    @Test
+    fun unauthorizedConnectDelegatesToConnectBudget() {
+        assertEquals(
+            RateLimitBudget.CONNECT,
+            budgetConsulted(isAuthorized = false, isConnectRequest = true)
+        )
+    }
+
+    @Test
+    fun authorizedSigningDelegatesToSigningBudget() {
+        assertEquals(
+            RateLimitBudget.SIGNING,
+            budgetConsulted(isAuthorized = true, isConnectRequest = false)
+        )
+    }
+
+    @Test
+    fun authorizedConnectDelegatesToConnectBudget() {
+        assertEquals(
+            RateLimitBudget.CONNECT,
+            budgetConsulted(isAuthorized = true, isConnectRequest = true)
+        )
+    }
+}

--- a/app/src/test/kotlin/io/privkey/keep/nip46/RateLimitDelegationTest.kt
+++ b/app/src/test/kotlin/io/privkey/keep/nip46/RateLimitDelegationTest.kt
@@ -13,24 +13,19 @@ import org.junit.Test
  */
 class RateLimitDelegationTest {
 
-    // Mirrors BunkerService.handleApprovalRequest ordering: the gate runs first,
-    // and only a RATE_LIMIT_THEN_PROCEED outcome consults limiterFor(isConnectRequest).
-    private fun budgetConsulted(isAuthorized: Boolean, isConnectRequest: Boolean): RateLimitBudget? =
-        when (requestGateDecision(isAuthorized, isConnectRequest)) {
-            RequestGate.REJECT_UNAUTHORIZED -> null
-            RequestGate.RATE_LIMIT_THEN_PROCEED -> rateLimitBudgetFor(isConnectRequest)
-        }
+    // Exercises the same rateLimitBudgetDecision seam BunkerService.handleApprovalRequest
+    // uses, so a production reordering (limiter consulted before the auth gate) fails here.
 
     @Test
     fun unauthorizedNonConnectConsultsNoLimiter() {
-        assertNull(budgetConsulted(isAuthorized = false, isConnectRequest = false))
+        assertNull(rateLimitBudgetDecision(isAuthorized = false, isConnectRequest = false))
     }
 
     @Test
     fun unauthorizedConnectDelegatesToConnectBudget() {
         assertEquals(
             RateLimitBudget.CONNECT,
-            budgetConsulted(isAuthorized = false, isConnectRequest = true)
+            rateLimitBudgetDecision(isAuthorized = false, isConnectRequest = true)
         )
     }
 
@@ -38,7 +33,7 @@ class RateLimitDelegationTest {
     fun authorizedSigningDelegatesToSigningBudget() {
         assertEquals(
             RateLimitBudget.SIGNING,
-            budgetConsulted(isAuthorized = true, isConnectRequest = false)
+            rateLimitBudgetDecision(isAuthorized = true, isConnectRequest = false)
         )
     }
 
@@ -46,7 +41,7 @@ class RateLimitDelegationTest {
     fun authorizedConnectDelegatesToConnectBudget() {
         assertEquals(
             RateLimitBudget.CONNECT,
-            budgetConsulted(isAuthorized = true, isConnectRequest = true)
+            rateLimitBudgetDecision(isAuthorized = true, isConnectRequest = true)
         )
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for request rate-limit delegation across connect and signing flows.
  * Verified that unauthorized requests are blocked before any limiter is consulted, and authorized requests use the appropriate budget.
* **Chores**
  * Added a clarifying note around request gating to document the expected ordering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->