### PR TITLE
build: bump keep pin to current main for the NIP-55 decision orchestrator

### DIFF
--- a/keep.version
+++ b/keep.version
@@ -1,1 +1,1 @@
-ded5f70eac80bff3722598b4a2ebf3f50a2567a7
+e36e103bffe7ffa9b29e657faff43ba21fe0c8f3


### PR DESCRIPTION
## Summary

Bumps the pinned keep checkout (`keep.version`) from the previous SHA to current keep `main`. This brings the app's keep-mobile dependency up to date, including the new unified NIP-55 signing-decision orchestrator (`evaluate_nip55_request`) and the other keep-mobile/keep-core changes merged since the last pin.

This is the enabling step for wiring the Android NIP-55 decision path to the Rust orchestrator; that Kotlin change follows in a separate PR.

## Verification

- keep-mobile's UniFFI export surface across this range is additive (the orchestrator entry points were added; no exported functions/records were removed or renamed), so existing bindings are unaffected.
- CI is the authoritative check: it builds keep-mobile for the Android targets at the pinned SHA, regenerates the UniFFI bindings, compiles the app, and runs unit, lint, and instrumented tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s internal version identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->