### PR TITLE
security: fail fast on a wrong-length decoded HMAC key

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
@@ -138,6 +138,11 @@ object KeystoreEncryptedPrefs {
                 if (stored != null) {
                     val decrypted = decrypt(secretKey, stored)
                     val key = Base64.decode(decrypted, Base64.NO_WRAP)
+                    // Our own 32-byte key, stored base64 then GCM-encrypted; GCM authentication
+                    // rules out external tampering, so a wrong length here is an internal bug.
+                    // Fail fast: Mac/SecretKeySpec accept any key length and would otherwise
+                    // silently diverge the audit-chain HMACs and key-name hashes.
+                    check(key.size == HMAC_KEY_LENGTH) { "Decoded HMAC key has wrong length: ${key.size}" }
                     hmacKey = key
                     return key
                 }


### PR DESCRIPTION
## Summary

Adds a single fail-fast invariant check in `KeystoreEncryptedPrefs.getHmacKey()`: the decoded HMAC key must be `HMAC_KEY_LENGTH` (32) bytes.

The HMAC key keys both the audit-chain HMACs and the encrypted-prefs key-name hashes. It is our own 32-byte value, stored base64 then AES-GCM-encrypted with the Keystore key; GCM authentication rules out external tampering, so a wrong length on read is an internal bug, not attacker input. Today that bug would be **silent**: `Mac`/`SecretKeySpec` accept any non-empty key length, so a mis-sized key would quietly diverge the audit-chain HMACs and key-name lookups rather than failing. The `check(...)` makes it fail fast. It cannot fire on any legitimate input (the deterministic fallback is SHA-256 = 32 bytes; the generated key is `ByteArray(HMAC_KEY_LENGTH)`).

Context (bead yivr, P10 Rule 5): a review of the security-critical storage/crypto/audit paths found Rule 5 is otherwise already satisfied idiomatically - dense `require`/`check` at the storage entry points, non-null types, and correct graceful-reject (`try/catch`, `?: return`) for untrusted/corruptible input, which must NOT be converted to asserts. This is the one genuinely-missing internal invariant where a violation currently proceeds silently; the rest were verified as either already-checked, tautological, or correctly kept graceful.

## Testing

- `./gradlew :app:compileDebugKotlin` - BUILD SUCCESSFUL
- HMAC-key / audit-chain path is exercised by the instrumented tests in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure stored encryption keys have the required length.
  * Invalid or corrupted keys now fail fast instead of being used, improving security and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->