### PR TITLE
security: require re-auth to weaken biometric app-lock settings

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -622,16 +622,39 @@ fun MainScreen(
             },
             biometricTimeout = biometricTimeout,
             onTimeoutChanged = { newTimeout ->
-                coroutineScope.launch {
+                val applyTimeout: suspend () -> Unit = {
                     val saved = withContext(Dispatchers.IO) { biometricTimeoutStore.setTimeout(newTimeout) }
                     if (saved) biometricTimeout = newTimeout
+                }
+                // A larger value is a longer window before re-auth, so it weakens the gate;
+                // require a fresh factor. Shortening it (or every-time) applies immediately.
+                if (newTimeout > biometricTimeout) {
+                    requireAuthThen(
+                        appContext.getString(R.string.settings_biometric_timeout_reauth_title),
+                        appContext.getString(R.string.settings_biometric_timeout_reauth_text),
+                        appContext.getString(R.string.settings_reauth_confirm),
+                        applyTimeout,
+                    )
+                } else {
+                    coroutineScope.launch { applyTimeout() }
                 }
             },
             biometricLockOnLaunch = biometricLockOnLaunch,
             onBiometricLockOnLaunchChanged = { enabled ->
-                coroutineScope.launch {
+                val applyLockOnLaunch: suspend () -> Unit = {
                     val saved = withContext(Dispatchers.IO) { biometricTimeoutStore.setLockOnLaunch(enabled) }
                     if (saved) biometricLockOnLaunch = enabled
+                }
+                // Disabling app-lock weakens the gate; require a fresh factor. Enabling applies immediately.
+                if (!enabled) {
+                    requireAuthThen(
+                        appContext.getString(R.string.settings_biometric_lock_disable_reauth_title),
+                        appContext.getString(R.string.settings_biometric_lock_disable_reauth_text),
+                        appContext.getString(R.string.settings_reauth_confirm),
+                        applyLockOnLaunch,
+                    )
+                } else {
+                    coroutineScope.launch { applyLockOnLaunch() }
                 }
             },
             biometricAvailable = biometricAvailable,

--- a/app/src/main/res/values/strings_settings.xml
+++ b/app/src/main/res/values/strings_settings.xml
@@ -115,4 +115,9 @@
     <string name="settings_biometric_on_launch_title">Biometric on Launch</string>
     <string name="settings_biometric_on_launch_subtitle">Require biometric authentication when opening app</string>
     <string name="settings_biometric_unavailable">Biometric hardware not available</string>
+    <string name="settings_reauth_confirm">Confirm</string>
+    <string name="settings_biometric_lock_disable_reauth_title">Turn off app lock?</string>
+    <string name="settings_biometric_lock_disable_reauth_text">Disabling biometric-on-launch means the app no longer requires authentication when reopened. Confirm it\'s you.</string>
+    <string name="settings_biometric_timeout_reauth_title">Lengthen re-auth window?</string>
+    <string name="settings_biometric_timeout_reauth_text">A longer timeout lets the app skip re-authentication for more time. Confirm it\'s you.</string>
 </resources>


### PR DESCRIPTION
## Summary

After the initial biometric/PIN gate, the Security settings screen let anyone with the app foregrounded silently weaken the app's own re-auth posture: disabling biometric-on-launch or lengthening the biometric timeout had no auth challenge (disabling the PIN and the kill switch already required a factor). An attacker with brief physical access to an unlocked app could disable the app lock for future persistence.

This gates the two weakening changes behind a fresh auth factor, at commit time:

- **Disable biometric-on-launch** now requires re-auth (enabling it does not).
- **Lengthening the biometric timeout** (a longer window before re-auth) now requires re-auth (shortening it, or "every time", applies immediately).

Both reuse the existing `requireAuthThen` gate (biometric when available, else PIN prompt, else immediate when no factor is configured), the same mechanism used for certificate-pin downgrades. If the user cancels the prompt, the setting is unchanged and the control reverts to its prior state.

## Testing

- `./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL
