### PR TITLE
ci: enforce NDK/cargo-ndk pin consistency with the vendored keep repo

### DIFF
--- a/scripts/check-toolchain-pins.sh
+++ b/scripts/check-toolchain-pins.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 #   .github/workflows/ci.yml (RUST_VERSION, NDK_VERSION, CARGO_NDK_VERSION)
 #   .github/workflows/release.yml (RUST_VERSION, NDK_VERSION, CARGO_NDK_VERSION)
 #   keep/rust-toolchain.toml (channel, if present)
+#   keep/.github/workflows/ci.yml (NDK_VERSION, CARGO_NDK_VERSION -- the vendored
+#                            keep repo's Android toolchain, which must match this
+#                            repo's since keep-mobile is cross-compiled with it)
 #   build.gradle.kts         (expectedNdkVersion, expectedJavaMajor)
 #   .github/workflows/*.yml  (java-version in actions/setup-java steps)
 
@@ -141,6 +144,22 @@ if [ -f "$TOOLCHAIN_TOML" ]; then
     check_equal "rust-toolchain.toml channel" "$BR_RUST" "$TOML_CHANNEL"
 else
     echo "note: $TOOLCHAIN_TOML not present; skipping channel check."
+fi
+
+# Cross-check the vendored keep checkout's Android toolchain pins against this
+# repo's. keep-android cross-compiles keep-mobile with these NDK / cargo-ndk
+# versions against that exact keep source, so a bump in one repo that is not
+# mirrored in the other silently diverges the toolchain the shipped bindings are
+# built with. Enforced here so bumping keep.version to a keep commit with different
+# pins (or changing this repo's pins) fails CI instead of drifting.
+KEEP_CI_YML="$ROOT/keep/.github/workflows/ci.yml"
+if [ -f "$KEEP_CI_YML" ]; then
+    KEEP_NDK=$(yaml_env "$KEEP_CI_YML" NDK_VERSION "$NDK_VER")
+    KEEP_CARGO_NDK=$(yaml_env "$KEEP_CI_YML" CARGO_NDK_VERSION "$SEMVER")
+    check_equal "keep-repo ndk version"       "$CI_NDK"       "$KEEP_NDK"
+    check_equal "keep-repo cargo-ndk version" "$BR_CARGO_NDK" "$KEEP_CARGO_NDK"
+else
+    echo "note: $KEEP_CI_YML not present; skipping keep-repo cross-checks."
 fi
 
 echo "all toolchain pins consistent."


### PR DESCRIPTION
## Summary
Part of #414 (the NDK / cargo-ndk pin-consistency sub-task).

`check-toolchain-pins.sh` validated the NDK and cargo-ndk pins across this repo's files, but never cross-checked the vendored `keep` checkout, even though keep-android cross-compiles `keep-mobile` with these versions against that exact keep source. keep's own `ci.yml` even carries a comment that its NDK/cargo-ndk/Rust versions "must stay in sync with that repository", but nothing enforced it: bumping `keep.version` to a keep commit with a different NDK or cargo-ndk pin (or changing this repo's pins) would silently diverge the toolchain the shipped bindings are built with.

Extend the script to read `NDK_VERSION` / `CARGO_NDK_VERSION` from `keep/.github/workflows/ci.yml` and assert they match this repo's, using the existing `check_equal` helper. Skipped with a note if the vendored checkout is absent.

The script already runs in CI (`ci.yml`), so this is enforced on every PR and push.

## Test plan
- `./scripts/check-toolchain-pins.sh` passes locally (pins currently match: NDK `29.0.14206865`, cargo-ndk `4.1.2`).
- Non-vacuity confirmed: temporarily setting keep's `CARGO_NDK_VERSION` to a different value makes the script fail with `keep-repo cargo-ndk version mismatch` (exit 1); reverting restores green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of Rust, NDK, and cargo-ndk toolchain versions against the vendored repository configuration.
  * Added a clear notice when the reference workflow is unavailable and validation is skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->