### PR TITLE
nip55: remove dead VelocityConfig (velocity limits are Rust-authoritative)

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/nip55/PermissionEntities.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/PermissionEntities.kt
@@ -125,12 +125,6 @@ data class Nip55AppSettings(
         isTimestampExpired(expiresAt, createdAt, createdAtElapsed, durationMs, currentElapsed, currentTimeMillis)
 }
 
-data class VelocityConfig(
-    val hourlyLimit: Int = 1000,
-    val dailyLimit: Int = 5000,
-    val enabled: Boolean = true
-)
-
 sealed class VelocityResult {
     data object Allowed : VelocityResult()
     data class Blocked(val reason: String, val resetAt: Long) : VelocityResult()


### PR DESCRIPTION
The `VelocityConfig` data class (`hourlyLimit`/`dailyLimit`/`enabled`) in `PermissionEntities.kt` had **zero references** anywhere in the codebase (verified by repo-wide grep across main + androidTest + test). NIP-55 velocity enforcement is authoritative in Rust: `PermissionStore.checkAndRecordVelocity` feeds raw window counts to `nip55CheckVelocity(hourly, daily, weekly)`, which applies its own thresholds, and even the display path reads limits from the UniFFI-generated Rust `AutoSignDecision` type, not this class.

Keeping a config-looking class that no code consults is a config-drift footgun: an operator could edit these limits expecting them to take effect, but they are silently ignored. Removing it makes it clear the Rust side is the single source of truth.

## Change

- Delete the unused `VelocityConfig` data class. `VelocityResult` (which IS used) is untouched.

## Verification

- Repo-wide `grep VelocityConfig`: no references remain after deletion.
- `./gradlew :app:compileDebugKotlin`: BUILD SUCCESSFUL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed an unused velocity configuration type from the application’s internal permission model.
  * No user-facing functionality or visible behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->