### PR TITLE
storage: select pending cipher by operation role, not fragile FIFO order

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
+++ b/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
@@ -311,9 +311,9 @@ internal class AccountActions(
                 val requestId = UUID.randomUUID().toString()
                 var pendingSet = false
                 try {
-                    storage.setPendingCipher(requestId, authedDecrypt)
+                    storage.setPendingCipher(requestId, authedDecrypt, AndroidKeystoreStorage.CipherRole.DECRYPT)
                     pendingSet = true
-                    storage.setPendingCipher(requestId, authedEncrypt)
+                    storage.setPendingCipher(requestId, authedEncrypt, AndroidKeystoreStorage.CipherRole.ENCRYPT)
                     withContext(Dispatchers.IO) {
                         storage.setRequestIdContext(requestId)
                         try {
@@ -511,9 +511,9 @@ internal class AccountActions(
                 val requestId = UUID.randomUUID().toString()
                 var pendingSet = false
                 try {
-                    storage.setPendingCipher(requestId, authedDecrypt)
+                    storage.setPendingCipher(requestId, authedDecrypt, AndroidKeystoreStorage.CipherRole.DECRYPT)
                     pendingSet = true
-                    storage.setPendingCipher(requestId, authedEncrypt)
+                    storage.setPendingCipher(requestId, authedEncrypt, AndroidKeystoreStorage.CipherRole.ENCRYPT)
                     withContext(Dispatchers.IO) {
                         storage.setRequestIdContext(requestId)
                         try {

--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
@@ -54,8 +54,12 @@ class AndroidKeystoreStorage(
         private const val METADATA_KEY_PREFIX = "__keep_"
     }
 
+    /** The operation a pending [Cipher] is for, so it is consumed by the matching callback. */
+    enum class CipherRole { ENCRYPT, DECRYPT }
+
     private data class PendingCipherData(
         val cipher: Cipher,
+        val role: CipherRole?,
         val creatingThreadId: Long,
         val createdAtMs: Long,
         val onConsumed: (() -> Unit)?
@@ -205,10 +209,16 @@ class AndroidKeystoreStorage(
     }
 
     @Suppress("DEPRECATION")
-    fun setPendingCipher(requestId: String, cipher: Cipher, onConsumed: (() -> Unit)? = null) {
+    fun setPendingCipher(
+        requestId: String,
+        cipher: Cipher,
+        role: CipherRole? = null,
+        onConsumed: (() -> Unit)? = null,
+    ) {
         cleanupExpiredCiphers()
         val data = PendingCipherData(
             cipher = cipher,
+            role = role,
             creatingThreadId = Thread.currentThread().id,
             createdAtMs = SystemClock.elapsedRealtime(),
             onConsumed = onConsumed
@@ -250,9 +260,12 @@ class AndroidKeystoreStorage(
         }
     }
 
-    // Consumes pending ciphers in FIFO order. Callers MUST setPendingCipher in the
-    // same order the Rust FFI consumes them (e.g. markShareBackedUp: decrypt then encrypt).
-    fun consumePendingCipher(requestId: String): Cipher? {
+    // Consumes a pending cipher for [requestId]. When [requiredRole] is given and a queued
+    // cipher carries that role, that one is taken (so the decrypt vs encrypt cipher is
+    // selected by the operation, not by enqueue order). Untagged ciphers fall back to FIFO,
+    // so single-cipher flows are unaffected; this makes the two-cipher flows (decrypt +
+    // encrypt under one requestId, e.g. markShareBackedUp/renameShare) order-independent.
+    fun consumePendingCipher(requestId: String, requiredRole: CipherRole? = null): Cipher? {
         val queue = pendingCiphers[requestId] ?: return null
         var poppedCipher: Cipher? = null
         var callbackToFire: (() -> Unit)? = null
@@ -265,7 +278,8 @@ class AndroidKeystoreStorage(
                 pendingCiphers.remove(requestId, queue)
                 return null
             }
-            val popped = queue.removeFirst()
+            val roleIdx = if (requiredRole != null) queue.indexOfFirst { it.role == requiredRole } else -1
+            val popped = if (roleIdx >= 0) queue.removeAt(roleIdx) else queue.removeFirst()
             poppedCipher = popped.cipher
             callbackToFire = popped.onConsumed
             if (queue.isEmpty()) {
@@ -290,7 +304,7 @@ class AndroidKeystoreStorage(
         require(data.isNotEmpty()) { "Share data must not be empty" }
         val requestId = requestIdContext.get()
             ?: throw KeepMobileException.StorageException("No request context - call setRequestIdContext first")
-        val cipher = consumePendingCipher(requestId)
+        val cipher = consumePendingCipher(requestId, CipherRole.ENCRYPT)
             ?: throw KeepMobileException.StorageException("No authenticated cipher available for this request")
         storeShareWithCipher(cipher, data, metadata)
     }
@@ -323,7 +337,7 @@ class AndroidKeystoreStorage(
     override fun loadShare(): ByteArray {
         val requestId = requestIdContext.get()
             ?: throw KeepMobileException.StorageException("No request context - call setRequestIdContext first")
-        val cipher = consumePendingCipher(requestId)
+        val cipher = consumePendingCipher(requestId, CipherRole.DECRYPT)
             ?: throw KeepMobileException.StorageException("No authenticated cipher available for this request")
         val data = loadShareWithCipher(cipher)
         check(data.isNotEmpty()) { "Loaded share data must not be empty" }
@@ -510,7 +524,7 @@ class AndroidKeystoreStorage(
         }
         val requestId = requestIdContext.get()
             ?: throw KeepMobileException.StorageException("No request context - call setRequestIdContext first")
-        val cipher = consumePendingCipher(requestId)
+        val cipher = consumePendingCipher(requestId, CipherRole.ENCRYPT)
             ?: throw KeepMobileException.StorageException("No authenticated cipher available for this request")
         storeShareByKeyWithCipher(cipher, key, data, metadata)
     }
@@ -522,7 +536,7 @@ class AndroidKeystoreStorage(
         }
         val requestId = requestIdContext.get()
             ?: throw KeepMobileException.StorageException("No request context - call setRequestIdContext first")
-        val cipher = consumePendingCipher(requestId)
+        val cipher = consumePendingCipher(requestId, CipherRole.DECRYPT)
             ?: throw KeepMobileException.StorageException("No authenticated cipher available for this request")
         return loadShareByKeyWithCipher(cipher, key)
     }


### PR DESCRIPTION
Flows that perform a re-encrypt (mark-backed-up, rename) enqueue TWO biometric-unlocked ciphers under one requestId — a decrypt cipher then an encrypt cipher — and relied on the Rust FFI's `SecureStorage` callbacks consuming them in that exact FIFO order (`consumePendingCipher` did `removeFirst()`). The ordering contract was enforced only by a comment. No current defect (Rust consumes load-then-store, matching the enqueue order, and a misorder failed safely), but it was fragile: if the Rust call order ever changed, the wrong-mode cipher would be handed to a callback.

## Change

- Tag a pending cipher with its operation role (`CipherRole.ENCRYPT` / `DECRYPT`) and select by role: `loadShare`/`loadShareByKey` consume a `DECRYPT` cipher, `storeShare`/`storeShareByKey` consume an `ENCRYPT` cipher. The decrypt vs encrypt cipher is now chosen by the operation, independent of enqueue order.
- Untagged ciphers fall back to FIFO, so every single-cipher flow (import, signing, export, view-seed, activate-share) is byte-for-byte unchanged. Only the two two-cipher flows (`finishMarkBackedUp`, `finishRename`) tag their ciphers.
- `Cipher` has no public opmode accessor, so the role is an explicit tag set at enqueue (the two-cipher flows already know which cipher is which). No keep-mobile/FFI change.

Behavior is identical today (role-match yields the same cipher FIFO did for the ordered enqueues) but is no longer order-dependent. On a genuine role mismatch, `consumePendingCipher` returns `null` → the existing "No authenticated cipher available" error (fails safe, same as today).

## Verification

- `./gradlew :app:compileDebugKotlin` (with `verifyKeepVersion`): BUILD SUCCESSFUL. The consume logic runs behind the Android Keystore (constructor loads `AndroidKeyStore`), so it is exercised by CI's instrumented tests; the biometric mark-backed-up / rename flows need an emulator with real Keystore-gated ciphers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved encrypted share operations by consistently selecting the correct encryption or decryption operation.
  - Fixed potential issues when encryption and decryption operations are queued in a different order.
  - Enhanced reliability for account rename and backup-status updates involving protected data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->