### PR TITLE
docs: record why audit anchor seeds PartiallyVerified (deliberate ceiling)

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/nip55/AuditAnchor.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/AuditAnchor.kt
@@ -55,6 +55,18 @@ internal fun resolveChainVerification(
  * Trust-on-first-use seed decision: only seed the anchor when there is none yet
  * (fresh/upgraded install) AND the Rust walk reports an intact chain, so a
  * corrupt chain is never baselined as the source of truth.
+ *
+ * [ChainVerificationResult.PartiallyVerified] (leading legacy/empty-hash rows) is
+ * intentionally seeded, NOT declined. Seeding pins the total count so any LATER
+ * prepend or truncation is caught by [resolveChainVerification]; declining would
+ * leave the anchor null and forfeit that forward protection. The only residual —
+ * legacy rows prepended BEFORE this first seed — is already excused-as-legacy by
+ * the Rust walk whether or not we seed, and is bounded to 1024 rows by the Rust
+ * leading-legacy cap (keep PR #842). PartiallyVerified is also effectively
+ * unreachable in the field: legacy rows are pruned at 30 days on every launch.
+ * If a strict chained-count guarantee is ever required, wire the Rust tip MAC
+ * (`nip55VerifyAuditChainWithTip`, already chained-count based) rather than
+ * reworking this total-count anchor. See keep-android-6mjx.
  */
 internal fun shouldSeed(anchor: AuditAnchor?, rustResult: ChainVerificationResult): Boolean =
     anchor == null &&


### PR DESCRIPTION
## Summary

Documents a deliberate security-design decision in `AuditAnchor.shouldSeed` so it is not naively "fixed" into a weaker posture.

Bead 6mjx proposed declining to trust-on-first-use seed the anchor for a `PartiallyVerified` chain (leading legacy/empty-hash rows), to avoid baselining an attacker who prepended rows before the first verify. A full analysis found that change would be **net-negative**:

- Seeding `PartiallyVerified` **pins the total count**, so any *later* prepend/truncation is caught by `resolveChainVerification`. Declining leaves the anchor null and forfeits that forward protection.
- The pre-seed forge it worries about is **already excused-as-legacy by the Rust walk whether or not we seed** (declining does not flag it either), and is **bounded to 1024 rows by the Rust leading-legacy cap (keep #842)**.
- `PartiallyVerified` is **effectively unreachable in the field**: legacy rows are pruned at 30 days on every app launch and are 5+ months old, so fresh and existing installs both return `Valid`.

So seeding `PartiallyVerified` is the *safer* of the two behaviors. This change adds a comment recording that rationale and pointing at the correct upgrade path (wire the already-chained-count Rust tip MAC `nip55VerifyAuditChainWithTip`) if a strict chained-count guarantee is ever required — rather than reworking the total-count anchor or declining to seed.

Doc-only; no logic change. Bead 6mjx is dispositioned mitigated-in-practice.

## Testing

- `AuditAnchorTest` (pure JVM unit tests over `shouldSeed`/`resolveChainVerification`) still green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified chain verification and anchor-seeding behavior.
  * Documented why partially verified chains are accepted to preserve forward protection against later changes.
  * Added context on legacy behavior and a potential stricter verification approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->