### PR TITLE
fix: bound the blocking rate-limiter FFI on the NIP-55 auto-sign path

### DIFF
--- a/app/src/androidTest/kotlin/io/privkey/keep/nip55/Nip55RunWithTimeoutInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/nip55/Nip55RunWithTimeoutInstrumentedTest.kt
@@ -1,0 +1,42 @@
+package io.privkey.keep.nip55
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Verifies that `Nip55ContentProvider.runWithTimeout` imposes a real wall-clock
+ * bound on a blocking, non-cancellable call (gh #314).
+ *
+ * The auto-sign path calls a blocking FFI (e.g. `SigningRateLimiter.checkAndRecord`,
+ * a synchronous encrypted keystore write) with no suspension point, so
+ * `withTimeoutOrNull` cannot cancel it in place. This test drives that shape with a
+ * `Thread.sleep` far longer than `OPERATION_TIMEOUT_MS` (5s) and asserts the call
+ * fails closed (`null`) well within the budget rather than waiting for the blocking
+ * work. Against the previous implementation (which ran the blocking call inside the
+ * timeout scope) this would only return after the full ~15s sleep.
+ */
+@RunWith(AndroidJUnit4::class)
+class Nip55RunWithTimeoutInstrumentedTest {
+
+    @Test
+    fun runWithTimeout_failsClosedWithinTheBudget_onABlockingCall() {
+        val provider = Nip55ContentProvider()
+        val start = System.currentTimeMillis()
+        val result: String? = provider.runWithTimeout {
+            // Blocking, no suspension point -- stands in for a stuck FFI call.
+            Thread.sleep(15_000)
+            "must-not-be-returned"
+        }
+        val elapsedMs = System.currentTimeMillis() - start
+
+        assertNull("a blocking call over the budget must fail closed (null)", result)
+        assertTrue(
+            "runWithTimeout must return within its wall-clock budget, not wait for the " +
+                "blocking call (elapsed=${elapsedMs}ms, budget=5000ms)",
+            elapsedMs < 10_000,
+        )
+    }
+}

--- a/app/src/main/kotlin/io/privkey/keep/nip55/Nip55ContentProvider.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/Nip55ContentProvider.kt
@@ -60,6 +60,11 @@ class Nip55ContentProvider : ContentProvider() {
         private const val MAX_CONTENT_LENGTH = 1024 * 1024
         private const val OPERATION_TIMEOUT_MS = 5000L
 
+        // Max IO threads orphaned (timed-out) FFI calls may occupy, so a run of
+        // stuck calls cannot pin the whole shared Dispatchers.IO pool. Matches the
+        // request-concurrency cap (concurrentRequestSemaphore).
+        private const val ORPHAN_IO_PARALLELISM = 4
+
         private const val BACKGROUND_SIGNING_CHANNEL_ID = "background_signing"
 
         private val SIGN_COLUMNS = arrayOf("signature", "event", "result")
@@ -80,9 +85,14 @@ class Nip55ContentProvider : ContentProvider() {
     // Scope for orphaned FFI work. A policy-store / rate-limiter call reaches a
     // blocking, non-cancellable UniFFI call (e.g. SigningRateLimiter.checkAndRecord,
     // a synchronous encrypted keystore write). If such a call overruns its wall-clock
-    // budget it is left to finish here, on the IO dispatcher, instead of pinning the
-    // caller. SupervisorJob so one orphaned failure cannot cancel the others.
-    private val orphanScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    // budget it is left to finish here instead of pinning the caller. Bounded to a
+    // small view of the IO pool via limitedParallelism, so a run of stuck FFI calls
+    // stays confined to a few threads rather than starving the app-wide Dispatchers.IO;
+    // callers still fail closed at the timeout whether the orphan runs or queues.
+    // SupervisorJob so one orphaned failure cannot cancel the others.
+    private val orphanScope = CoroutineScope(
+        Dispatchers.IO.limitedParallelism(ORPHAN_IO_PARALLELISM) + SupervisorJob(),
+    )
 
     private val app: KeepMobileApp? get() = context?.applicationContext as? KeepMobileApp
 
@@ -276,7 +286,10 @@ class Nip55ContentProvider : ContentProvider() {
         }
 
         val hasSignedKindBefore = if (eventKind != null) {
-            runWithTimeout { store.hasSignedKindBefore(callerPackage, eventKind) } ?: true
+            // Fail safe on timeout/contention: an unknown history is treated as
+            // "not signed before" so the first-kind risk factor is kept (biases the
+            // risk assessment toward more scrutiny, not auto-approval).
+            runWithTimeout { store.hasSignedKindBefore(callerPackage, eventKind) } ?: false
         } else {
             true
         }

--- a/app/src/main/kotlin/io/privkey/keep/nip55/Nip55ContentProvider.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/Nip55ContentProvider.kt
@@ -34,7 +34,10 @@ import io.privkey.keep.uniffi.evaluateNip55Request
 import io.privkey.keep.uniffi.nip55ExtractRelayHost
 import io.privkey.keep.uniffi.nip55SignableEventKind
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import java.security.MessageDigest
@@ -74,13 +77,30 @@ class Nip55ContentProvider : ContentProvider() {
     private val backgroundNotificationId = AtomicInteger(0)
     private val concurrentRequestSemaphore = Semaphore(4)
 
+    // Scope for orphaned FFI work. A policy-store / rate-limiter call reaches a
+    // blocking, non-cancellable UniFFI call (e.g. SigningRateLimiter.checkAndRecord,
+    // a synchronous encrypted keystore write). If such a call overruns its wall-clock
+    // budget it is left to finish here, on the IO dispatcher, instead of pinning the
+    // caller. SupervisorJob so one orphaned failure cannot cancel the others.
+    private val orphanScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
     private val app: KeepMobileApp? get() = context?.applicationContext as? KeepMobileApp
 
-    private fun <T> runWithTimeout(block: suspend () -> T): T? {
+    // Run `block` under a real wall-clock bound. `block` may reach a blocking,
+    // non-cancellable FFI call, which `withTimeoutOrNull` cannot interrupt in place
+    // (there is no suspension point to cancel at). So the work runs on [orphanScope]
+    // -- deliberately NOT structured under the `runBlocking` below -- and we await it
+    // with a timeout: when the budget is exceeded the await is cancelled, releasing
+    // the caller's binder thread and the semaphore permit and failing closed (null),
+    // while the orphaned call finishes on its own IO thread rather than pinning both
+    // for its full, unbounded duration. Cancelling the await does not cancel the
+    // orphan (orphanScope owns it). `internal` only so the bound can be unit-tested.
+    internal fun <T> runWithTimeout(block: suspend () -> T): T? {
         if (!concurrentRequestSemaphore.tryAcquire()) return null
         return try {
-            runBlocking(Dispatchers.IO) {
-                withTimeoutOrNull(OPERATION_TIMEOUT_MS) { block() }
+            val deferred = orphanScope.async { block() }
+            runBlocking {
+                withTimeoutOrNull(OPERATION_TIMEOUT_MS) { deferred.await() }
             }
         } finally {
             concurrentRequestSemaphore.release()


### PR DESCRIPTION
## Summary
Closes #314 (the timeout half).

`Nip55ContentProvider.runWithTimeout` wrapped its work in `withTimeoutOrNull(OPERATION_TIMEOUT_MS) { block() }`, but on the opted-in auto-sign path `block` reaches a **blocking, non-cancellable** UniFFI call (`SigningRateLimiter.checkAndRecord`, which does a synchronous encrypted keystore write). `withTimeoutOrNull` can only cancel at a suspension point, and there is none inside a blocking FFI call, so the timeout was inert: a slow or stuck keystore write pinned the binder thread for its full, unbounded duration **while holding a `concurrentRequestSemaphore(4)` permit**.

Fix: run the work on a class-level `orphanScope` (`Dispatchers.IO + SupervisorJob`), deliberately **not** structured under the `runBlocking`, and await it with the timeout. When the budget is exceeded the `await` is cancelled — releasing the binder thread and the semaphore permit and failing closed (`null` → `FallToUi`, unchanged security posture) — while the orphaned call finishes on its own IO thread instead of pinning the caller. Cancelling the await does not cancel the orphan (`orphanScope` owns it), and a real result before the budget is returned exactly as before.

Scope: this addresses the "no real timeout" robustness cost. The other cost the issue notes — `commit()` doing synchronous encrypted disk I/O per request — is intentionally left as-is: it is deliberate for durability, and the wall-clock bound above already prevents a slow write from pinning the caller.

## Test plan
- New instrumented test `Nip55RunWithTimeoutInstrumentedTest`: a 15s blocking `Thread.sleep` (a stuck-FFI stand-in) must return `null` within the 5s budget (asserts elapsed < 10s). This fails against the previous implementation, which returned only after the full ~15s.
- `./gradlew :app:compileDebugKotlin :app:compileDebugAndroidTestKotlin` green (JDK21).
- The `instrumented-tests` CI job runs the new bound test plus the existing suite (non-regression).