### PR TITLE
nip46: extract + unit-test the client authorization boolean

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/nip46/BunkerService.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip46/BunkerService.kt
@@ -617,7 +617,11 @@ class BunkerService : Service() {
         val mobile = keepMobileRef
         val pk = clientPubkey.lowercase()
         val denylisted = runCatching { Nip46ClientStore.isDenylisted(this, pk) }.getOrDefault(true)
-        val isAuthorized = !denylisted && (pendingAuthSaves.contains(pk) || authorizedClientsCache.contains(pk))
+        val isAuthorized = isClientAuthorized(
+            denylisted = denylisted,
+            inPendingAuth = pendingAuthSaves.contains(pk),
+            inCache = authorizedClientsCache.contains(pk)
+        )
         val isConnectRequest = request.method == "connect"
 
         // Gate-then-budget ordering is contract-tested by RateLimitDelegationTest:

--- a/app/src/main/kotlin/io/privkey/keep/nip46/RequestGate.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip46/RequestGate.kt
@@ -22,3 +22,19 @@ internal fun requestGateDecision(
     } else {
         RequestGate.RATE_LIMIT_THEN_PROCEED
     }
+
+/**
+ * Whether a NIP-46 client is authorized to have its (non-connect) requests
+ * served. The denylist always wins; otherwise the client must be present in
+ * either the warm-start `pending-auth` set (it just completed a connect
+ * approval before its persisted authorization was reloaded into the cache) or
+ * the authorized-clients cache. This is the security-critical authorization
+ * boolean feeding [requestGateDecision].
+ *
+ * Pure function: no Service state, no native calls, fully unit-testable.
+ */
+internal fun isClientAuthorized(
+    denylisted: Boolean,
+    inPendingAuth: Boolean,
+    inCache: Boolean
+): Boolean = !denylisted && (inPendingAuth || inCache)

--- a/app/src/test/kotlin/io/privkey/keep/nip46/IsClientAuthorizedTest.kt
+++ b/app/src/test/kotlin/io/privkey/keep/nip46/IsClientAuthorizedTest.kt
@@ -1,0 +1,41 @@
+package io.privkey.keep.nip46
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Coverage for the authorization boolean that gates NIP-46 non-connect requests
+ * ([isClientAuthorized]). It feeds [requestGateDecision]; getting it wrong would
+ * either serve an unauthorized client or deny an authorized one. The cache
+ * population / eviction / revoke paths are Service state and out of unit scope.
+ */
+class IsClientAuthorizedTest {
+
+    @Test
+    fun denylistAlwaysWins() {
+        // A denylisted client is unauthorized even if it somehow appears in the
+        // cache or the warm-start pending-auth set.
+        assertFalse(isClientAuthorized(denylisted = true, inPendingAuth = true, inCache = true))
+        assertFalse(isClientAuthorized(denylisted = true, inPendingAuth = false, inCache = true))
+        assertFalse(isClientAuthorized(denylisted = true, inPendingAuth = true, inCache = false))
+    }
+
+    @Test
+    fun authorizedViaCache() {
+        assertTrue(isClientAuthorized(denylisted = false, inPendingAuth = false, inCache = true))
+    }
+
+    @Test
+    fun authorizedViaPendingAuthWarmStart() {
+        // A client that just completed connect approval, before its persisted
+        // authorization was reloaded into the cache, is authorized via pendingAuth.
+        assertTrue(isClientAuthorized(denylisted = false, inPendingAuth = true, inCache = false))
+    }
+
+    @Test
+    fun unknownClientIsUnauthorized() {
+        // Not denylisted, but present in neither set -> not authorized (re-prompt).
+        assertFalse(isClientAuthorized(denylisted = false, inPendingAuth = false, inCache = false))
+    }
+}


### PR DESCRIPTION
The security-critical authorization decision that gates NIP-46 non-connect requests, `!denylisted && (pendingAuthSaves.contains(pk) || authorizedClientsCache.contains(pk))`, was computed inline in `BunkerService.handleRequest` and had no unit coverage. The gate *ordering* was already extracted/tested (`requestGateDecision` in `RequestGate.kt`), but the boolean that decides *whether a client is authorized at all* was not.

## Change

- Extract the pure `isClientAuthorized(denylisted, inPendingAuth, inCache): Boolean` into `RequestGate.kt` (co-located with `requestGateDecision`, same pure-function style), and route the `BunkerService` call site through it. Behavior is identical.
- Add `IsClientAuthorizedTest` covering: denylist always wins (even when in cache/pending), authorized-via-cache, authorized-via-pending-auth (warm-start), and unknown-client-unauthorized.

## Verification

- `./gradlew :app:testDebugUnitTest --tests io.privkey.keep.nip46.IsClientAuthorizedTest`: BUILD SUCCESSFUL (4 tests pass).