### PR TITLE
import: bound QR frame geometry to prevent Int-overflow in size math

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/ImportShareScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/ImportShareScreen.kt
@@ -49,6 +49,12 @@ private const val MAX_SHARE_LENGTH = 8192
 private const val MAX_ANIMATED_FRAMES = 100
 private const val MAX_FRAME_LENGTH = 4096
 
+// Upper bound on a camera frame's reported width/height (and 4x for rowStride).
+// A real ImageAnalysis frame is ~640x480; this rejects pathological, possibly
+// HAL-reported, geometry so the byte-count arithmetic below (rowStride*(height-1)
+// + width, width*height) cannot overflow Int.
+private const val MAX_FRAME_DIMENSION = 10000
+
 private class LuminanceBuffers {
     private var raw: ByteArray = ByteArray(0)
     private var rotated: ByteArray = ByteArray(0)
@@ -75,7 +81,12 @@ private fun decodeQrFromImageProxy(
     val width = imageProxy.width
     val height = imageProxy.height
 
-    if (width <= 0 || height <= 0 || rowStride < width) return null
+    if (width <= 0 || height <= 0 || rowStride < width ||
+        width > MAX_FRAME_DIMENSION || height > MAX_FRAME_DIMENSION ||
+        rowStride > MAX_FRAME_DIMENSION * 4
+    ) {
+        return null
+    }
 
     val expected = rowStride * (height - 1) + width
     buffer.rewind()


### PR DESCRIPTION
`decodeQrFromImageProxy` validated `width/height/rowStride` for the low bound (`<= 0`, `rowStride < width`) but placed no upper bound before the byte-count arithmetic `rowStride * (height - 1) + width` and `width * height`. With pathological, possibly HAL-reported, dimensions these `Int` products could overflow, producing a wrong (possibly negative/small) expected size and mis-driving the buffer copy. Not reachable via a real camera (analysis frames are ~640x480), so this is defense-in-depth.

## Change

- Add `MAX_FRAME_DIMENSION = 10000` and reject frames whose `width`/`height` exceed it, or whose `rowStride` exceeds `4 * MAX_FRAME_DIMENSION`, before any size arithmetic. With those bounds the products stay well within `Int` range (max ~4e8 vs `Int.MAX` ~2.1e9). Real frames are ~15x below the bound.

## Verification

- `./gradlew :app:compileDebugKotlin`: BUILD SUCCESSFUL.