### PR TITLE
onboarding: add first-run FROST/share guidance and sign-policy choice (#295)

### DIFF
--- a/app/src/androidTest/kotlin/io/privkey/keep/OnboardingScreenTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/OnboardingScreenTest.kt
@@ -1,8 +1,13 @@
 package io.privkey.keep
 
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.hasAnyDescendant
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isSelectable
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import io.privkey.keep.storage.SignPolicy
@@ -21,6 +26,10 @@ import org.junit.runner.RunWith
  * selection, and the chosen policy is reported once via `onDone`. This guards the
  * regression where tapping an option immediately committed the global signing
  * policy, so merely reading the least-secure "Auto" option applied it.
+ *
+ * The screen scrolls, so every interaction scrolls its target into view first.
+ * Each test also asserts the tap landed, otherwise a no-op click would satisfy
+ * the "nothing was persisted" assertions vacuously.
  */
 @RunWith(AndroidJUnit4::class)
 class OnboardingScreenTest {
@@ -45,18 +54,32 @@ class OnboardingScreenTest {
         context.deleteSharedPreferences(SIGN_POLICY_PREFS)
     }
 
-    @Test
-    fun selectingPolicyDoesNotPersistIt() {
-        var reported: SignPolicy? = null
+    private fun setContent(onDone: (SignPolicy) -> Unit) {
         compose.setContent {
             KeepAndroidTheme {
-                OnboardingScreen(signPolicyStore, onDone = { reported = it })
+                OnboardingScreen(signPolicyStore, onDone = onDone)
             }
         }
         compose.waitForIdle()
+    }
 
-        compose.onNodeWithText(context.getString(R.string.sign_policy_auto)).performClick()
+    /** The selectable card wrapping the option whose title is exactly [title]. */
+    private fun optionCard(title: String) =
+        compose.onNode(isSelectable() and hasAnyDescendant(hasText(title)))
+
+    private fun selectAuto() {
+        val auto = optionCard(context.getString(R.string.sign_policy_auto))
+        auto.performScrollTo().performClick()
         compose.waitForIdle()
+        auto.assertIsSelected()
+    }
+
+    @Test
+    fun selectingPolicyDoesNotPersistIt() {
+        var reported: SignPolicy? = null
+        setContent { reported = it }
+
+        selectAuto()
 
         assertEquals(SignPolicy.MANUAL, signPolicyStore.getGlobalPolicy())
         assertNull(reported)
@@ -65,15 +88,12 @@ class OnboardingScreenTest {
     @Test
     fun confirmingReportsSelectionWithoutWritingFromTheScreen() {
         var reported: SignPolicy? = null
-        compose.setContent {
-            KeepAndroidTheme {
-                OnboardingScreen(signPolicyStore, onDone = { reported = it })
-            }
-        }
-        compose.waitForIdle()
+        setContent { reported = it }
 
-        compose.onNodeWithText(context.getString(R.string.sign_policy_auto)).performClick()
-        compose.onNodeWithText(context.getString(R.string.onboarding_get_started)).performClick()
+        selectAuto()
+        compose.onNodeWithText(context.getString(R.string.onboarding_get_started))
+            .performScrollTo()
+            .performClick()
         compose.waitForIdle()
 
         assertEquals(SignPolicy.AUTO, reported)

--- a/app/src/androidTest/kotlin/io/privkey/keep/OnboardingScreenTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/OnboardingScreenTest.kt
@@ -1,0 +1,87 @@
+package io.privkey.keep
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import io.privkey.keep.storage.SignPolicy
+import io.privkey.keep.storage.SignPolicyStore
+import io.privkey.keep.ui.theme.KeepAndroidTheme
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Onboarding hoists persistence to its caller: selecting an option only moves the
+ * selection, and the chosen policy is reported once via `onDone`. This guards the
+ * regression where tapping an option immediately committed the global signing
+ * policy, so merely reading the least-secure "Auto" option applied it.
+ */
+@RunWith(AndroidJUnit4::class)
+class OnboardingScreenTest {
+
+    // createComposeRule() is deprecated in favor of the v2 API; the classic rule
+    // is intentional here, and the project builds with -Werror.
+    @Suppress("DEPRECATION")
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private lateinit var signPolicyStore: SignPolicyStore
+
+    @Before
+    fun setup() {
+        context.deleteSharedPreferences(SIGN_POLICY_PREFS)
+        signPolicyStore = SignPolicyStore(context)
+    }
+
+    @After
+    fun teardown() {
+        context.deleteSharedPreferences(SIGN_POLICY_PREFS)
+    }
+
+    @Test
+    fun selectingPolicyDoesNotPersistIt() {
+        var reported: SignPolicy? = null
+        compose.setContent {
+            KeepAndroidTheme {
+                OnboardingScreen(signPolicyStore, onDone = { reported = it })
+            }
+        }
+        compose.waitForIdle()
+
+        compose.onNodeWithText(context.getString(R.string.sign_policy_auto)).performClick()
+        compose.waitForIdle()
+
+        assertEquals(SignPolicy.MANUAL, signPolicyStore.getGlobalPolicy())
+        assertNull(reported)
+    }
+
+    @Test
+    fun confirmingReportsSelectionWithoutWritingFromTheScreen() {
+        var reported: SignPolicy? = null
+        compose.setContent {
+            KeepAndroidTheme {
+                OnboardingScreen(signPolicyStore, onDone = { reported = it })
+            }
+        }
+        compose.waitForIdle()
+
+        compose.onNodeWithText(context.getString(R.string.sign_policy_auto)).performClick()
+        compose.onNodeWithText(context.getString(R.string.onboarding_get_started)).performClick()
+        compose.waitForIdle()
+
+        assertEquals(SignPolicy.AUTO, reported)
+        // The screen reports the choice; MainActivity performs the single write.
+        assertEquals(SignPolicy.MANUAL, signPolicyStore.getGlobalPolicy())
+    }
+
+    private companion object {
+        const val SIGN_POLICY_PREFS = "keep_sign_policy"
+    }
+}

--- a/app/src/androidTest/kotlin/io/privkey/keep/OnboardingScreenTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/OnboardingScreenTest.kt
@@ -1,7 +1,6 @@
 package io.privkey.keep
 
 import androidx.compose.ui.test.assertIsSelected
-import androidx.compose.ui.test.hasAnyDescendant
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isSelectable
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -63,9 +62,13 @@ class OnboardingScreenTest {
         compose.waitForIdle()
     }
 
-    /** The selectable card wrapping the option whose title is exactly [title]. */
+    /**
+     * The selectable card for the option titled exactly [title]. `Modifier.selectable`
+     * merges its descendants, so the card node carries the title and description text
+     * itself; [hasText] matches a whole entry, so the title never matches the body copy.
+     */
     private fun optionCard(title: String) =
-        compose.onNode(isSelectable() and hasAnyDescendant(hasText(title)))
+        compose.onNode(isSelectable() and hasText(title))
 
     private fun selectAuto() {
         val auto = optionCard(context.getString(R.string.sign_policy_auto))

--- a/app/src/androidTest/kotlin/io/privkey/keep/storage/OnboardingStoreIntegrationTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/storage/OnboardingStoreIntegrationTest.kt
@@ -1,0 +1,58 @@
+package io.privkey.keep.storage
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class OnboardingStoreIntegrationTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        clear()
+    }
+
+    @After
+    fun teardown() {
+        clear()
+    }
+
+    private fun clear() {
+        context.deleteSharedPreferences(PREFS_NAME)
+    }
+
+    @Test
+    fun defaultsToNotCompletedOnFreshInstall() {
+        assertFalse(OnboardingStore(context).isCompleted())
+    }
+
+    @Test
+    fun persistsCompletionAcrossInstances() {
+        OnboardingStore(context).setCompleted(true)
+
+        // A new instance reads the committed value, so onboarding is not shown again.
+        assertTrue(OnboardingStore(context).isCompleted())
+    }
+
+    @Test
+    fun completionCanBeReset() {
+        val store = OnboardingStore(context)
+        store.setCompleted(true)
+        store.setCompleted(false)
+
+        assertFalse(OnboardingStore(context).isCompleted())
+    }
+
+    private companion object {
+        const val PREFS_NAME = "keep_onboarding"
+    }
+}

--- a/app/src/main/kotlin/io/privkey/keep/KeepMobileApp.kt
+++ b/app/src/main/kotlin/io/privkey/keep/KeepMobileApp.kt
@@ -27,6 +27,7 @@ import io.privkey.keep.storage.AutoStartStore
 import io.privkey.keep.storage.BiometricTimeoutStore
 import io.privkey.keep.storage.ForegroundServiceStore
 import io.privkey.keep.storage.KillSwitchStore
+import io.privkey.keep.storage.OnboardingStore
 import io.privkey.keep.storage.PinStore
 import io.privkey.keep.storage.RelayAuthWhitelistStore
 import io.privkey.keep.storage.SignPolicyStore
@@ -66,6 +67,7 @@ class KeepMobileApp : Application() {
     private var foregroundServiceStore: ForegroundServiceStore? = null
     private var pinStore: PinStore? = null
     private var biometricTimeoutStore: BiometricTimeoutStore? = null
+    private var onboardingStore: OnboardingStore? = null
     private var nip55Handler: Nip55Handler? = null
     private var permissionStore: PermissionStore? = null
     private var callerVerificationStore: CallerVerificationStore? = null
@@ -122,6 +124,7 @@ class KeepMobileApp : Application() {
             foregroundServiceStore = ForegroundServiceStore(this)
             pinStore = PinStore(this)
             biometricTimeoutStore = BiometricTimeoutStore(this)
+            onboardingStore = OnboardingStore(this)
             keepMobile = newKeepMobile
             migrateKillSwitch(newKeepMobile)
             nip55Handler = Nip55Handler(newKeepMobile)
@@ -309,6 +312,8 @@ class KeepMobileApp : Application() {
     fun getPinStore(): PinStore? = pinStore
 
     fun getBiometricTimeoutStore(): BiometricTimeoutStore? = biometricTimeoutStore
+
+    fun getOnboardingStore(): OnboardingStore? = onboardingStore
 
     fun getNip55Handler(): Nip55Handler? = nip55Handler
 

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -175,9 +175,10 @@ class MainActivity : FragmentActivity() {
                         val safeOnboardingStore = onboardingStore ?: return@Surface
                         OnboardingScreen(
                             signPolicyStore = safeSignPolicyStore,
-                            onDone = {
+                            onDone = { policy ->
                                 onboardingScope.launch {
                                     withContext(Dispatchers.IO) {
+                                        safeSignPolicyStore.setGlobalPolicy(policy)
                                         safeOnboardingStore.setCompleted(true)
                                     }
                                     onboardingCompleted = true

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -94,6 +94,8 @@ class MainActivity : FragmentActivity() {
         ).all { it != null }
 
         setContent {
+            val onboardingScope = rememberCoroutineScope()
+
             var isPinUnlocked by remember {
                 mutableStateOf(pinStore?.isSessionValid() ?: true)
             }
@@ -174,8 +176,12 @@ class MainActivity : FragmentActivity() {
                         OnboardingScreen(
                             signPolicyStore = safeSignPolicyStore,
                             onDone = {
-                                safeOnboardingStore.setCompleted(true)
-                                onboardingCompleted = true
+                                onboardingScope.launch {
+                                    withContext(Dispatchers.IO) {
+                                        safeOnboardingStore.setCompleted(true)
+                                    }
+                                    onboardingCompleted = true
+                                }
                             }
                         )
                     } else if (allDependenciesAvailable) {

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -85,16 +85,21 @@ class MainActivity : FragmentActivity() {
         val pinStore = app.getPinStore()
         val biometricTimeoutStore = app.getBiometricTimeoutStore()
         val permissionStore = app.getPermissionStore()
+        val onboardingStore = app.getOnboardingStore()
 
         val allDependenciesAvailable = listOf(
             keepMobile, storage, signPolicyStore,
             autoStartStore, foregroundServiceStore, pinStore, biometricTimeoutStore,
-            permissionStore
+            permissionStore, onboardingStore
         ).all { it != null }
 
         setContent {
             var isPinUnlocked by remember {
                 mutableStateOf(pinStore?.isSessionValid() ?: true)
+            }
+
+            var onboardingCompleted by remember {
+                mutableStateOf(onboardingStore?.isCompleted() ?: true)
             }
 
             var biometricStatus by remember {
@@ -162,6 +167,16 @@ class MainActivity : FragmentActivity() {
                                 ) ?: BiometricHelper.AuthResult.FAILED
                             },
                             onUnlocked = { isBiometricUnlocked = true }
+                        )
+                    } else if (allDependenciesAvailable && !onboardingCompleted) {
+                        val safeSignPolicyStore = signPolicyStore ?: return@Surface
+                        val safeOnboardingStore = onboardingStore ?: return@Surface
+                        OnboardingScreen(
+                            signPolicyStore = safeSignPolicyStore,
+                            onDone = {
+                                safeOnboardingStore.setCompleted(true)
+                                onboardingCompleted = true
+                            }
                         )
                     } else if (allDependenciesAvailable) {
                         val safeKeepMobile = keepMobile ?: return@Surface

--- a/app/src/main/kotlin/io/privkey/keep/OnboardingScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/OnboardingScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -52,7 +53,13 @@ fun OnboardingScreen(
     onDone: () -> Unit
 ) {
     var selectedPolicy by remember { mutableStateOf(SignPolicy.MANUAL) }
+    var userInteracted by remember { mutableStateOf(false) }
     val coroutineScope = rememberCoroutineScope()
+
+    LaunchedEffect(Unit) {
+        val loaded = withContext(Dispatchers.IO) { signPolicyStore.getGlobalPolicy() }
+        if (!userInteracted) selectedPolicy = loaded
+    }
 
     KeepScreenScaffold(title = stringResource(R.string.onboarding_title)) { padding ->
         Column(
@@ -108,6 +115,7 @@ fun OnboardingScreen(
                     policy = policy,
                     isSelected = selectedPolicy == policy,
                     onClick = {
+                        userInteracted = true
                         selectedPolicy = policy
                         coroutineScope.launch {
                             withContext(Dispatchers.IO) {

--- a/app/src/main/kotlin/io/privkey/keep/OnboardingScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/OnboardingScreen.kt
@@ -1,0 +1,194 @@
+package io.privkey.keep
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import io.privkey.keep.storage.SignPolicy
+import io.privkey.keep.storage.SignPolicyStore
+import io.privkey.keep.ui.components.KeepCard
+import io.privkey.keep.ui.components.KeepScreenScaffold
+import io.privkey.keep.ui.theme.Dimens
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+@Composable
+fun OnboardingScreen(
+    signPolicyStore: SignPolicyStore,
+    onDone: () -> Unit
+) {
+    var selectedPolicy by remember { mutableStateOf(SignPolicy.MANUAL) }
+    val coroutineScope = rememberCoroutineScope()
+
+    KeepScreenScaffold(title = stringResource(R.string.onboarding_title)) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(Dimens.space16)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(Dimens.space16)
+        ) {
+            Text(
+                text = stringResource(R.string.onboarding_intro),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            OnboardingInfoCard(
+                icon = Icons.Filled.Key,
+                title = stringResource(R.string.onboarding_frost_title),
+                body = stringResource(R.string.onboarding_frost_body)
+            )
+
+            OnboardingInfoCard(
+                icon = Icons.Filled.CheckCircle,
+                title = stringResource(R.string.onboarding_threshold_title),
+                body = stringResource(R.string.onboarding_threshold_body)
+            )
+
+            OnboardingInfoCard(
+                icon = Icons.Filled.Info,
+                title = stringResource(R.string.onboarding_nsec_title),
+                body = stringResource(R.string.onboarding_nsec_body)
+            )
+
+            OnboardingInfoCard(
+                icon = Icons.Filled.Warning,
+                title = stringResource(R.string.onboarding_backup_title),
+                body = stringResource(R.string.onboarding_backup_body)
+            )
+
+            Text(
+                text = stringResource(R.string.onboarding_sign_policy_heading),
+                style = MaterialTheme.typography.titleMedium
+            )
+            Text(
+                text = stringResource(R.string.onboarding_sign_policy_subheading),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            SignPolicy.entries.forEach { policy ->
+                OnboardingPolicyOption(
+                    policy = policy,
+                    isSelected = selectedPolicy == policy,
+                    onClick = {
+                        selectedPolicy = policy
+                        coroutineScope.launch {
+                            withContext(Dispatchers.IO) {
+                                signPolicyStore.setGlobalPolicy(policy)
+                            }
+                        }
+                    }
+                )
+            }
+
+            Spacer(Modifier.height(Dimens.space4))
+            Button(
+                onClick = onDone,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(stringResource(R.string.onboarding_get_started))
+            }
+        }
+    }
+}
+
+@Composable
+private fun OnboardingInfoCard(
+    icon: ImageVector,
+    title: String,
+    body: String
+) {
+    KeepCard {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(24.dp)
+            )
+            Spacer(Modifier.width(Dimens.space12))
+            Text(title, style = MaterialTheme.typography.titleMedium)
+        }
+        Spacer(Modifier.height(Dimens.space8))
+        Text(
+            body,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun OnboardingPolicyOption(
+    policy: SignPolicy,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    val borderColor = if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent
+    KeepCard(
+        modifier = Modifier.border(
+            Dimens.cardBorderWidth,
+            borderColor,
+            RoundedCornerShape(Dimens.space12)
+        ).selectable(
+            selected = isSelected,
+            onClick = onClick,
+            role = Role.RadioButton
+        )
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            RadioButton(selected = isSelected, onClick = null)
+            Spacer(Modifier.width(Dimens.space16))
+            Column {
+                Text(
+                    stringResource(policy.displayNameRes),
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Spacer(Modifier.height(Dimens.space4))
+                Text(
+                    stringResource(policy.descriptionRes),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/io/privkey/keep/OnboardingScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/OnboardingScreen.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.unit.dp
 import io.privkey.keep.storage.SignPolicy
 import io.privkey.keep.storage.SignPolicyStore
 import io.privkey.keep.ui.components.KeepCard
@@ -142,7 +141,7 @@ private fun OnboardingInfoCard(
                 icon,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(24.dp)
+                modifier = Modifier.size(Dimens.space24)
             )
             Spacer(Modifier.width(Dimens.space12))
             Text(title, style = MaterialTheme.typography.titleMedium)

--- a/app/src/main/kotlin/io/privkey/keep/OnboardingScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/OnboardingScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -44,17 +43,15 @@ import io.privkey.keep.ui.components.KeepCard
 import io.privkey.keep.ui.components.KeepScreenScaffold
 import io.privkey.keep.ui.theme.Dimens
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 @Composable
 fun OnboardingScreen(
     signPolicyStore: SignPolicyStore,
-    onDone: () -> Unit
+    onDone: (SignPolicy) -> Unit
 ) {
     var selectedPolicy by remember { mutableStateOf(SignPolicy.MANUAL) }
     var userInteracted by remember { mutableStateOf(false) }
-    val coroutineScope = rememberCoroutineScope()
 
     LaunchedEffect(Unit) {
         val loaded = withContext(Dispatchers.IO) { signPolicyStore.getGlobalPolicy() }
@@ -117,18 +114,13 @@ fun OnboardingScreen(
                     onClick = {
                         userInteracted = true
                         selectedPolicy = policy
-                        coroutineScope.launch {
-                            withContext(Dispatchers.IO) {
-                                signPolicyStore.setGlobalPolicy(policy)
-                            }
-                        }
                     }
                 )
             }
 
             Spacer(Modifier.height(Dimens.space4))
             Button(
-                onClick = onDone,
+                onClick = { onDone(selectedPolicy) },
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Text(stringResource(R.string.onboarding_get_started))

--- a/app/src/main/kotlin/io/privkey/keep/storage/OnboardingStore.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/OnboardingStore.kt
@@ -1,0 +1,25 @@
+package io.privkey.keep.storage
+
+import android.content.Context
+import android.content.SharedPreferences
+
+// Presentation-only flag: records whether the first-run guidance has been shown
+// so it appears once. Encodes no signing/authorization policy.
+class OnboardingStore(context: Context) {
+
+    companion object {
+        private const val PREFS_NAME = "keep_onboarding"
+        private const val KEY_COMPLETED = "onboarding_completed"
+    }
+
+    private val prefs: SharedPreferences = run {
+        val newPrefs = KeystoreEncryptedPrefs.create(context, PREFS_NAME)
+        LegacyPrefsMigration.migrateIfNeeded(context, PREFS_NAME, newPrefs)
+    }
+
+    fun isCompleted(): Boolean = prefs.getBoolean(KEY_COMPLETED, false)
+
+    fun setCompleted(completed: Boolean) {
+        prefs.edit().putBoolean(KEY_COMPLETED, completed).commit()
+    }
+}

--- a/app/src/main/res/values/strings_onboarding.xml
+++ b/app/src/main/res/values/strings_onboarding.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources tools:ignore="MissingTranslation" xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- OnboardingScreen -->
+    <string name="onboarding_title">Welcome to Keep</string>
+    <string name="onboarding_intro">Keep is a Nostr signer. Before you create or import an account, here is what protects your identity and how signing works.</string>
+    <string name="onboarding_frost_title">What is a FROST share?</string>
+    <string name="onboarding_frost_body">Your Nostr key is split into multiple FROST shares instead of living in one place. Each device or backup holds only a share, so a single lost or stolen share never exposes your full key.</string>
+    <string name="onboarding_threshold_title">Threshold and recovery</string>
+    <string name="onboarding_threshold_body">Signing needs a threshold of shares to cooperate — for example 2 of 3. You can recover your account as long as you still have a threshold of shares, and you can rotate a lost share without changing your public identity.</string>
+    <string name="onboarding_nsec_title">nsec vs FROST share</string>
+    <string name="onboarding_nsec_body">An nsec is your whole private key in one secret: simple, but anyone who copies it controls your account forever. A FROST share is safer because it is only one piece and can be revoked. Import an nsec only if you already manage one elsewhere.</string>
+    <string name="onboarding_backup_title">What \"backup confirmed\" means</string>
+    <string name="onboarding_backup_body">Confirming a backup tells Keep you have safely stored your recovery seed words offline. Until you confirm, losing this device can mean losing access. Keep never uploads your backup for you.</string>
+    <string name="onboarding_sign_policy_heading">Choose a signing policy</string>
+    <string name="onboarding_sign_policy_subheading">Decide how much Keep asks before signing. You can change this any time in Settings.</string>
+    <string name="onboarding_get_started">Get Started</string>
+</resources>

--- a/app/src/main/res/values/strings_onboarding.xml
+++ b/app/src/main/res/values/strings_onboarding.xml
@@ -6,7 +6,7 @@
     <string name="onboarding_frost_title">What is a FROST share?</string>
     <string name="onboarding_frost_body">Your Nostr key is split into multiple FROST shares instead of living in one place. Each device or backup holds only a share, so a single lost or stolen share never exposes your full key.</string>
     <string name="onboarding_threshold_title">Threshold and recovery</string>
-    <string name="onboarding_threshold_body">Signing needs a threshold of shares to cooperate — for example 2 of 3. You can recover your account as long as you still have a threshold of shares, and you can rotate a lost share without changing your public identity.</string>
+    <string name="onboarding_threshold_body">Signing needs a threshold of shares to cooperate, for example 2 of 3. You can recover your account as long as you still have a threshold of shares, and you can rotate a lost share without changing your public identity.</string>
     <string name="onboarding_nsec_title">nsec vs FROST share</string>
     <string name="onboarding_nsec_body">An nsec is your whole private key in one secret: simple, but anyone who copies it controls your account forever. A FROST share is safer because it is only one piece and can be revoked. Import an nsec only if you already manage one elsewhere.</string>
     <string name="onboarding_backup_title">What \"backup confirmed\" means</string>


### PR DESCRIPTION
Adds a first-run onboarding flow: explanatory cards covering FROST shares, threshold/recovery, nsec-vs-share tradeoffs, and what "backup confirmed" means, followed by a signing-policy choice and a "Get started" action. Completion is recorded so the flow appears once.

Closes #295.

## Signing policy is persisted on confirmation, not on selection

An earlier revision of this branch wrote the global signing policy on every radio-button tap. That meant tapping "Auto" simply to read its description ("auto-approve all signing requests without any prompts... least secure") immediately committed it as the global policy, with no confirmation. Backgrounding the app at that point left `AUTO` persisted while onboarding remained incomplete.

`OnboardingScreen` no longer persists anything. It reports the chosen policy through `onDone(selectedPolicy)`, and `MainActivity` performs a single write, setting the policy before the completion flag, inside one `withContext(Dispatchers.IO)` block on an activity-lifetime scope. Because `commit()` is blocking rather than suspending, cancellation cannot interleave between the two writes. If the process dies between them, onboarding simply re-shows on next launch, which is the fail-safe direction.

## Scope of the sign-policy criterion

Issue #295 asked the onboarding screen to dispatch its policy selection to the keep core, on the basis that sign policy was already exposed over FFI. That is only half accurate. The core exposes the policy *evaluator* (`PolicyMode`, `evaluate_sign_policy`), but not a setter for the user's *selection*. Selection persistence lives natively in `SignPolicyStore`, which the Settings screen already writes to.

This PR therefore reuses the existing native store rather than introducing a new one, and adds no new policy logic or persistence mechanism. Moving selection ownership into the core is tracked upstream in privkeyio/keep#716, which will migrate both call sites (Settings and `MainActivity`) together and requires a `keep.version` bump. Hoisting persistence out of `OnboardingScreen` in this PR reduces that migration to two call sites instead of three.

## Tests

- `OnboardingScreenTest` guards the regression above: selecting an option must not persist it, and confirming must report the selection without the screen writing.
- `OnboardingStoreIntegrationTest` covers the completion flag's default, round-trip, and persistence across store instances.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an onboarding flow for first-time app setup, including introductory content and sign policy selection.
  * Users can now choose a signing policy during onboarding and continue into the app after confirming.
  * Added persistent onboarding completion tracking so the welcome flow only appears when needed.

* **Tests**
  * Added coverage for onboarding screen behavior and onboarding completion storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->