### PR TITLE
security: require re-auth to clear/retire certificate pins; make pinning drift loud

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/CertificatePinning.kt
+++ b/app/src/main/kotlin/io/privkey/keep/CertificatePinning.kt
@@ -29,7 +29,10 @@ private fun Any.readBoolProperty(name: String): Boolean {
 fun KeepMobile.getCertificatePinsCompat(): List<CertificatePin> = runCatching {
     val method = javaClass.methods.firstOrNull { it.name == "getCertificatePins" }
     if (method == null) {
-        android.util.Log.w("CertificatePinning", "getCertificatePins method not found via reflection, pinning disabled")
+        // Enforcement lives in the Rust core (verify_relay_certificate), not here, so this
+        // only means the pin-management UI is degraded due to keep-mobile binding version
+        // drift. Log at ERROR so that drift is loud rather than a buried warning.
+        android.util.Log.e(CERT_PIN_TAG, "getCertificatePins not found via reflection (binding version drift); pin list unavailable in UI, Rust-side enforcement unaffected")
         return emptyList()
     }
     val result = method.invoke(this) as? List<*> ?: return emptyList()
@@ -51,7 +54,7 @@ fun KeepMobile.stageCertificatePinCompat(hostname: String, spkiHash: String): Bo
         it.name == "stageCertificatePin" && it.parameterCount == 2
     }
     if (method == null) {
-        android.util.Log.w(CERT_PIN_TAG, "stageCertificatePin method not found via reflection")
+        android.util.Log.e(CERT_PIN_TAG, "stageCertificatePin not found via reflection (binding version drift); cannot add pins, Rust-side enforcement unaffected")
         return false
     }
     method.invoke(this, hostname, spkiHash)
@@ -69,7 +72,7 @@ fun KeepMobile.removeCertificatePinCompat(hostname: String, spkiHash: String): C
         it.name == "removeCertificatePin" && it.parameterCount == 2
     }
     if (method == null) {
-        android.util.Log.w(CERT_PIN_TAG, "removeCertificatePin method not found via reflection")
+        android.util.Log.e(CERT_PIN_TAG, "removeCertificatePin not found via reflection (binding version drift); cannot remove pins, Rust-side enforcement unaffected")
         return null
     }
     val result = method.invoke(this, hostname, spkiHash) ?: return null

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -352,6 +352,12 @@ fun MainScreen(
     var foregroundServiceEnabled by remember { mutableStateOf(foregroundServiceStore.isEnabled()) }
     var showKillSwitchConfirmDialog by remember { mutableStateOf(false) }
     var showKillSwitchPinPrompt by remember { mutableStateOf(false) }
+    // Re-auth gate for security-downgrade actions (e.g. clearing/removing a certificate
+    // pin, which re-opens trust-on-first-use for that host).
+    var pendingAuthGateAction by remember { mutableStateOf<(suspend () -> Unit)?>(null) }
+    var authGateTitle by remember { mutableStateOf("") }
+    var authGateMessage by remember { mutableStateOf("") }
+    var authGateConfirm by remember { mutableStateOf("") }
     var showConnectedApps by remember { mutableStateOf(false) }
     var selectedAppPackage by remember { mutableStateOf<String?>(null) }
     var showPinSetup by remember { mutableStateOf(false) }
@@ -409,6 +415,25 @@ fun MainScreen(
             showKillSwitchPinPrompt = true
         }
     }
+
+    // Runs [action] only after a verified auth factor: biometric when available, else a
+    // PIN prompt, else (no factor configured) immediately, consistent with the rest of the
+    // app in that config. Used to gate security-downgrade actions like clearing a cert pin.
+    val requireAuthThen: (String, String, String, suspend () -> Unit) -> Unit =
+        { title, message, confirmLabel, action ->
+            when {
+                biometricAvailable -> coroutineScope.launch {
+                    if (onBiometricAuth?.invoke(title, message) == true) action()
+                }
+                pinEnabled -> {
+                    authGateTitle = title
+                    authGateMessage = message
+                    authGateConfirm = confirmLabel
+                    pendingAuthGateAction = action
+                }
+                else -> coroutineScope.launch { action() }
+            }
+        }
 
     val accountActions = remember {
         AccountActions(
@@ -553,6 +578,24 @@ fun MainScreen(
                 }
             },
             onDismiss = { showKillSwitchPinPrompt = false }
+        )
+    }
+
+    pendingAuthGateAction?.let { action ->
+        PinPromptDialog(
+            title = authGateTitle,
+            message = authGateMessage,
+            confirmLabel = authGateConfirm,
+            onVerify = { pin ->
+                val verified = withContext(Dispatchers.IO) { pinStore.verifyPin(pin) }
+                if (verified) {
+                    action()
+                    true
+                } else {
+                    false
+                }
+            },
+            onDismiss = { pendingAuthGateAction = null }
         )
     }
 
@@ -973,7 +1016,13 @@ fun MainScreen(
         PinMismatchDialog(
             hostname = pinMismatchInfo.hostname,
             onClearAndRetry = {
-                coroutineScope.launch {
+                // Clearing a pin re-opens trust-on-first-use for this host (here, right after
+                // a possible-MITM mismatch), so require a fresh auth factor first.
+                requireAuthThen(
+                    appContext.getString(R.string.settings_cert_pins_clear_dialog_title),
+                    appContext.getString(R.string.settings_cert_pins_clear_dialog_text, pinMismatchInfo.hostname),
+                    appContext.getString(R.string.settings_cert_pins_clear),
+                ) {
                     withContext(Dispatchers.IO) { onClearCertificatePin(pinMismatchInfo.hostname) }
                     refreshCertificatePins()
                     onReconnectRelays()
@@ -1166,7 +1215,14 @@ fun MainScreen(
                         }
                     },
                     onRetirePin = { hostname, spkiHash ->
-                        coroutineScope.launch {
+                        // Removing a pin can leave a host unpinned (re-opening TOFU), so gate
+                        // it behind auth too, otherwise the clear-all gate is bypassable by
+                        // retiring pins one at a time.
+                        requireAuthThen(
+                            appContext.getString(R.string.settings_cert_pins_clear_dialog_title),
+                            appContext.getString(R.string.settings_cert_pins_clear_dialog_text, hostname),
+                            appContext.getString(R.string.settings_cert_pins_clear),
+                        ) {
                             val removal = withContext(Dispatchers.IO) {
                                 onRemoveCertificatePin(hostname, spkiHash)
                             }
@@ -1181,7 +1237,11 @@ fun MainScreen(
                         }
                     },
                     onClearAllPins = {
-                        coroutineScope.launch {
+                        requireAuthThen(
+                            appContext.getString(R.string.settings_cert_pins_clear_all_dialog_title),
+                            appContext.getString(R.string.settings_cert_pins_clear_all_dialog_text),
+                            appContext.getString(R.string.settings_cert_pins_clear_all),
+                        ) {
                             withContext(Dispatchers.IO) { onClearAllCertificatePins() }
                             refreshCertificatePins()
                         }


### PR DESCRIPTION
## 959u — gate certificate-pin removal behind re-auth (the real fix)

Clearing or retiring a certificate pin re-opens trust-on-first-use for that host — a deliberate downgrade of MITM protection — but the actions fired with no authentication. The most dangerous is "Clear and Retry" in the pin-mismatch dialog, which appears *precisely when a possible MITM was just detected*: clearing then reconnecting pins whatever cert is now presented (potentially an attacker's).

- All three downgrade paths now require a verified auth factor before running: clear-and-retry (`PinMismatchDialog`), clear-all (settings), and retire-single-pin (gated too, so the clear-all gate can't be bypassed by retiring pins one at a time).
- Reuses the kill-switch pattern via a small `requireAuthThen(...)` helper: biometric when available, else the existing `PinPromptDialog` verifying via `PinStore.verifyPin`, else (no factor configured) proceed — consistent with the app's behavior in that config. The Rust `clear_certificate_pin*` FFI is unchanged.

## h09r — make reflection-drift loud (defense-in-depth)

Certificate-pin *enforcement* lives entirely in the Rust core (`verify_relay_certificate`, fail-closed in strict mode); the Kotlin reflection layer is pin management/display only, so a reflection miss is fail-*safe* (pins stay; the UI just can't list/add them), never fail-open. The methods are present in the current binding, so the reflection always succeeds today.

- Raise the three "method not found" logs from `Log.w` to `Log.e` so a keep-mobile binding version-drift is loud, and correct the misleading "pinning disabled" message (enforcement is unaffected).

## Verification

- `./gradlew :app:compileDebugKotlin` (with `verifyKeepVersion`): BUILD SUCCESSFUL. The auth-gate is Compose UI reusing the tested `PinStore.verifyPin`; exercised by CI's instrumented tests (a full biometric/PIN roundtrip needs an emulator).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fresh authentication checks before clearing, retiring, or resetting certificate pins.
  * Supports biometric authentication, PIN verification, or immediate continuation when no authentication method is configured.
  * Added a PIN prompt for deferred security-sensitive actions.

* **Bug Fixes**
  * Improved compatibility diagnostics when certificate-management features cannot be accessed.
  * Clarified that underlying certificate enforcement remains active despite UI compatibility issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->