### PR TITLE
security: force a live biometric prompt on security-downgrade gates

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -244,9 +244,16 @@ class MainActivity : FragmentActivity() {
                                 }
                             },
                             onBiometricAuth = { title, subtitle ->
+                                // This gate backs security-downgrade actions (kill-switch
+                                // disable, cert-pin clear/retire, weakening app-lock
+                                // settings). Force a live prompt so an attacker holding a
+                                // recently-authenticated, foregrounded phone cannot ride an
+                                // open biometric-timeout window to weaken security silently
+                                // (matches the app-unlock gate above).
                                 biometricHelper?.authenticate(
                                     title = title,
-                                    subtitle = subtitle
+                                    subtitle = subtitle,
+                                    forcePrompt = true
                                 ) ?: false
                             },
                             onAutoStartChanged = { enabled ->

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -243,17 +243,11 @@ class MainActivity : FragmentActivity() {
                                     }
                                 }
                             },
-                            onBiometricAuth = { title, subtitle ->
-                                // This gate backs security-downgrade actions (kill-switch
-                                // disable, cert-pin clear/retire, weakening app-lock
-                                // settings). Force a live prompt so an attacker holding a
-                                // recently-authenticated, foregrounded phone cannot ride an
-                                // open biometric-timeout window to weaken security silently
-                                // (matches the app-unlock gate above).
+                            onBiometricAuth = { title, subtitle, forcePrompt ->
                                 biometricHelper?.authenticate(
                                     title = title,
                                     subtitle = subtitle,
-                                    forcePrompt = true
+                                    forcePrompt = forcePrompt
                                 ) ?: false
                             },
                             onAutoStartChanged = { enabled ->
@@ -310,7 +304,7 @@ fun MainScreen(
     onConnect: (Cipher, (Boolean, String?) -> Unit) -> Unit,
     onBiometricRequest: (String, String, Cipher, (Cipher?) -> Unit) -> Unit,
     biometricStatus: BiometricHelper.BiometricStatus = BiometricHelper.BiometricStatus.NOT_AVAILABLE,
-    onBiometricAuth: (suspend (title: String, subtitle: String) -> Boolean)? = null,
+    onBiometricAuth: (suspend (title: String, subtitle: String, forcePrompt: Boolean) -> Boolean)? = null,
     onAutoStartChanged: (Boolean) -> Unit = {},
     onForegroundServiceChanged: (Boolean) -> Unit = {},
     onBunkerServiceChanged: (Boolean) -> Unit = {},
@@ -405,9 +399,12 @@ fun MainScreen(
             showKillSwitchConfirmDialog = true
         } else if (biometricAvailable) {
             coroutineScope.launch {
+                // Downgrade action: force a live prompt so an open biometric-timeout
+                // window can't be ridden to disable the kill switch silently.
                 val authenticated = onBiometricAuth?.invoke(
                     appContext.getString(R.string.main_disable_kill_switch_title),
                     appContext.getString(R.string.main_disable_kill_switch_subtitle),
+                    true,
                 ) ?: false
                 if (authenticated) {
                     val updated = withContext(Dispatchers.IO) {
@@ -431,7 +428,9 @@ fun MainScreen(
         { title, message, confirmLabel, action ->
             when {
                 biometricAvailable -> coroutineScope.launch {
-                    if (onBiometricAuth?.invoke(title, message) == true) action()
+                    // Downgrade gate (cert-pin clear/retire, app-lock weakening): force a
+                    // live prompt rather than accepting an open biometric-timeout window.
+                    if (onBiometricAuth?.invoke(title, message, true) == true) action()
                 }
                 pinEnabled -> {
                     authGateTitle = title
@@ -1111,9 +1110,13 @@ fun MainScreen(
                     onApproveRequest = { id ->
                         coroutineScope.launch {
                             val authed = if (biometricAvailable && onBiometricAuth != null) {
+                                // Signing approval, not a downgrade: respect the biometric-
+                                // timeout window (forcePrompt=false) so batch approvals work
+                                // as configured.
                                 onBiometricAuth.invoke(
                                     appContext.getString(R.string.cosign_request_label),
                                     appContext.getString(R.string.cosign_approve),
+                                    false,
                                 )
                             } else {
                                 true


### PR DESCRIPTION
## Summary

The biometric gate backing security-downgrade actions (kill-switch disable, certificate-pin clear/retire, and weakening biometric app-lock settings) called `authenticate(...)` with the default `forcePrompt = false`. Per `BiometricHelper.authenticateWithResult`, when the biometric-timeout window is still open (`requiresBiometric() == false`) that returns `SUCCESS` immediately with no live prompt. So within an active session an attacker holding a recently-authenticated, foregrounded phone could ride the open window to weaken security settings without a live challenge.

This adds an explicit `forcePrompt` parameter to the shared `(title, subtitle)` `onBiometricAuth` lambda and passes:
- `true` from the two **downgrade gates** (`handleKillSwitchToggle` and `requireAuthThen`, covering cert-pin clears and app-lock weakening) — they now always require a live biometric prompt, matching the app-unlock gate.
- `false` from the **co-sign approval** path (`onApproveRequest`) — deliberately unchanged, so the biometric-timeout window keeps working as configured for batch signing approvals. Per-approval prompting is a separate product decision, out of scope here.

The signing/export cipher-based biometric paths are a separate `onBiometricAuth` overload and are unaffected. Strengthening actions and normal signing are unchanged.

Surfaced by the security reviews of PR #437 and PR #438 (the "auth-or-valid-session" ceiling on the downgrade path). The scope-narrowing to preserve the approval window addresses a finding from PR #440's own review.

## Testing

- `./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL
