### PR TITLE
security: allow disabling the kill switch via PIN when biometrics are unavailable

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -351,6 +351,7 @@ fun MainScreen(
 
     var foregroundServiceEnabled by remember { mutableStateOf(foregroundServiceStore.isEnabled()) }
     var showKillSwitchConfirmDialog by remember { mutableStateOf(false) }
+    var showKillSwitchPinPrompt by remember { mutableStateOf(false) }
     var showConnectedApps by remember { mutableStateOf(false) }
     var selectedAppPackage by remember { mutableStateOf<String?>(null) }
     var showPinSetup by remember { mutableStateOf(false) }
@@ -388,7 +389,7 @@ fun MainScreen(
     val handleKillSwitchToggle: (Boolean) -> Unit = { newValue ->
         if (newValue) {
             showKillSwitchConfirmDialog = true
-        } else {
+        } else if (biometricAvailable) {
             coroutineScope.launch {
                 val authenticated = onBiometricAuth?.invoke(
                     appContext.getString(R.string.main_disable_kill_switch_title),
@@ -401,6 +402,11 @@ fun MainScreen(
                     if (updated) killSwitchEnabled = false
                 }
             }
+        } else {
+            // Biometrics unavailable: fall back to PIN so the kill switch cannot lock the
+            // user out of signing permanently (the switch is enabled here only when a PIN
+            // is set). Disabling still requires a verified auth factor.
+            showKillSwitchPinPrompt = true
         }
     }
 
@@ -526,6 +532,27 @@ fun MainScreen(
                 }
             },
             onDismiss = { showKillSwitchConfirmDialog = false }
+        )
+    }
+
+    if (showKillSwitchPinPrompt) {
+        PinPromptDialog(
+            title = stringResource(R.string.main_disable_kill_switch_title),
+            message = stringResource(R.string.main_disable_kill_switch_subtitle),
+            confirmLabel = stringResource(R.string.settings_pin_disable),
+            onVerify = { pin ->
+                val verified = withContext(Dispatchers.IO) { pinStore.verifyPin(pin) }
+                if (!verified) {
+                    false
+                } else {
+                    val updated = withContext(Dispatchers.IO) {
+                        runCatching { keepMobile.setKillSwitch(false) }.isSuccess
+                    }
+                    if (updated) killSwitchEnabled = false
+                    updated
+                }
+            },
+            onDismiss = { showKillSwitchPinPrompt = false }
         )
     }
 
@@ -1029,6 +1056,7 @@ fun MainScreen(
                     securityLevel = securityLevel,
                     killSwitchEnabled = killSwitchEnabled,
                     biometricAvailable = biometricAvailable,
+                    pinEnabled = pinEnabled,
                     onShareDetailsClick = { showShareDetails = true },
                     onAccountSwitcherClick = { showAccountSwitcher = true },
                     onImport = { showImportScreen = true },
@@ -1278,6 +1306,7 @@ private fun HomeTab(
     onRecoverMnemonic: () -> Unit,
     onConnect: () -> Unit,
     biometricAvailable: Boolean,
+    pinEnabled: Boolean,
     onKillSwitchToggle: (Boolean) -> Unit
 ) {
     Column(
@@ -1336,7 +1365,7 @@ private fun HomeTab(
         KillSwitchCard(
             enabled = killSwitchEnabled,
             onToggle = onKillSwitchToggle,
-            toggleEnabled = biometricAvailable
+            toggleEnabled = biometricAvailable || pinEnabled
         )
 
         Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/kotlin/io/privkey/keep/SecuritySettingsScreen.kt
+++ b/app/src/main/kotlin/io/privkey/keep/SecuritySettingsScreen.kt
@@ -61,7 +61,7 @@ fun SecuritySettingsScreen(
             KillSwitchCard(
                 enabled = killSwitchEnabled,
                 onToggle = onKillSwitchToggle,
-                toggleEnabled = biometricAvailable
+                toggleEnabled = biometricAvailable || pinEnabled
             )
 
             PinSettingsCard(

--- a/app/src/main/kotlin/io/privkey/keep/SettingsCards.kt
+++ b/app/src/main/kotlin/io/privkey/keep/SettingsCards.kt
@@ -324,3 +324,90 @@ fun BackupSettingsCard(onClick: () -> Unit) {
         )
     }
 }
+
+/**
+ * A PIN-entry dialog that verifies a PIN before performing a gated action. [onVerify]
+ * receives the entered PIN, performs its own work (verification + the action) off the
+ * main thread as needed, and returns whether it succeeded; on success the dialog
+ * dismisses, otherwise it shows an incorrect-PIN error. Reused by any settings action
+ * that must be PIN-gated (e.g. disabling the kill switch when biometrics are unavailable).
+ */
+@Composable
+fun PinPromptDialog(
+    title: String,
+    message: String,
+    confirmLabel: String,
+    onVerify: suspend (String) -> Boolean,
+    onDismiss: () -> Unit,
+) {
+    val incorrectPinMsg = stringResource(R.string.settings_pin_incorrect)
+    var pinInput by remember { mutableStateOf("") }
+    var error by remember { mutableStateOf<String?>(null) }
+    val coroutineScope = rememberCoroutineScope()
+    AlertDialog(
+        onDismissRequest = {
+            pinInput = ""
+            error = null
+            onDismiss()
+        },
+        title = { Text(title) },
+        text = {
+            Column {
+                Text(message)
+                Spacer(modifier = Modifier.height(16.dp))
+                OutlinedTextField(
+                    value = pinInput,
+                    onValueChange = { newValue ->
+                        if (newValue.length <= PinStore.MAX_PIN_LENGTH && newValue.all { it.isDigit() }) {
+                            pinInput = newValue
+                            error = null
+                        }
+                    },
+                    label = { Text(stringResource(R.string.settings_pin_current_label)) },
+                    singleLine = true,
+                    visualTransformation = PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
+                    isError = error != null,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                error?.let {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    coroutineScope.launch {
+                        val ok = onVerify(pinInput)
+                        if (ok) {
+                            pinInput = ""
+                            error = null
+                            onDismiss()
+                        } else {
+                            error = incorrectPinMsg
+                            pinInput = ""
+                        }
+                    }
+                },
+                enabled = pinInput.length >= PinStore.MIN_PIN_LENGTH
+            ) {
+                Text(confirmLabel)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = {
+                pinInput = ""
+                error = null
+                onDismiss()
+            }) {
+                Text(stringResource(R.string.settings_cancel))
+            }
+        }
+    )
+}


### PR DESCRIPTION
Disabling the kill switch (which blocks all signing) required a biometric, and the UI toggle was disabled whenever biometrics were unavailable. So if the kill switch was ON and the user then lost/removed biometric enrollment (or the device has no biometric hardware), the switch could never be disabled — a permanent signing lockout. keep-android already has a PIN as a second auth factor.

## Change

- Enable the kill-switch toggle whenever any auth factor exists: `toggleEnabled = biometricAvailable || pinEnabled` (SecuritySettingsScreen and the Home tab).
- When disabling and biometrics are unavailable but a PIN is set, prompt for the PIN and verify it via `PinStore.verifyPin` (real verification, with its existing lockout escalation) before calling `setKillSwitch(false)`.
- Add a reusable `PinPromptDialog` composable for PIN-gated actions.

Security constraints honored:
- The biometric-gated disable is unchanged when biometrics are available (not weakened).
- The PIN path calls `verifyPin` (not merely `isPinEnabled`), so a wrong PIN is rejected and rate-limited.
- Enabling the kill switch stays as-is (confirmation dialog only); only disabling requires a verified factor.
- No keep-mobile/FFI change: `setKillSwitch(false)` already exists.

## Verification

- `./gradlew :app:compileDebugKotlin` (with `verifyKeepVersion`): BUILD SUCCESSFUL. This is Compose UI wiring reusing the tested `PinStore.verifyPin`; the dialog flow is exercised by CI's instrumented tests (a full PIN-prompt roundtrip needs an emulator with biometrics unavailable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PIN verification as a fallback for disabling the kill switch when biometric authentication is unavailable.
  * Kill-switch controls are now available when either biometrics or a PIN is enabled.
  * Added a reusable PIN prompt with input validation and incorrect-PIN feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->