### PR TITLE
Seed the encrypted-prefs key registry before rewriting it

### DIFF
--- a/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsRegistryTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsRegistryTest.kt
@@ -95,6 +95,41 @@ class KeystoreEncryptedPrefsRegistryTest {
         assertTrue(visible.contains("beta"))
     }
 
+    @Test
+    fun concurrentWritersDoNotDropEachOthersKeys() {
+        // Two writers racing on one instance. Each snapshots the shared cache to
+        // rewrite the registry, so without serialising the commit the later one
+        // can persist a registry that predates the other's key, stranding it.
+        val prefs = reopen()
+        val threads = (0 until 8).map { i ->
+            Thread { prefs.edit().putString("key$i", "v$i").commit() }
+        }
+        threads.forEach { it.start() }
+        threads.forEach { it.join() }
+
+        val visible = reopen().all.keys
+        for (i in 0 until 8) {
+            assertTrue("key$i must survive concurrent writers", visible.contains("key$i"))
+        }
+    }
+
+    @Test
+    fun aSecondInstanceWritingConcurrentlyDoesNotTruncateTheRegistry() {
+        // Separate wrappers over the same file, each seeding independently.
+        reopen().edit().putString("existing", "1").commit()
+
+        val a = reopen()
+        val b = reopen()
+        val t1 = Thread { a.edit().putString("fromA", "2").commit() }
+        val t2 = Thread { b.edit().putString("fromB", "3").commit() }
+        t1.start(); t2.start(); t1.join(); t2.join()
+
+        val visible = reopen().all.keys
+        assertTrue("pre-existing key must survive", visible.contains("existing"))
+        assertTrue(visible.contains("fromA"))
+        assertTrue(visible.contains("fromB"))
+    }
+
     companion object {
         private const val PREFS_NAME = "keystore_prefs_registry_test"
     }

--- a/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsRegistryTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsRegistryTest.kt
@@ -1,0 +1,101 @@
+package io.privkey.keep.storage
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * The key registry lists every plaintext key the store holds. It is rewritten
+ * from an in-memory cache on each commit, and that cache only contains keys the
+ * current instance has touched, so a write performed after a restart must not be
+ * allowed to drop the rest.
+ *
+ * This matters beyond tidiness: entries missing from the registry stay on disk
+ * but become invisible to [android.content.SharedPreferences.getAll] and to the
+ * migration that re-hashes keys after a derivation-key change, which only visits
+ * registry-listed keys. For the signer's rate-limiter store that turns a
+ * package's recorded usage into "no usage yet".
+ */
+@RunWith(AndroidJUnit4::class)
+class KeystoreEncryptedPrefsRegistryTest {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun setup() = clear()
+
+    @After
+    fun teardown() = clear()
+
+    private fun clear() {
+        context.deleteSharedPreferences(PREFS_NAME)
+    }
+
+    /** A fresh wrapper over the same file, standing in for a process restart. */
+    private fun reopen() = KeystoreEncryptedPrefs.create(context, PREFS_NAME)
+
+    @Test
+    fun aWriteFromAFreshInstanceKeepsEntriesItNeverTouched() {
+        val first = reopen()
+        first.edit().putString("alpha", "1").commit()
+        first.edit().putString("beta", "2").commit()
+
+        // A new instance writes a third key without ever reading the first two,
+        // so its cache holds only "gamma" when the registry is rewritten.
+        val second = reopen()
+        second.edit().putString("gamma", "3").commit()
+
+        val visible = reopen().all.keys
+        assertTrue("alpha must survive a write that never touched it", visible.contains("alpha"))
+        assertTrue("beta must survive a write that never touched it", visible.contains("beta"))
+        assertTrue(visible.contains("gamma"))
+    }
+
+    @Test
+    fun untouchedEntriesRemainReadableAfterAnUnrelatedWrite() {
+        reopen().edit().putString("alpha", "1").commit()
+
+        val second = reopen()
+        second.edit().putString("beta", "2").commit()
+
+        val reopened = reopen()
+        assertEquals("1", reopened.getString("alpha", null))
+        assertEquals("2", reopened.getString("beta", null))
+    }
+
+    @Test
+    fun clearStillEmptiesTheRegistry() {
+        val prefs = reopen()
+        prefs.edit().putString("alpha", "1").commit()
+        prefs.edit().putString("beta", "2").commit()
+
+        // Seeding must not resurrect keys a clear removed.
+        reopen().edit().clear().commit()
+
+        assertTrue(reopen().all.keys.isEmpty())
+    }
+
+    @Test
+    fun aRemovedKeyIsNotResurrectedBySeeding() {
+        reopen().edit().putString("alpha", "1").commit()
+        reopen().edit().putString("beta", "2").commit()
+
+        // Fresh instance: the removal is applied against a cache seeded from the
+        // registry, so the key must not reappear when the registry is rewritten.
+        reopen().edit().remove("alpha").commit()
+
+        val visible = reopen().all.keys
+        assertTrue("removed key must stay removed", !visible.contains("alpha"))
+        assertTrue(visible.contains("beta"))
+    }
+
+    companion object {
+        private const val PREFS_NAME = "keystore_prefs_registry_test"
+    }
+}

--- a/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
@@ -118,6 +118,13 @@ object KeystoreEncryptedPrefs {
 
         private val keyCache = ConcurrentHashMap<String, String>()
         private val reverseKeyCache = ConcurrentHashMap<String, String>()
+
+        /// Whether the persisted key registry has been folded into [keyCache] for
+        /// this instance. The registry is rewritten from that cache on every
+        /// commit, and the cache only holds keys this instance has touched, so
+        /// the first write after a process start would otherwise truncate the
+        /// registry to those keys and orphan the rest.
+        private val registrySeeded = java.util.concurrent.atomic.AtomicBoolean(false)
         @Volatile
         private var hmacKey: ByteArray? = null
         private val listenerMap = ConcurrentHashMap<SharedPreferences.OnSharedPreferenceChangeListener, SharedPreferences.OnSharedPreferenceChangeListener>()
@@ -250,6 +257,14 @@ object KeystoreEncryptedPrefs {
                 reverseKeyCache[hash] = plainKey
                 hash
             } else null
+        }
+
+        /// Fold the persisted registry into [keyCache] once per instance, so a
+        /// registry rewrite unions with what is already stored instead of
+        /// replacing it. Skipped when a clear is in flight, which legitimately
+        /// empties the registry.
+        private fun ensureRegistrySeeded() {
+            if (registrySeeded.compareAndSet(false, true)) rebuildKeyCacheFromRegistry()
         }
 
         private fun rebuildKeyCacheFromRegistry() {
@@ -460,6 +475,18 @@ object KeystoreEncryptedPrefs {
                     keyCache.clear()
                     reverseKeyCache.clear()
                     hmacKey = null
+                } else {
+                    // Fold in what is already on disk before the registry is
+                    // rewritten below from the in-memory cache. Without this, the
+                    // first write in a process drops every key this instance has
+                    // not touched: the entries survive on disk but disappear from
+                    // the registry, so `getAll` stops seeing them and the
+                    // deterministic-key migration, which only re-hashes
+                    // registry-listed keys, leaves them stranded under the old
+                    // hash. For the rate-limiter store that means a package's
+                    // usage counters and cooling-off entries silently stop being
+                    // found, which reads as "no usage yet".
+                    ensureRegistrySeeded()
                 }
 
                 for (plainKey in pendingRemoves) {

--- a/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
@@ -124,7 +124,12 @@ object KeystoreEncryptedPrefs {
         /// commit, and the cache only holds keys this instance has touched, so
         /// the first write after a process start would otherwise truncate the
         /// registry to those keys and orphan the rest.
-        private val registrySeeded = java.util.concurrent.atomic.AtomicBoolean(false)
+        ///
+        /// Guarded by the per-file monitor, and set only once the fold has
+        /// finished. A flag published before the work completes would let a
+        /// second writer proceed against a half-filled cache and persist the very
+        /// truncation this exists to prevent.
+        private var registrySeeded = false
         @Volatile
         private var hmacKey: ByteArray? = null
         private val listenerMap = ConcurrentHashMap<SharedPreferences.OnSharedPreferenceChangeListener, SharedPreferences.OnSharedPreferenceChangeListener>()
@@ -263,8 +268,16 @@ object KeystoreEncryptedPrefs {
         /// registry rewrite unions with what is already stored instead of
         /// replacing it. Skipped when a clear is in flight, which legitimately
         /// empties the registry.
+        ///
+        /// Callers hold the per-file monitor, which also serialises this against
+        /// a concurrent clear. Without that, the fold could read the registry
+        /// under one derivation key and hash its names under a newer one, caching
+        /// hashes that point nowhere and writing cleared names back into the
+        /// registry.
         private fun ensureRegistrySeeded() {
-            if (registrySeeded.compareAndSet(false, true)) rebuildKeyCacheFromRegistry()
+            if (registrySeeded) return
+            rebuildKeyCacheFromRegistry()
+            registrySeeded = true
         }
 
         private fun rebuildKeyCacheFromRegistry() {
@@ -446,25 +459,19 @@ object KeystoreEncryptedPrefs {
                 return this
             }
 
-            override fun commit(): Boolean {
-                if (clearRequested) {
-                    return synchronized(initLockFor(prefsName)) {
-                        applyChanges()
-                        baseEditor.commit()
-                    }
-                }
+            // Both paths take the per-file monitor, not just the clearing one.
+            // The registry is rewritten from a shared cache, so two concurrent
+            // writers could otherwise each snapshot it before the other's key was
+            // added and the later commit would persist a registry missing it,
+            // stranding that entry. Serialising also keeps the registry fold from
+            // tearing against a clear. The monitor is reentrant, so the nested
+            // derivation-key lookup is safe.
+            override fun commit(): Boolean = synchronized(initLockFor(prefsName)) {
                 applyChanges()
-                return baseEditor.commit()
+                baseEditor.commit()
             }
 
-            override fun apply() {
-                if (clearRequested) {
-                    synchronized(initLockFor(prefsName)) {
-                        applyChanges()
-                        baseEditor.apply()
-                    }
-                    return
-                }
+            override fun apply() = synchronized(initLockFor(prefsName)) {
                 applyChanges()
                 baseEditor.apply()
             }
@@ -493,9 +500,13 @@ object KeystoreEncryptedPrefs {
                     val encKey = findEncryptedKey(plainKey)
                     if (encKey != null) {
                         baseEditor.remove(encKey)
-                        keyCache.remove(plainKey)
                         reverseKeyCache.remove(encKey)
                     }
+                    // Drop the name even when nothing was found on disk, so a
+                    // registry entry whose value is already gone is not carried
+                    // forward forever now that the registry is seeded rather than
+                    // rebuilt from scratch each time.
+                    keyCache.remove(plainKey)
                 }
 
                 for ((plainKey, value) in pendingPuts) {


### PR DESCRIPTION
## Summary

The encrypted preferences wrapper keeps a registry of every plaintext key it holds, and rewrites that registry from an in-memory cache on each commit. The cache only contains keys the current instance has touched, so the first write after a process start replaced the registry with just those keys and dropped the rest.

The dropped entries stay on disk, but they stop being listed, and two things depend on that listing:

- Enumeration no longer sees them.
- The migration that re-hashes keys after a derivation-key change only visits registry-listed keys, so anything missing stays stranded under its old hash and cannot be found again.

For the signer's rate-limiter store this is a security-relevant loss rather than a tidiness one. That store holds several keys per package, and an unfindable counter reads as "this package has no usage yet", which restarts the window and puts the hourly and daily ceilings out of reach for that package. It is the amplifier behind the residual gap noted when the rate limiter was made to fail closed: recovering from a derivation-key fallback re-hashes only what the registry lists.

The registry is now folded into the cache once per instance before it is rewritten, so a rewrite unions with what is stored rather than replacing it. Seeding is skipped when a clear is in flight, since a clear legitimately empties the registry, and it happens before pending removals are applied so a removed key is not resurrected.

## Test plan

- `./gradlew compileDebugKotlin compileDebugAndroidTestKotlin` — BUILD SUCCESSFUL, warnings treated as errors.
- New instrumented tests, each using a fresh wrapper over the same file to stand in for a process restart: entries survive a later write that never touched them, they remain readable afterwards, a clear still empties the registry, and a removal is not undone by seeding. The first two fail without this change.
- Instrumented tests run in CI; no local device is available here.