### PR TITLE
nip46: show NIP-98 HTTP url/method in the bunker approval screen

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/nip46/Nip46ApprovalActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip46/Nip46ApprovalActivity.kt
@@ -94,6 +94,8 @@ class Nip46ApprovalActivity : FragmentActivity() {
                         eventKind = request.eventKind?.toInt(),
                         eventContent = request.eventContent,
                         isConnectRequest = isConnect,
+                        httpAuthUrl = request.httpAuth?.url,
+                        httpAuthMethod = request.httpAuth?.method,
                         onApprove = ::handleApprove,
                         onReject = ::handleReject
                     )

--- a/app/src/main/kotlin/io/privkey/keep/nip46/Nip46ApprovalActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip46/Nip46ApprovalActivity.kt
@@ -94,6 +94,7 @@ class Nip46ApprovalActivity : FragmentActivity() {
                         eventKind = request.eventKind?.toInt(),
                         eventContent = request.eventContent,
                         isConnectRequest = isConnect,
+                        hasHttpAuth = request.httpAuth != null,
                         httpAuthUrl = request.httpAuth?.url,
                         httpAuthMethod = request.httpAuth?.method,
                         onApprove = ::handleApprove,

--- a/app/src/main/kotlin/io/privkey/keep/nip46/Nip46ApprovalScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip46/Nip46ApprovalScreen.kt
@@ -26,6 +26,27 @@ private fun sanitizeDisplayContent(content: String): String {
         .take(500)
 }
 
+/**
+ * The HTTP-auth (NIP-98, kind 27235) detail rows for the approval prompt as
+ * (label resource id, display value) pairs, or empty when the request carries no
+ * HTTP-auth. Gated on presence ([hasHttpAuth]), not field content: the signer core
+ * returns a present-but-empty httpAuth for a malformed 27235 (no `u` tag), and both
+ * rows must still render with [unspecified] so the missing target is flagged, never
+ * silently hidden.
+ */
+internal fun httpAuthRows(
+    hasHttpAuth: Boolean,
+    url: String?,
+    method: String?,
+    unspecified: String
+): List<Pair<Int, String>> {
+    if (!hasHttpAuth) return emptyList()
+    return listOf(
+        R.string.connections_nip46_http_url to (url?.takeIf { it.isNotBlank() } ?: unspecified),
+        R.string.connections_nip46_http_method to (method?.takeIf { it.isNotBlank() } ?: unspecified)
+    )
+}
+
 @Composable
 fun Nip46ApprovalScreen(
     appPubkey: String,
@@ -34,6 +55,7 @@ fun Nip46ApprovalScreen(
     eventKind: Int?,
     eventContent: String?,
     isConnectRequest: Boolean = false,
+    hasHttpAuth: Boolean = false,
     httpAuthUrl: String? = null,
     httpAuthMethod: String? = null,
     onApprove: (duration: PermissionDuration, onComplete: (success: Boolean) -> Unit) -> Unit,
@@ -116,19 +138,14 @@ fun Nip46ApprovalScreen(
                     Nip46DetailRow(stringResource(R.string.connections_nip46_event_kind), EventKind.displayName(context, eventKind))
                 }
 
-                if (!sanitizedHttpUrl.isNullOrBlank() || !sanitizedHttpMethod.isNullOrBlank()) {
-                    val unspecified = stringResource(R.string.connections_nip46_http_unspecified)
-                    Spacer(modifier = Modifier.height(12.dp))
-                    Nip46DetailRow(
-                        stringResource(R.string.connections_nip46_http_url),
-                        sanitizedHttpUrl?.takeIf { it.isNotBlank() } ?: unspecified
-                    )
-                    Spacer(modifier = Modifier.height(12.dp))
-                    Nip46DetailRow(
-                        stringResource(R.string.connections_nip46_http_method),
-                        sanitizedHttpMethod?.takeIf { it.isNotBlank() } ?: unspecified
-                    )
-                }
+                // Gate on PRESENCE, not field content: the signer core returns a
+                // present-but-empty httpAuth for a malformed kind-27235 so the prompt
+                // must flag the missing target ("Unspecified"), never hide it.
+                httpAuthRows(hasHttpAuth, sanitizedHttpUrl, sanitizedHttpMethod, stringResource(R.string.connections_nip46_http_unspecified))
+                    .forEach { (labelRes, value) ->
+                        Spacer(modifier = Modifier.height(12.dp))
+                        Nip46DetailRow(stringResource(labelRes), value, valueMaxLines = 4)
+                    }
 
                 if (!sanitizedContent.isNullOrBlank()) {
                     Spacer(modifier = Modifier.height(12.dp))

--- a/app/src/main/kotlin/io/privkey/keep/nip46/Nip46ApprovalScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip46/Nip46ApprovalScreen.kt
@@ -34,6 +34,8 @@ fun Nip46ApprovalScreen(
     eventKind: Int?,
     eventContent: String?,
     isConnectRequest: Boolean = false,
+    httpAuthUrl: String? = null,
+    httpAuthMethod: String? = null,
     onApprove: (duration: PermissionDuration, onComplete: (success: Boolean) -> Unit) -> Unit,
     onReject: () -> Unit
 ) {
@@ -44,6 +46,11 @@ fun Nip46ApprovalScreen(
     val sanitizedContent = remember(eventContent) {
         eventContent?.let { sanitizeDisplayContent(it) }
     }
+    // NIP-98 (kind 27235) HTTP-auth: the security-relevant URL and method live in
+    // the event tags, not the (empty) content, so surface them so the user can see
+    // exactly which request they are authorizing before approving.
+    val sanitizedHttpUrl = remember(httpAuthUrl) { httpAuthUrl?.let { sanitizeDisplayContent(it) } }
+    val sanitizedHttpMethod = remember(httpAuthMethod) { httpAuthMethod?.let { sanitizeDisplayContent(it) } }
     val sanitizedAppName = remember(appName) { sanitizeDisplayContent(appName) }
 
     Column(
@@ -107,6 +114,20 @@ fun Nip46ApprovalScreen(
                 if (eventKind != null) {
                     Spacer(modifier = Modifier.height(12.dp))
                     Nip46DetailRow(stringResource(R.string.connections_nip46_event_kind), EventKind.displayName(context, eventKind))
+                }
+
+                if (!sanitizedHttpUrl.isNullOrBlank() || !sanitizedHttpMethod.isNullOrBlank()) {
+                    val unspecified = stringResource(R.string.connections_nip46_http_unspecified)
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Nip46DetailRow(
+                        stringResource(R.string.connections_nip46_http_url),
+                        sanitizedHttpUrl?.takeIf { it.isNotBlank() } ?: unspecified
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Nip46DetailRow(
+                        stringResource(R.string.connections_nip46_http_method),
+                        sanitizedHttpMethod?.takeIf { it.isNotBlank() } ?: unspecified
+                    )
                 }
 
                 if (!sanitizedContent.isNullOrBlank()) {

--- a/app/src/main/kotlin/io/privkey/keep/nip46/Nip46UiComponents.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip46/Nip46UiComponents.kt
@@ -21,13 +21,22 @@ import io.privkey.keep.nip55.PermissionDuration
 import io.privkey.keep.uniffi.Nip55RequestType
 
 @Composable
-internal fun Nip46DetailRow(label: String, value: String) {
+internal fun Nip46DetailRow(
+    label: String,
+    value: String,
+    valueMaxLines: Int = Int.MAX_VALUE
+) {
     Text(
         text = label,
         style = MaterialTheme.typography.labelMedium,
         color = MaterialTheme.colorScheme.onSurfaceVariant
     )
-    Text(text = value, style = MaterialTheme.typography.bodyLarge)
+    Text(
+        text = value,
+        style = MaterialTheme.typography.bodyLarge,
+        maxLines = valueMaxLines,
+        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/res/values/strings_connections.xml
+++ b/app/src/main/res/values/strings_connections.xml
@@ -129,6 +129,9 @@
     <string name="connections_nip46_method">Method</string>
     <string name="connections_nip46_event_kind">Event Kind</string>
     <string name="connections_nip46_content">Content</string>
+    <string name="connections_nip46_http_url">HTTP URL</string>
+    <string name="connections_nip46_http_method">HTTP Method</string>
+    <string name="connections_nip46_http_unspecified">Unspecified</string>
     <string name="connections_nip46_app_public_key">App Public Key</string>
     <string name="connections_nip46_remember_decision">Remember this decision</string>
     <string name="connections_nip46_reject">Reject</string>

--- a/app/src/test/kotlin/io/privkey/keep/nip46/HttpAuthRowsTest.kt
+++ b/app/src/test/kotlin/io/privkey/keep/nip46/HttpAuthRowsTest.kt
@@ -1,0 +1,43 @@
+package io.privkey.keep.nip46
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The NIP-98 HTTP-auth rows must be gated on presence, not field content, so a
+ * malformed kind-27235 (present httpAuth but no `u` tag) still flags the missing
+ * target rather than hiding it. Assertions check row count + values (independent
+ * of resource-id resolution in JVM unit tests).
+ */
+class HttpAuthRowsTest {
+    private val unspecified = "Unspecified"
+
+    @Test
+    fun noHttpAuth_yieldsNoRows() {
+        assertTrue(httpAuthRows(hasHttpAuth = false, url = "https://x", method = "GET", unspecified).isEmpty())
+    }
+
+    @Test
+    fun presentButBothBlank_stillShowsBothRowsAsUnspecified() {
+        val rows = httpAuthRows(hasHttpAuth = true, url = null, method = "", unspecified)
+        assertEquals(2, rows.size)
+        assertEquals(unspecified, rows[0].second)
+        assertEquals(unspecified, rows[1].second)
+    }
+
+    @Test
+    fun presentWithValues_showsValues() {
+        val rows = httpAuthRows(hasHttpAuth = true, url = "https://api.example.com/x", method = "POST", unspecified)
+        assertEquals(2, rows.size)
+        assertEquals("https://api.example.com/x", rows[0].second)
+        assertEquals("POST", rows[1].second)
+    }
+
+    @Test
+    fun oneBlank_fallsBackForThatFieldOnly() {
+        val rows = httpAuthRows(hasHttpAuth = true, url = "https://x", method = null, unspecified)
+        assertEquals("https://x", rows[0].second)
+        assertEquals(unspecified, rows[1].second)
+    }
+}


### PR DESCRIPTION
## Summary

Closes the keep-android follow-up from the NIP-98 over-broad-grant fix: the bunker approval screen did not show the HTTP URL/method being authorized.

NIP-98 (kind 27235) events carry empty content; the security-relevant `u` (URL) and method live in the event tags. The Rust signer core already surfaces these as `BunkerApprovalRequest.httpAuth { url, method }`, but `Nip46ApprovalScreen` never rendered them, so a user approving an HTTP-auth signature could not see which request they were authorizing.

This renders the URL and method in the approval details for kind-27235 requests, so HTTP-auth is not approved blind.

## Changes

- `Nip46ApprovalScreen`: new `httpAuthUrl`/`httpAuthMethod` params; when present, renders sanitized "HTTP URL" and "HTTP Method" detail rows (a missing tag reads as "Unspecified", per the Rust contract, rather than being hidden).
- `Nip46ApprovalActivity`: passes `request.httpAuth?.url` / `?.method` through.
- String resources for the two labels and the unspecified placeholder.

The URL/method are already sanitized in the signer core and are re-sanitized for display (`sanitizeDisplayContent`).

## Testing

- Local: `compileDebugKotlin`, `testDebugUnitTest`, and `lintDebug` pass.

GH: privkeyio/keep-android#392


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NIP-46 approval requests now display HTTP authentication details, including the request URL and method.
  * Unspecified HTTP methods are clearly labeled.
  * Displayed security-related values are sanitized before being shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->