### PR TITLE
test: isolate kill-switch mutations with a per-test reset RunListener

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,6 +17,11 @@ android {
         versionName = "1.1.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        // Reset the persisted kill switch to its disengaged baseline before every
+        // instrumented test, so a switch left engaged by a process death mid-test
+        // cannot fail-close signing tests in a later class (gh #397).
+        testInstrumentationRunnerArguments["listener"] =
+            "io.privkey.keep.KillSwitchResetRunListener"
         vectorDrawables {
             useSupportLibrary = true
         }

--- a/app/src/androidTest/kotlin/io/privkey/keep/KillSwitchResetRunListener.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/KillSwitchResetRunListener.kt
@@ -1,0 +1,31 @@
+package io.privkey.keep
+
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.runner.Description
+import org.junit.runner.notification.RunListener
+
+/**
+ * Forces the Rust-owned kill switch to its disengaged baseline before every
+ * instrumented test (gh #397).
+ *
+ * The kill switch is persisted core state (it must survive a process restart). A
+ * test that engages it and then suffers process death strictly between the engage
+ * and its `@After` restore leaves the switch engaged on disk, which would then
+ * fail-closed every signing test in a *subsequent* test class. Resetting it here,
+ * before each test runs (`testStarted` fires before the test's own `@Before`),
+ * neutralizes that cross-class leak without the module-wide blast radius of Android
+ * Test Orchestrator + `clearPackageData`: a kill-switch-mutating class still engages
+ * the switch in its own `@Before`, which runs after this reset.
+ *
+ * Registered via the `listener` instrumentation-runner argument in
+ * `app/build.gradle.kts`. Best-effort: if the core is not yet initialized the reset
+ * is skipped (the application's own `onCreate` establishes the disengaged default).
+ */
+class KillSwitchResetRunListener : RunListener() {
+    override fun testStarted(description: Description) {
+        val app = InstrumentationRegistry.getInstrumentation()
+            .targetContext
+            .applicationContext as? KeepMobileApp
+        app?.getKeepMobile()?.setKillSwitch(false)
+    }
+}

--- a/app/src/androidTest/kotlin/io/privkey/keep/KillSwitchResetRunListener.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/KillSwitchResetRunListener.kt
@@ -26,6 +26,10 @@ class KillSwitchResetRunListener : RunListener() {
         val app = InstrumentationRegistry.getInstrumentation()
             .targetContext
             .applicationContext as? KeepMobileApp
-        app?.getKeepMobile()?.setKillSwitch(false)
+        // Best-effort: setKillSwitch is @Throws, and an exception escaping
+        // testStarted() would flake the very test this listener protects (JUnit
+        // turns it into a test failure). Swallow it -- a transient throw here is no
+        // worse than the pre-listener behavior.
+        runCatching { app?.getKeepMobile()?.setKillSwitch(false) }
     }
 }

--- a/app/src/androidTest/kotlin/io/privkey/keep/nip55/ApprovalFlowKillSwitchInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/nip55/ApprovalFlowKillSwitchInstrumentedTest.kt
@@ -37,11 +37,12 @@ import org.junit.runner.RunWith
  * @Before disengages the core switch to a known baseline before engaging it for the test, and
  * @After forces it back to disengaged unconditionally -- so this class both self-heals a switch
  * left engaged by a prior aborted run and never leaves the installed app kill-switched. The
- * single residual gap is process death strictly between setKillSwitch(true) and @After, which is
- * uncatchable in-process; a suite that must be hardened against that would need per-test
- * process isolation (Android Test Orchestrator), a module-wide execution change out of scope
- * here. Since the switch fails CLOSED (only ever disables signing), that residual cannot
- * yield a rogue signature.
+ * one residual gap was process death strictly between setKillSwitch(true) and @After, which is
+ * uncatchable in-process; that is now closed suite-wide by [io.privkey.keep.KillSwitchResetRunListener]
+ * (gh #397), which resets the switch to disengaged before every test, so a leaked engaged switch
+ * cannot poison a later class -- without the module-wide blast radius of Test Orchestrator +
+ * clearPackageData. Since the switch also fails CLOSED (only ever disables signing), that residual
+ * could never yield a rogue signature regardless.
  *
  * Sibling coverage (gh #396):
  *  - Biometric-authentication FAILURE and user CANCELLATION of the prompt are covered in


### PR DESCRIPTION
## Summary
Closes #397.

`ApprovalFlowKillSwitchInstrumentedTest` engages the Rust-owned kill switch in `@Before` and restores it in `@After`. The switch is persisted core state (it must survive a restart), so a process death strictly between `setKillSwitch(true)` and the `@After` restore leaves it engaged on disk, which then fail-closes every signing test in a subsequent class (e.g. `FrostSigningIntegrationTest.killSwitch_isDisabledByDefault`). That leak is uncatchable in-process.

Fix: `KillSwitchResetRunListener` resets the switch to its disengaged baseline before every instrumented test (`testStarted` fires before the test's own `@Before`), so a leaked engaged switch cannot poison a later class. It is registered via the `listener` instrumentation-runner argument in `app/build.gradle.kts`.

This is the issue's lower-risk option (a suite-level baseline reset) rather than Android Test Orchestrator + `clearPackageData`: it targets the identified persisted-state leak (the kill switch) without the module-wide execution change that clears app data between all 27 instrumented test classes. A kill-switch-mutating class still engages the switch in its own `@Before`, which runs after this reset, so those tests are unaffected; for every other test the reset is a no-op (disengaged is the normal default).

## Test plan
- `./gradlew :app:compileDebugAndroidTestKotlin` green (JDK21).
- The `instrumented-tests` CI job runs all 27 instrumented test classes with the listener active: it verifies the listener registers and runs, resets the switch before each test, and does not break any existing test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved instrumented test isolation by resetting the persisted signing kill switch before each test.
  * Prevented a previous test’s state from affecting later signing scenarios, including after process termination.
  * Updated test documentation to reflect the strengthened coverage of kill-switch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->