### PR TITLE
test: fix androidTest compile against keep v0.5.0 bindings (httpAuth)

### DIFF
--- a/app/src/androidTest/kotlin/io/privkey/keep/nip46/ConcurrencyCapInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/nip46/ConcurrencyCapInstrumentedTest.kt
@@ -59,6 +59,7 @@ class ConcurrencyCapInstrumentedTest {
         eventKind = null,
         eventContent = null,
         requestedPermissions = null,
+        httpAuth = null,
     )
 
     private fun add(pubkey: String): Pair<String, Boolean> {


### PR DESCRIPTION
Fixes the `instrumented-tests` CI failure on `main` introduced by pinning keep to v0.5.0 (#398).

## Cause
keep v0.5.0's keep-mobile added an `httpAuth` field to the `BunkerApprovalRequest` UniFFI record (it surfaces a NIP-98 request's URL/method in the approval prompt). The regenerated Kotlin binding therefore requires `httpAuth`, but the `ConcurrencyCapInstrumentedTest` helper still constructed `BunkerApprovalRequest` without it, so `compileDebugAndroidTestKotlin` failed. The app itself compiles and the released APK is unaffected; only the androidTest source was stale.

## Fix
Pass `httpAuth = null` in the test's `approvalRequest(...)` builder.
