### PR TITLE
test: document that AuditChainVerificationTest wipes the on-device audit log

### DIFF
--- a/app/src/androidTest/kotlin/io/privkey/keep/nip55/AuditChainVerificationTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/nip55/AuditChainVerificationTest.kt
@@ -12,6 +12,14 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
+/**
+ * DESTRUCTIVE: this suite operates on the production audit log. verifyAuditChain
+ * reads the Keystore-backed HMAC key and audit anchor wired up only by
+ * Nip55Database.getInstance, so setup/teardown call PermissionStore.clearAuditLog()
+ * on the real on-device database. Running these tests wipes any existing audit-log
+ * entries on the device/emulator. Do not point this at a device whose audit log
+ * you need to keep.
+ */
 @RunWith(AndroidJUnit4::class)
 class AuditChainVerificationTest {
 


### PR DESCRIPTION
`AuditChainVerificationTest` must use the production `Nip55Database.getInstance` singleton (an in-memory Room DB has neither the Keystore-backed HMAC key nor the audit anchor that `verifyAuditChain` reads), so its `@Before`/`@After` call `PermissionStore.clearAuditLog()` on the real on-device database. That destructive side effect was undocumented, so a maintainer running the instrumented suite on a device with a real audit log would silently wipe it.

## Change

- Add a KDoc block on the class documenting that the suite is destructive to the on-device audit log and why the production singleton is required. Comment-only; no behavior change.