### PR TITLE
chore: rethrow CancellationException in cleanup wrappers; drop dead ConnectionState

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/KeepMobileApp.kt
+++ b/app/src/main/kotlin/io/privkey/keep/KeepMobileApp.kt
@@ -481,8 +481,13 @@ class KeepMobileApp : Application() {
     }
 
     private suspend fun runAccountSwitchCleanup(label: String, action: suspend () -> Unit) {
-        runCatching { action() }
-            .onFailure { if (BuildConfig.DEBUG) Log.e(TAG, "Failed to $label on account switch", it) }
+        try {
+            action()
+        } catch (c: CancellationException) {
+            throw c
+        } catch (t: Throwable) {
+            if (BuildConfig.DEBUG) Log.e(TAG, "Failed to $label on account switch", t)
+        }
     }
 
     fun reconnectRelays() {
@@ -574,13 +579,6 @@ class KeepMobileApp : Application() {
             .take(10)
             .any { it is CancellationException }
 }
-
-data class ConnectionState(
-    val isConnected: Boolean = false,
-    val isConnecting: Boolean = false,
-    val error: String? = null,
-    val pinMismatch: PinMismatchInfo? = null
-)
 
 data class PinMismatchInfo(
     val hostname: String,

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -450,7 +450,15 @@ fun MainScreen(
             appContext = appContext,
             onBiometricRequest = onBiometricRequest,
             onAccountSwitched = onAccountSwitched,
-            onAccountDeleted = { runCatching { permissionStore.logSelfEvent(AUDIT_OP_ACCOUNT_DELETE) } },
+            onAccountDeleted = {
+                try {
+                    permissionStore.logSelfEvent(AUDIT_OP_ACCOUNT_DELETE)
+                } catch (c: CancellationException) {
+                    throw c
+                } catch (_: Throwable) {
+                    // best-effort audit; a failed append must not block deletion
+                }
+            },
             onStateChanged = { state ->
                 hasShare = state.hasShare
                 shareInfo = state.shareInfo


### PR DESCRIPTION
## Summary

Two small cleanups surfaced by the PR #439 security review and the gj1x verification:

- `runAccountSwitchCleanup` (KeepMobileApp) and the `onAccountDeleted` audit callback (MainActivity) used `runCatching`, which swallows `kotlinx.coroutines.CancellationException` (the standard coroutine footgun). Both now `catch (c: CancellationException) { throw c }` before swallowing other failures, so cooperative cancellation propagates while the appends stay best-effort. Applies to the account-switch cleanup path (all steps) and the delete-audit callback.
- Removed the dead `ConnectionState` data class (zero usages anywhere; connection state is core-driven via `ConnectionStatus`/`liveState`).

No behavioral change beyond correct cancellation propagation.

## Testing

- `./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account switching and deletion reliability by preserving cancellation behavior during background operations.
  * Account deletion now proceeds even if recording the related audit event fails.
  * Added clearer failure logging for account cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->