### PR TITLE
test: cover NIP-55 approval-flow biometric failure and cancellation branches

### DIFF
--- a/app/src/androidTest/kotlin/io/privkey/keep/BiometricHelperInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/BiometricHelperInstrumentedTest.kt
@@ -46,10 +46,7 @@ class BiometricHelperInstrumentedTest {
 
     @Test
     fun authenticateWithResult_genericError_mapsToFailed() = withActivity { activity ->
-        val helper = BiometricHelper(
-            activity,
-            authenticator = erroringAuthenticator(BiometricPrompt.ERROR_TIMEOUT)
-        )
+        val helper = BiometricHelper.withAuthenticator(activity, null, erroringAuthenticator(BiometricPrompt.ERROR_TIMEOUT))
         val result = runBlocking { helper.authenticateWithResult(forcePrompt = true) }
         assertEquals(
             "A non-lockout authentication error must map to FAILED (auth not granted)",
@@ -60,50 +57,35 @@ class BiometricHelperInstrumentedTest {
 
     @Test
     fun authenticateWithResult_lockout_mapsToLockout() = withActivity { activity ->
-        val helper = BiometricHelper(
-            activity,
-            authenticator = erroringAuthenticator(BiometricPrompt.ERROR_LOCKOUT)
-        )
+        val helper = BiometricHelper.withAuthenticator(activity, null, erroringAuthenticator(BiometricPrompt.ERROR_LOCKOUT))
         val result = runBlocking { helper.authenticateWithResult(forcePrompt = true) }
         assertEquals(BiometricHelper.AuthResult.LOCKOUT, result)
     }
 
     @Test
     fun authenticateWithResult_permanentLockout_mapsToLockoutPermanent() = withActivity { activity ->
-        val helper = BiometricHelper(
-            activity,
-            authenticator = erroringAuthenticator(BiometricPrompt.ERROR_LOCKOUT_PERMANENT)
-        )
+        val helper = BiometricHelper.withAuthenticator(activity, null, erroringAuthenticator(BiometricPrompt.ERROR_LOCKOUT_PERMANENT))
         val result = runBlocking { helper.authenticateWithResult(forcePrompt = true) }
         assertEquals(BiometricHelper.AuthResult.LOCKOUT_PERMANENT, result)
     }
 
     @Test
     fun authenticateWithCrypto_userCancellation_returnsNullWithoutKeyUse() = withActivity { activity ->
-        val helper = BiometricHelper(
-            activity,
-            authenticator = erroringAuthenticator(BiometricPrompt.ERROR_USER_CANCELED)
-        )
+        val helper = BiometricHelper.withAuthenticator(activity, null, erroringAuthenticator(BiometricPrompt.ERROR_USER_CANCELED))
         val cipher = runBlocking { helper.authenticateWithCrypto(uninitializedCipher()) }
         assertNull("User cancellation must yield no cipher (key use gated)", cipher)
     }
 
     @Test
     fun authenticateWithCrypto_negativeButton_returnsNullWithoutKeyUse() = withActivity { activity ->
-        val helper = BiometricHelper(
-            activity,
-            authenticator = erroringAuthenticator(BiometricPrompt.ERROR_NEGATIVE_BUTTON)
-        )
+        val helper = BiometricHelper.withAuthenticator(activity, null, erroringAuthenticator(BiometricPrompt.ERROR_NEGATIVE_BUTTON))
         val cipher = runBlocking { helper.authenticateWithCrypto(uninitializedCipher()) }
         assertNull("Negative-button cancellation must yield no cipher (key use gated)", cipher)
     }
 
     @Test
     fun authenticateWithCrypto_nonCancellationError_throwsWithoutKeyUse() = withActivity { activity ->
-        val helper = BiometricHelper(
-            activity,
-            authenticator = erroringAuthenticator(BiometricPrompt.ERROR_LOCKOUT)
-        )
+        val helper = BiometricHelper.withAuthenticator(activity, null, erroringAuthenticator(BiometricPrompt.ERROR_LOCKOUT))
         assertThrows(BiometricHelper.BiometricException::class.java) {
             runBlocking { helper.authenticateWithCrypto(uninitializedCipher()) }
         }

--- a/app/src/androidTest/kotlin/io/privkey/keep/BiometricHelperInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/BiometricHelperInstrumentedTest.kt
@@ -1,0 +1,111 @@
+package io.privkey.keep
+
+import androidx.biometric.BiometricPrompt
+import androidx.fragment.app.FragmentActivity
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import javax.crypto.Cipher
+
+/**
+ * Covers the NIP-55 approval-flow unhappy branches named in gh #396 (split of #376): biometric
+ * authentication FAILURE and user CANCELLATION. These live inside the anonymous
+ * [BiometricPrompt.AuthenticationCallback] objects in [BiometricHelper]; on BIOMETRIC_STRONG
+ * hardware with no PIN fallback and no emulator injection, the real prompt fires them only from
+ * hardware. [BiometricHelper.BiometricAuthenticator] is the seam that lets these tests drive the
+ * callbacks deterministically without stubbing the outcome into a hollow pass. Each test asserts
+ * the result the callback maps to, and for the crypto path that no [Cipher] escapes on a
+ * non-success outcome (key use is gated).
+ */
+@RunWith(AndroidJUnit4::class)
+class BiometricHelperInstrumentedTest {
+
+    // Drives a single error outcome through the seam. The default executor is unused: the fake
+    // resumes the callback synchronously, so the suspend call completes on the test thread.
+    private fun erroringAuthenticator(errorCode: Int, message: String = "test-injected-error") =
+        BiometricHelper.BiometricAuthenticator { _, _, callback ->
+            callback.onAuthenticationError(errorCode, message)
+        }
+
+    // A syntactically valid Cipher for the crypto path's CryptoObject wrapper. It is never used:
+    // the injected error resolves before onAuthenticationSucceeded, so the key is never touched.
+    private fun uninitializedCipher(): Cipher = Cipher.getInstance("AES/GCM/NoPadding")
+
+    private inline fun withActivity(block: (FragmentActivity) -> Unit) {
+        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+            var activity: FragmentActivity? = null
+            scenario.onActivity { activity = it }
+            block(activity ?: error("MainActivity was not available to the scenario"))
+        }
+    }
+
+    @Test
+    fun authenticateWithResult_genericError_mapsToFailed() = withActivity { activity ->
+        val helper = BiometricHelper(
+            activity,
+            authenticator = erroringAuthenticator(BiometricPrompt.ERROR_TIMEOUT)
+        )
+        val result = runBlocking { helper.authenticateWithResult(forcePrompt = true) }
+        assertEquals(
+            "A non-lockout authentication error must map to FAILED (auth not granted)",
+            BiometricHelper.AuthResult.FAILED,
+            result
+        )
+    }
+
+    @Test
+    fun authenticateWithResult_lockout_mapsToLockout() = withActivity { activity ->
+        val helper = BiometricHelper(
+            activity,
+            authenticator = erroringAuthenticator(BiometricPrompt.ERROR_LOCKOUT)
+        )
+        val result = runBlocking { helper.authenticateWithResult(forcePrompt = true) }
+        assertEquals(BiometricHelper.AuthResult.LOCKOUT, result)
+    }
+
+    @Test
+    fun authenticateWithResult_permanentLockout_mapsToLockoutPermanent() = withActivity { activity ->
+        val helper = BiometricHelper(
+            activity,
+            authenticator = erroringAuthenticator(BiometricPrompt.ERROR_LOCKOUT_PERMANENT)
+        )
+        val result = runBlocking { helper.authenticateWithResult(forcePrompt = true) }
+        assertEquals(BiometricHelper.AuthResult.LOCKOUT_PERMANENT, result)
+    }
+
+    @Test
+    fun authenticateWithCrypto_userCancellation_returnsNullWithoutKeyUse() = withActivity { activity ->
+        val helper = BiometricHelper(
+            activity,
+            authenticator = erroringAuthenticator(BiometricPrompt.ERROR_USER_CANCELED)
+        )
+        val cipher = runBlocking { helper.authenticateWithCrypto(uninitializedCipher()) }
+        assertNull("User cancellation must yield no cipher (key use gated)", cipher)
+    }
+
+    @Test
+    fun authenticateWithCrypto_negativeButton_returnsNullWithoutKeyUse() = withActivity { activity ->
+        val helper = BiometricHelper(
+            activity,
+            authenticator = erroringAuthenticator(BiometricPrompt.ERROR_NEGATIVE_BUTTON)
+        )
+        val cipher = runBlocking { helper.authenticateWithCrypto(uninitializedCipher()) }
+        assertNull("Negative-button cancellation must yield no cipher (key use gated)", cipher)
+    }
+
+    @Test
+    fun authenticateWithCrypto_nonCancellationError_throwsWithoutKeyUse() = withActivity { activity ->
+        val helper = BiometricHelper(
+            activity,
+            authenticator = erroringAuthenticator(BiometricPrompt.ERROR_LOCKOUT)
+        )
+        assertThrows(BiometricHelper.BiometricException::class.java) {
+            runBlocking { helper.authenticateWithCrypto(uninitializedCipher()) }
+        }
+    }
+}

--- a/app/src/androidTest/kotlin/io/privkey/keep/nip55/ApprovalFlowKillSwitchInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/nip55/ApprovalFlowKillSwitchInstrumentedTest.kt
@@ -43,16 +43,15 @@ import org.junit.runner.RunWith
  * here. Since the switch fails CLOSED (only ever disables signing), that residual cannot
  * yield a rogue signature.
  *
- * Out of scope (documented, not faked), per the #388/#389 precedent:
- *  - Biometric-authentication FAILURE and user CANCELLATION of the prompt. On these
- *    physical devices biometric is BIOMETRIC_STRONG with no PIN fallback and cannot be
- *    software-injected (no emulator biometric injection is available either). The failure/
- *    cancellation decision logic lives inside the [androidx.biometric.BiometricPrompt]
- *    .AuthenticationCallback in BiometricHelper (onAuthenticationError ->
- *    AuthResult.FAILED/LOCKOUT; onAuthenticationError ERROR_USER_CANCELED /
- *    ERROR_NEGATIVE_BUTTON -> resume(null)); those callbacks are invoked only by the real
- *    hardware prompt, so there is no non-UI seam to drive them directly. Both branches are
- *    manual/out-of-scope here rather than stubbed into a hollow pass.
+ * Sibling coverage (gh #396):
+ *  - Biometric-authentication FAILURE and user CANCELLATION of the prompt are covered in
+ *    BiometricHelperInstrumentedTest. Those branches live inside the
+ *    [androidx.biometric.BiometricPrompt].AuthenticationCallback in BiometricHelper
+ *    (onAuthenticationError -> AuthResult.FAILED/LOCKOUT; onAuthenticationError
+ *    ERROR_USER_CANCELED / ERROR_NEGATIVE_BUTTON -> resume(null)); on BIOMETRIC_STRONG hardware
+ *    with no PIN fallback and no emulator injection the real prompt fires them only from
+ *    hardware, so BiometricHelper now exposes a BiometricAuthenticator seam that lets those
+ *    tests drive the callbacks deterministically rather than stubbing a hollow pass.
  */
 @RunWith(AndroidJUnit4::class)
 class ApprovalFlowKillSwitchInstrumentedTest {

--- a/app/src/androidTest/kotlin/io/privkey/keep/nip55/ApprovalFlowKillSwitchInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/nip55/ApprovalFlowKillSwitchInstrumentedTest.kt
@@ -47,7 +47,7 @@ import org.junit.runner.RunWith
  *  - Biometric-authentication FAILURE and user CANCELLATION of the prompt are covered in
  *    BiometricHelperInstrumentedTest. Those branches live inside the
  *    [androidx.biometric.BiometricPrompt].AuthenticationCallback in BiometricHelper
- *    (onAuthenticationError -> AuthResult.FAILED/LOCKOUT; onAuthenticationError
+ *    (onAuthenticationError -> AuthResult.FAILED/LOCKOUT/LOCKOUT_PERMANENT; onAuthenticationError
  *    ERROR_USER_CANCELED / ERROR_NEGATIVE_BUTTON -> resume(null)); on BIOMETRIC_STRONG hardware
  *    with no PIN fallback and no emulator injection the real prompt fires them only from
  *    hardware, so BiometricHelper now exposes a BiometricAuthenticator seam that lets those

--- a/app/src/main/kotlin/io/privkey/keep/BiometricHelper.kt
+++ b/app/src/main/kotlin/io/privkey/keep/BiometricHelper.kt
@@ -13,9 +13,35 @@ import kotlin.coroutines.suspendCoroutine
 
 class BiometricHelper(
     private val activity: FragmentActivity,
-    private val timeoutStore: BiometricTimeoutStore? = null
+    private val timeoutStore: BiometricTimeoutStore? = null,
+    authenticator: BiometricAuthenticator? = null
 ) {
     private val executor = ContextCompat.getMainExecutor(activity)
+
+    /**
+     * Seam over [BiometricPrompt] so the approval-flow failure and cancellation branches can be
+     * driven deterministically in tests. On these devices biometric is BIOMETRIC_STRONG with no
+     * PIN fallback and no emulator injection, so the real prompt's callbacks are otherwise only
+     * invoked by hardware. Production passes no authenticator and gets the default below, which is
+     * the prior inline behavior unchanged.
+     */
+    fun interface BiometricAuthenticator {
+        fun authenticate(
+            promptInfo: BiometricPrompt.PromptInfo,
+            cryptoObject: BiometricPrompt.CryptoObject?,
+            callback: BiometricPrompt.AuthenticationCallback
+        )
+    }
+
+    private val authenticator: BiometricAuthenticator = authenticator
+        ?: BiometricAuthenticator { promptInfo, cryptoObject, callback ->
+            val prompt = BiometricPrompt(activity, executor, callback)
+            if (cryptoObject != null) {
+                prompt.authenticate(promptInfo, cryptoObject)
+            } else {
+                prompt.authenticate(promptInfo)
+            }
+        }
 
     enum class BiometricStatus {
         AVAILABLE,
@@ -78,7 +104,7 @@ class BiometricHelper(
                 override fun onAuthenticationFailed() {}
             }
 
-            BiometricPrompt(activity, executor, callback).authenticate(promptInfo)
+            authenticator.authenticate(promptInfo, null, callback)
         }
     }
 
@@ -111,10 +137,7 @@ class BiometricHelper(
                 override fun onAuthenticationFailed() {}
             }
 
-            BiometricPrompt(activity, executor, callback).authenticate(
-                promptInfo,
-                BiometricPrompt.CryptoObject(cipher)
-            )
+            authenticator.authenticate(promptInfo, BiometricPrompt.CryptoObject(cipher), callback)
         }
     }
 

--- a/app/src/main/kotlin/io/privkey/keep/BiometricHelper.kt
+++ b/app/src/main/kotlin/io/privkey/keep/BiometricHelper.kt
@@ -11,21 +11,28 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 
-class BiometricHelper(
+class BiometricHelper private constructor(
     private val activity: FragmentActivity,
-    private val timeoutStore: BiometricTimeoutStore? = null,
-    authenticator: BiometricAuthenticator? = null
+    private val timeoutStore: BiometricTimeoutStore?,
+    authenticator: BiometricAuthenticator?
 ) {
+    /** Production constructor: always uses the real [BiometricPrompt]. */
+    constructor(
+        activity: FragmentActivity,
+        timeoutStore: BiometricTimeoutStore? = null
+    ) : this(activity, timeoutStore, null)
+
     private val executor = ContextCompat.getMainExecutor(activity)
 
     /**
      * Seam over [BiometricPrompt] so the approval-flow failure and cancellation branches can be
      * driven deterministically in tests. On these devices biometric is BIOMETRIC_STRONG with no
      * PIN fallback and no emulator injection, so the real prompt's callbacks are otherwise only
-     * invoked by hardware. Production passes no authenticator and gets the default below, which is
-     * the prior inline behavior unchanged.
+     * invoked by hardware. `internal` so it stays off the public API: production never injects one
+     * (the public constructor above always uses the default), only same-module tests do via
+     * [withAuthenticator].
      */
-    fun interface BiometricAuthenticator {
+    internal fun interface BiometricAuthenticator {
         fun authenticate(
             promptInfo: BiometricPrompt.PromptInfo,
             cryptoObject: BiometricPrompt.CryptoObject?,
@@ -170,5 +177,12 @@ class BiometricHelper(
             if (status == BiometricStatus.AVAILABLE) return
             throw BiometricNotReadyException(getBiometricNotReadyMessage(context, status))
         }
+
+        /** Test-only seam: build a helper whose prompt callbacks are driven by [authenticator]. */
+        internal fun withAuthenticator(
+            activity: FragmentActivity,
+            timeoutStore: BiometricTimeoutStore?,
+            authenticator: BiometricAuthenticator
+        ): BiometricHelper = BiometricHelper(activity, timeoutStore, authenticator)
     }
 }


### PR DESCRIPTION
## Summary
Closes #396.

The approval-flow biometric **failure** and **user-cancellation** branches were previously untested: their decision logic lives inside the anonymous `BiometricPrompt.AuthenticationCallback` objects in `BiometricHelper`, and on BIOMETRIC_STRONG hardware with no PIN fallback and no emulator biometric injection, the real prompt fires those callbacks only from hardware. There was no non-UI seam to drive them, so they were documented as out-of-scope rather than stubbed into a hollow pass.

This adds a minimal seam and covers both branches:

- **`BiometricHelper.BiometricAuthenticator`** — a `fun interface` wrapping the `BiometricPrompt(...).authenticate(...)` calls, injected via a new optional constructor parameter that defaults to the real prompt. Production constructs `BiometricHelper` with no authenticator and its behavior is unchanged (the default runs exactly the prior inline code). Tests inject a fake that invokes the callback deterministically.
- **`BiometricHelperInstrumentedTest`** — drives the failure and cancellation outcomes and asserts the mapping:
  - `authenticateWithResult`: non-lockout error → `FAILED`; `ERROR_LOCKOUT` → `LOCKOUT`; `ERROR_LOCKOUT_PERMANENT` → `LOCKOUT_PERMANENT`.
  - `authenticateWithCrypto`: `ERROR_USER_CANCELED` / `ERROR_NEGATIVE_BUTTON` → returns `null` (no `Cipher` escapes, so key use is gated); a non-cancellation error → throws `BiometricException` (again no `Cipher`).
- Updated the `ApprovalFlowKillSwitchInstrumentedTest` header, which previously stated these branches had no seam and were out of scope, to point at the new coverage.

## Test plan
- `./gradlew :app:compileDebugKotlin :app:compileDebugAndroidTestKotlin` green locally (JDK21).
- The new instrumented tests run on the `instrumented-tests` CI job (emulator); production code path is unchanged, so `build` remains green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved biometric authentication handling for generic failures, temporary lockouts, and permanent lockouts.
  * Ensured cancellations exit cleanly without attempting to use protected cryptographic credentials.
  * Prevented cryptographic operations from proceeding after non-cancellation biometric errors.

* **Tests**
  * Added comprehensive coverage for biometric success and failure scenarios.
  * Added deterministic validation of authentication result mapping and cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->