### PR TITLE
account: revoke old permissions before activating new share on switch

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
+++ b/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
@@ -131,8 +131,16 @@ internal class AccountActions(
                             keepMobile.saveRelayConfig(currentKey, RelayConfigInfo(currentRelays, existing.profileRelays, existing.bunkerRelays))
                         }
                     }
-                    activateShare(authedCipher, account.groupPubkeyHex)
+                    // Clear the previous account's permissions/state BEFORE
+                    // activating the new signing key. The NIP-55 ContentProvider
+                    // signing path does not take accountMutex, so if activation
+                    // happened first a request racing this switch could resolve an
+                    // old grant against the newly-active key. Revoking first makes
+                    // the transition window fail-safe (no grants + old key -> the
+                    // request re-prompts). onAccountSwitched clears state account-
+                    // agnostically and does not depend on the new active share.
                     onAccountSwitched()
+                    activateShare(authedCipher, account.groupPubkeyHex)
                     refreshAccountState()
                 } catch (e: Exception) {
                     logAndToast("Switch failed", appContext.getString(R.string.account_switch_failed), e)
@@ -207,6 +215,11 @@ internal class AccountActions(
                 coroutineScope.launch {
                     accountMutex.withLock {
                         try {
+                            // Clear the deleted account's permissions/state before
+                            // activating the next account's key, so a signing request
+                            // racing this switch cannot resolve an old grant against
+                            // the new key (revoke-before-activate; see switchAccount).
+                            onAccountSwitched()
                             if (switchAuthed != null) {
                                 try {
                                     activateShare(switchAuthed, nextAccount.groupPubkeyHex)
@@ -214,7 +227,6 @@ internal class AccountActions(
                                     if (BuildConfig.DEBUG) Log.e("AccountActions", "Post-delete switch failed: ${e::class.simpleName}")
                                 }
                             }
-                            onAccountSwitched()
                             refreshAccountState()
                         } finally {
                             onDismiss()


### PR DESCRIPTION
On an account switch, `AccountActions` activated the new signing key (`activateShare` → `setActiveShare`) and only **afterward** ran `onAccountSwitched()` (which revokes all NIP-55 permissions, clears caller trust / velocity / auto-signing state, and stops the bunker). Because the NIP-55 ContentProvider signing path does not take `accountMutex`, a signing request arriving in that window could see the newly-active key together with the previous account's still-present grants, and auto-approve a signature under the new account's key using an old ALLOW.

## Change

Reorder both switch paths to **revoke-then-activate**:
- `switchAccount`: `onAccountSwitched()` now runs before `activateShare(...)`.
- `switchToNextAccountAfterDelete`: same reorder.

This makes the transition window fail-safe: during it the old key is still active but the grants are already cleared, so a racing request finds no grant and re-prompts, and once the new key is active the grants are already gone. The reorder is safe because `onAccountSwitched` clears state account-agnostically (it does not depend on the newly-activated share) and `activateShare` only calls `setActiveShare` (it does not depend on permissions). `saveRelayConfig` for the outgoing account still runs first in `switchAccount`, and both paths remain inside `accountMutex`.

## Verification

- `./gradlew :app:compileDebugKotlin`: BUILD SUCCESSFUL.

## Note (fail-safe, no security impact)
If `activateShare` throws during a switch, the still-active old account is now left with permissions revoked / bunker stopped (previously these stayed intact because the revoke ran after activation and was skipped on failure). This is a mild UX degradation on a failed switch (re-grant / reconnect on the old account) but strictly in the fail-safe direction. Security-reviewed: the reorder closes the authorization-window race with no dependency inversion and no new window.