### PR TITLE
Accept NIP-44 v3 types when reopening a signing request from a notification

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/service/SigningNotificationReceiver.kt
+++ b/app/src/main/kotlin/io/privkey/keep/service/SigningNotificationReceiver.kt
@@ -12,6 +12,7 @@ class SigningNotificationReceiver : BroadcastReceiver() {
             "get_public_key", "sign_event",
             "nip04_encrypt", "nip04_decrypt",
             "nip44_encrypt", "nip44_decrypt",
+            "nip44v3_encrypt", "nip44v3_decrypt",
             "decrypt_zap_event"
         )
 


### PR DESCRIPTION
## Summary

`SigningNotificationReceiver.isValidNostrSignerUri` gates a signing request reopened from its notification against a `VALID_TYPES` allowlist. The allowlist was missing `nip44v3_encrypt` / `nip44v3_decrypt`, even though `Nip55Activity` already parses those types on the intent path. As a result, tapping the notification for a NIP-44 v3 request failed validation and the request was silently dropped instead of opening the approval screen.

Adds the two v3 types to the allowlist so it matches the types the activity actually handles.

## Test plan

- `./gradlew compileDebugKotlin` — BUILD SUCCESSFUL.
- The allowlist now covers exactly the `type` values parsed by `Nip55Activity` (get_public_key, sign_event, nip04/nip44 encrypt/decrypt, nip44 v3 encrypt/decrypt, decrypt_zap_event), verified by reading both.