### PR TITLE
security: audit account switch and deletion to the tamper-evident chain

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
+++ b/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
@@ -27,6 +27,7 @@ internal class AccountActions(
     private val appContext: Context,
     private val onBiometricRequest: (String, String, Cipher, (Cipher?) -> Unit) -> Unit,
     private val onAccountSwitched: suspend () -> Unit,
+    private val onAccountDeleted: suspend () -> Unit,
     private val onStateChanged: (AccountState) -> Unit
 ) {
     data class AccountState(
@@ -165,6 +166,10 @@ internal class AccountActions(
                         keepMobile.deleteShareByKey(account.groupPubkeyHex)
                         runCatching { keepMobile.deleteRelayConfig(account.groupPubkeyHex) }
                             .onFailure { if (BuildConfig.DEBUG) Log.e("AccountActions", "Relay config cleanup failed: ${it::class.simpleName}") }
+                        // Audit the deletion in the current chain. Deleting the active
+                        // account then switches to another (whose fresh chain records the
+                        // switch), so this entry persists for non-active deletes.
+                        onAccountDeleted()
                     }
                 } catch (e: Exception) {
                     logAndToast("Delete failed", appContext.getString(R.string.account_delete_failed), e)

--- a/app/src/main/kotlin/io/privkey/keep/KeepMobileApp.kt
+++ b/app/src/main/kotlin/io/privkey/keep/KeepMobileApp.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.setValue
 import io.privkey.keep.descriptor.DescriptorSessionManager
 import io.privkey.keep.nip46.BunkerConfigStore
 import io.privkey.keep.nip46.BunkerService
+import io.privkey.keep.nip55.AUDIT_OP_ACCOUNT_SWITCH
 import io.privkey.keep.nip55.AndroidSigningRateLimiterStorage
 import io.privkey.keep.nip55.AutoSigningSafeguards
 import io.privkey.keep.nip55.CallerVerificationStore
@@ -470,6 +471,12 @@ class KeepMobileApp : Application() {
             runAccountSwitchCleanup("clear auto-sign rate limits") { signingRateLimiter?.clearAll() }
             runAccountSwitchCleanup("clear signing audit log") { permissionStore?.clearAuditLog() }
             runAccountSwitchCleanup("clear activity log") { eventLogStore?.clear() }
+            // Genesis entry for the new account's fresh audit chain: the per-account wipe
+            // above clears the prior trail, so record the activation itself here to keep
+            // every account switch auditable (a switch is otherwise evidence-free).
+            runAccountSwitchCleanup("record account-switch audit") {
+                permissionStore?.logSelfEvent(AUDIT_OP_ACCOUNT_SWITCH)
+            }
         }
     }
 

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -41,6 +41,7 @@ import io.privkey.keep.descriptor.WalletDescriptorScreen
 import io.privkey.keep.navigation.Route
 import io.privkey.keep.nip46.BunkerScreen
 import io.privkey.keep.nip46.BunkerService
+import io.privkey.keep.nip55.AUDIT_OP_ACCOUNT_DELETE
 import io.privkey.keep.nip55.AppPermissionsScreen
 import io.privkey.keep.nip55.ConnectedAppsScreen
 import io.privkey.keep.nip55.EventLogScreen
@@ -443,6 +444,7 @@ fun MainScreen(
             appContext = appContext,
             onBiometricRequest = onBiometricRequest,
             onAccountSwitched = onAccountSwitched,
+            onAccountDeleted = { runCatching { permissionStore.logSelfEvent(AUDIT_OP_ACCOUNT_DELETE) } },
             onStateChanged = { state ->
                 hasShare = state.hasShare
                 shareInfo = state.shareInfo

--- a/app/src/main/kotlin/io/privkey/keep/nip55/PermissionEntities.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/PermissionEntities.kt
@@ -32,6 +32,8 @@ const val SELF_CALLER = "self"
 // Activity-log requestType values for self-initiated key-management operations.
 const val AUDIT_OP_EXPORT_NCRYPTSEC = "EXPORT_NCRYPTSEC"
 const val AUDIT_OP_EXPORT_SHARE = "EXPORT_SHARE"
+const val AUDIT_OP_ACCOUNT_SWITCH = "ACCOUNT_SWITCH"
+const val AUDIT_OP_ACCOUNT_DELETE = "ACCOUNT_DELETE"
 
 // Relay scope sentinels for kind-22242 (NIP-42) grants. RELAY_NONE is used for all
 // other grants, where the relay dimension is not meaningful.

--- a/app/src/main/kotlin/io/privkey/keep/nip55/PermissionStore.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/PermissionStore.kt
@@ -198,7 +198,17 @@ class PermissionStore(private val database: Nip55Database) {
      * a real package name) and a fixed "allow" decision. Exporting a private key is
      * a high-sensitivity action that must always be audited.
      */
-    suspend fun logKeyExport(operation: String) {
+    suspend fun logKeyExport(operation: String) = logSelfEvent(operation)
+
+    /**
+     * Record a self-initiated, security-sensitive event (not an external NIP-55
+     * request) in the tamper-evident activity log, using the reserved [SELF_CALLER]
+     * sentinel and a fixed "allow" decision. [operation] names the event (see the
+     * AUDIT_OP_* constants). Used for key exports and for account-lifecycle events
+     * (switch, delete) so that operations leaving no NIP-55 request still leave an
+     * audit trail.
+     */
+    suspend fun logSelfEvent(operation: String) {
         val timestamp = System.currentTimeMillis()
         auditWriter.append({ previousHash ->
             Nip55AuditLog(


### PR DESCRIPTION
## Summary

Account switches and deletions are security-sensitive but left no audit trail: an attacker with temporary device access could switch accounts (and sign) or delete an account with no record. This adds both to the existing tamper-evident audit chain (`nip55_audit_log`).

- **Account switch** is recorded as the genesis entry of the new account's fresh chain. `onAccountSwitched()` deliberately wipes all cross-account state (permissions, settings, velocity, caller trust, audit log) for per-account isolation, so the switch is logged immediately *after* that wipe, ensuring every activation is auditable even though the prior chain is cleared.
- **Account deletion** is recorded at the deletion point via a new `onAccountDeleted` callback. It persists in the current chain for non-active-account deletes; deleting the active account then switches to another, whose fresh chain records that switch.

Both reuse the proven self-event append idiom: `logKeyExport` is generalized to `logSelfEvent(operation)` (identical body, `logKeyExport` now delegates), and the writes go through the same `AuditLogWriter.append` that computes the hash-linked chain. New `AUDIT_OP_ACCOUNT_SWITCH` / `AUDIT_OP_ACCOUNT_DELETE` operation constants sit alongside the existing export ops. Appends are best-effort (failure never blocks the switch/delete).

Revocation (`revokeAllPermissions`) is intentionally not separately audited: its only caller is `onAccountSwitched`, which wipes the chain immediately after, so the switch-genesis entry supersedes it.

## Testing

- `./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL
- Tamper-evident chain integrity is covered by the existing instrumented audit tests (Rust HMAC + Keystore anchor), exercised in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tamper-evident audit records for account switching and account deletion.
  * Key export and other self-initiated security events now use a consistent audit-recording process.
* **Security**
  * Account lifecycle actions are now explicitly recorded, improving visibility and traceability of sensitive changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->