### PR TITLE
security: invalidate the biometric timeout window when the app is backgrounded

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -129,6 +129,15 @@ class MainActivity : FragmentActivity() {
                             biometricTimeoutStore.requiresBiometric()) {
                             isBiometricUnlocked = false
                         }
+                    } else if (event == Lifecycle.Event.ON_STOP) {
+                        // Close the biometric timeout window when the app leaves the
+                        // foreground. Otherwise a recently-authenticated session survives a
+                        // background transition, letting someone who resumes the app perform a
+                        // presence-gated action (cosign approval, kill-switch disable) without a
+                        // fresh biometric. ON_STOP (not ON_PAUSE) so the in-app BiometricPrompt
+                        // overlay, which pauses but does not stop the activity, is not clobbered.
+                        // Also lets lock-on-launch re-engage on resume (an open window suppressed it).
+                        biometricTimeoutStore?.invalidateSession()
                     }
                 }
                 lifecycle.addObserver(observer)


### PR DESCRIPTION
With a user-selected non-zero biometric timeout, a successful biometric auth opens a window during which presence-gated actions skip re-authentication. That window was never invalidated on background, so someone who resumes a recently-authenticated app could perform a presence-gated action without a fresh biometric. Two operations honor the window: approving a queued FROST co-sign request (`approveRequest`, which produces a signature) and disabling the kill switch (`setKillSwitch(false)`). Crypto-cipher operations (signing via the ContentProvider/Activity, exports, imports, backup, account creation) always force a fresh biometric via `authenticateWithCrypto`, so they were never affected. The default timeout ("every time") was already safe; this closes the opt-in gap.

## Change

- Invalidate the biometric timeout window on `ON_STOP` in MainActivity's existing lifecycle observer (`biometricTimeoutStore.invalidateSession()`), so the window closes when the app leaves the foreground. `ON_STOP` (not `ON_PAUSE`) is used so the in-app `BiometricPrompt` overlay, which pauses but does not stop the host activity, is not clobbered.
- This also fixes a secondary bug: an open window suppressed lock-on-launch on resume (`requiresBiometric()` returned false), so lock-on-launch now re-engages correctly.

The window still suppresses re-prompts for consecutive operations within one continuous foreground session (its intended purpose); it only closes when the user actually leaves the app, which is the expected meaning of the timeout.

## Verification

- `./gradlew :app:compileDebugKotlin` (with `verifyKeepVersion`): BUILD SUCCESSFUL. The lifecycle wiring is exercised by CI's instrumented tests; `BiometricTimeoutStore` requires a `Context` + `SystemClock`, so it is not plain-JVM-unit-testable.