### PR TITLE
storage: durably commit the wipe of undecryptable metadata before throwing

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
@@ -97,7 +97,10 @@ class AndroidKeystoreStorage(
             decryptWithCipher(cipher, encryptedData)
         } catch (e: Exception) {
             if (BuildConfig.DEBUG) Log.e(TAG, "Metadata key recovery: ${e::class.simpleName}", e)
-            sharePrefs.edit().clear().apply()
+            // Durably flush the wipe of the undecryptable entry before propagating, so a
+            // crash right after this cannot leave the corrupt prefs behind. Runs on a
+            // background FFI-callback thread (@Synchronized), so commit() won't jank the UI.
+            sharePrefs.edit().clear().commit()
             throw KeepMobileException.StorageException("No metadata stored")
         }
     }


### PR DESCRIPTION
When `loadMetadata` cannot decrypt a stored metadata entry (e.g. the shared metadata key was invalidated), it wipes the orphaned entry and throws. The wipe used `SharedPreferences.Editor.apply()` (asynchronous), so a process death immediately after the throw could leave the corrupt entry on disk.

## Change

- Use `.commit()` instead of `.apply()` for that wipe so it is durably flushed before the exception propagates. This path runs only after a decryption failure, touches no crypto and no decryptable data (only the already-orphaned entry's own prefs file), and executes on a background FFI-callback thread (the method is `@Synchronized` and invoked via the SecureStorage callback on Dispatchers.IO), so the blocking `commit()` cannot jank the UI.

Metadata is a non-authoritative UI cache (Rust is the source of truth), so this is a durability hardening of an already fail-safe path, not a behavior change.

## Verification

- `./gradlew :app:compileDebugKotlin` (with `verifyKeepVersion`): BUILD SUCCESSFUL.