### PR TITLE
bunker: fail closed instead of connecting without proxy on proxy-start failure

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/nip46/BunkerService.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip46/BunkerService.kt
@@ -419,9 +419,19 @@ class BunkerService : Service() {
             }
 
             val proxy = runCatching { keepMobileRef?.getProxyConfig() }.getOrNull()
-            val proxyStarted = proxy != null && proxy.enabled && proxy.port.toInt() in 1..65535 &&
-                invokeStartBunkerWithProxy(handler, safeRelays, callbacks, "127.0.0.1", proxy.port)
-            if (!proxyStarted) {
+            if (proxy != null && proxy.enabled && proxy.port.toInt() in 1..65535) {
+                // A proxy is configured. Fail closed if it cannot be started:
+                // falling back to a direct connection would leak the user's IP to
+                // the relays, defeating the point of the proxy (e.g. Tor).
+                if (!invokeStartBunkerWithProxy(handler, safeRelays, callbacks, "127.0.0.1", proxy.port)) {
+                    if (BuildConfig.DEBUG) {
+                        Log.e(TAG, "proxy enabled but startBunkerWithProxy failed; refusing to connect without proxy")
+                    }
+                    _status.value = BunkerStatus.ERROR
+                    stopSelf()
+                    return false
+                }
+            } else {
                 handler.startBunker(safeRelays, callbacks)
             }
 


### PR DESCRIPTION
`BunkerService.startBunker` computed `proxyStarted = proxy enabled && invokeStartBunkerWithProxy(...)` and then did `if (!proxyStarted) handler.startBunker(...)`. When a proxy was configured and enabled but `invokeStartBunkerWithProxy` returned false (the reflected `startBunkerWithProxy` method absent, or `invoke` threw), `proxyStarted` was false and the code silently fell through to a **direct, non-proxied** bunker connection. For a user running the bunker over Tor (or any privacy proxy), that leaks their real IP address to the relays, exactly what the proxy is meant to prevent, with only a DEBUG-level log.

## Change

- Split the two cases: if a proxy is configured (enabled + valid port), start **only** via the proxy; if the proxy start fails, fail closed (set `BunkerStatus.ERROR`, `stopSelf()`, return) instead of connecting directly. If no proxy is configured, connect directly as before.

Uses a smart-cast (no `!!`) and a DEBUG-gated error log, matching the surrounding style.

## Verification

- `./gradlew :app:compileDebugKotlin`: BUILD SUCCESSFUL (the only warning is a pre-existing Room schema-export note, unrelated).

Note: runtime/instrumented verification (actually forcing a proxy-start failure) is not covered here; the change is a straightforward control-flow fix that removes the fall-through path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bunker startup reliability when using a configured proxy.
  * The service now reports an error and stops cleanly if proxy-based startup fails.
  * Falls back to direct startup when proxy settings are unavailable or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->