### PR TITLE
ci: authenticate and retry the reproducibility release-version lookup

### DIFF
--- a/.github/workflows/reproducibility.yml
+++ b/.github/workflows/reproducibility.yml
@@ -64,9 +64,11 @@ jobs:
                  && [ -n "$VERSION" ] && [ "$VERSION" != "null" ]; then
                 break
               fi
-              echo "releases/latest lookup failed (attempt $attempt/5); retrying in 15s..." >&2
               VERSION=""
-              sleep 15
+              if [ "$attempt" -lt 5 ]; then
+                echo "releases/latest lookup failed (attempt $attempt/5); retrying in 15s..." >&2
+                sleep 15
+              fi
             done
           fi
           if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then

--- a/.github/workflows/reproducibility.yml
+++ b/.github/workflows/reproducibility.yml
@@ -48,11 +48,26 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           REF_NAME: ${{ github.ref_name }}
           REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ "$EVENT_NAME" = "push" ]; then
             VERSION="$REF_NAME"
           else
-            VERSION="$(curl -fsSL "https://api.github.com/repos/${REPOSITORY}/releases/latest" | jq -r .tag_name)"
+            # Authenticated + retried lookup. An unauthenticated api.github.com
+            # request shares the runner's egress IP and can hit the 60/hr limit,
+            # which -eo pipefail turns into an immediate step failure (the weekly
+            # cron went red this way). The workflow token raises the limit to
+            # 1000/hr, and the retry rides out any transient API blip.
+            VERSION=""
+            for attempt in 1 2 3 4 5; do
+              if VERSION="$(gh api "repos/${REPOSITORY}/releases/latest" --jq .tag_name)" \
+                 && [ -n "$VERSION" ] && [ "$VERSION" != "null" ]; then
+                break
+              fi
+              echo "releases/latest lookup failed (attempt $attempt/5); retrying in 15s..." >&2
+              VERSION=""
+              sleep 15
+            done
           fi
           if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
             echo "::error::could not determine release version to verify" >&2


### PR DESCRIPTION
## Problem
The weekly `Reproducibility` cron on `main` went red at the **Resolve release version to verify** step. The step failed in ~1 second on a `schedule` event, while `releases/latest` resolves fine (currently `v1.1.8`).

Root cause: on non-`push` events the step resolved the version with an **unauthenticated** `curl https://api.github.com/.../releases/latest`. GitHub Actions runners share egress IPs, so unauthenticated API calls (60/hr per IP) can hit a rate-limit 403. Under the step's default `bash -eo pipefail`, the failed `curl` aborts the step before the existing null-check, so a transient rate-limit turns the scheduled run red.

## Fix
Resolve the version with an **authenticated, retried** `gh api` call using the workflow token:
- The `GITHUB_TOKEN` raises the API rate limit to 1000/hr, removing the shared-IP rate-limit failure mode.
- Up to 5 attempts (15s apart) ride out any transient API blip.
- The existing `::error::could not determine release version to verify` / `exit 1` is preserved as the definitive failure after retries, so a genuine "no release" state still fails loudly.

The job already holds `contents: read`, which is sufficient for the authenticated release lookup; no new permissions are added. The `push`-tag path (which uses the tag ref directly) is unchanged.

## Verification
- Ran the exact resolve logic locally against the live API on the `schedule` path: authenticated `gh api ... --jq .tag_name` returns `v1.1.8`, the loop breaks on first success, and `version=v1.1.8` is written to the step output.
- `bash -n` and YAML parse both clean.
- After merge the fix is exercisable via `workflow_dispatch` on the workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release verification reliability by using authenticated release lookups with automatic retries.
  * Reduced failures caused by API rate limits or temporary request issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->