### PR TITLE
ui: extract shared sign-policy option row and fix doubled card border (#403)

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/OnboardingScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/OnboardingScreen.kt
@@ -1,6 +1,5 @@
 package io.privkey.keep
 
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -12,8 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.selection.selectable
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
@@ -23,7 +20,6 @@ import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -33,14 +29,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.Role
 import io.privkey.keep.storage.SignPolicy
 import io.privkey.keep.storage.SignPolicyStore
 import io.privkey.keep.ui.components.KeepCard
 import io.privkey.keep.ui.components.KeepScreenScaffold
+import io.privkey.keep.ui.components.SignPolicyOptionRow
 import io.privkey.keep.ui.theme.Dimens
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -108,10 +103,10 @@ fun OnboardingScreen(
             )
 
             SignPolicy.entries.forEach { policy ->
-                OnboardingPolicyOption(
+                SignPolicyOptionRow(
                     policy = policy,
                     isSelected = selectedPolicy == policy,
-                    onClick = {
+                    onSelected = {
                         userInteracted = true
                         selectedPolicy = policy
                     }
@@ -152,42 +147,5 @@ private fun OnboardingInfoCard(
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
-    }
-}
-
-@Composable
-private fun OnboardingPolicyOption(
-    policy: SignPolicy,
-    isSelected: Boolean,
-    onClick: () -> Unit
-) {
-    val borderColor = if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent
-    KeepCard(
-        modifier = Modifier.border(
-            Dimens.cardBorderWidth,
-            borderColor,
-            RoundedCornerShape(Dimens.space12)
-        ).selectable(
-            selected = isSelected,
-            onClick = onClick,
-            role = Role.RadioButton
-        )
-    ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            RadioButton(selected = isSelected, onClick = null)
-            Spacer(Modifier.width(Dimens.space16))
-            Column {
-                Text(
-                    stringResource(policy.displayNameRes),
-                    style = MaterialTheme.typography.titleMedium
-                )
-                Spacer(Modifier.height(Dimens.space4))
-                Text(
-                    stringResource(policy.descriptionRes),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
     }
 }

--- a/app/src/main/kotlin/io/privkey/keep/nip55/SignPolicyScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/SignPolicyScreen.kt
@@ -1,23 +1,18 @@
 package io.privkey.keep.nip55
 
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.selection.selectable
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import io.privkey.keep.R
 import io.privkey.keep.storage.SignPolicy
 import io.privkey.keep.storage.SignPolicyStore
+import io.privkey.keep.ui.components.SignPolicyOptionRow
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -62,10 +57,10 @@ fun SignPolicyScreen(
             )
 
             SignPolicy.entries.forEach { policy ->
-                SignPolicyOption(
+                SignPolicyOptionRow(
                     policy = policy,
                     isSelected = selectedPolicy == policy,
-                    onClick = {
+                    onSelected = {
                         userInteracted = true
                         selectedPolicy = policy
                         coroutineScope.launch {
@@ -74,50 +69,6 @@ fun SignPolicyScreen(
                             }
                         }
                     }
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun SignPolicyOption(
-    policy: SignPolicy,
-    isSelected: Boolean,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val borderColor = if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent
-
-    Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .border(2.dp, borderColor, RoundedCornerShape(12.dp))
-            .selectable(
-                selected = isSelected,
-                onClick = onClick,
-                role = Role.RadioButton
-            )
-    ) {
-        Row(
-            modifier = Modifier.padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            RadioButton(
-                selected = isSelected,
-                onClick = null
-            )
-            Spacer(modifier = Modifier.width(16.dp))
-            Column {
-                Text(
-                    text = stringResource(policy.displayNameRes),
-                    style = MaterialTheme.typography.titleMedium
-                )
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = stringResource(policy.descriptionRes),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         }

--- a/app/src/main/kotlin/io/privkey/keep/ui/components/KeepCard.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ui/components/KeepCard.kt
@@ -22,10 +22,10 @@ fun KeepCard(
     modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null,
     contentPadding: PaddingValues = PaddingValues(Dimens.cardPadding),
+    border: BorderStroke = BorderStroke(Dimens.cardBorderWidth, MaterialTheme.colorScheme.outline),
     content: @Composable ColumnScope.() -> Unit
 ) {
     val colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
-    val border = BorderStroke(Dimens.cardBorderWidth, MaterialTheme.colorScheme.outline)
     val elevation = CardDefaults.cardElevation(defaultElevation = Dimens.cardElevation)
     if (onClick != null) {
         Card(onClick = onClick, modifier = modifier.fillMaxWidth(), colors = colors, border = border, elevation = elevation) {

--- a/app/src/main/kotlin/io/privkey/keep/ui/components/SignPolicyOptionRow.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ui/components/SignPolicyOptionRow.kt
@@ -1,0 +1,54 @@
+package io.privkey.keep.ui.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import io.privkey.keep.storage.SignPolicy
+import io.privkey.keep.ui.theme.Dimens
+
+@Composable
+fun SignPolicyOptionRow(
+    policy: SignPolicy,
+    isSelected: Boolean,
+    onSelected: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val borderColor = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline
+    KeepCard(
+        modifier = modifier.selectable(
+            selected = isSelected,
+            onClick = onSelected,
+            role = Role.RadioButton
+        ),
+        border = BorderStroke(Dimens.cardBorderWidth, borderColor)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            RadioButton(selected = isSelected, onClick = null)
+            Spacer(Modifier.width(Dimens.space16))
+            Column {
+                Text(
+                    stringResource(policy.displayNameRes),
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Spacer(Modifier.height(Dimens.space4))
+                Text(
+                    stringResource(policy.descriptionRes),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent sign-policy selection rows with radio buttons, titles, descriptions, and selection styling.
  * Standardized sign-policy choices across onboarding and sign-policy settings screens.
  * Added configurable card borders for greater UI flexibility.

* **UI Improvements**
  * Improved visual consistency and accessibility for policy selection controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->