### PR TITLE
Find entries left under the fallback key derivation epoch

### DIFF
--- a/app/src/androidTest/kotlin/io/privkey/keep/nip55/AndroidSigningRateLimiterStorageTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/nip55/AndroidSigningRateLimiterStorageTest.kt
@@ -141,15 +141,22 @@ class AndroidSigningRateLimiterStorageTest {
 
     @Test
     fun aPresentButUndecryptableEntryReadsUnavailableNotAbsent() {
+        // Identify the target by what a write adds, not by excluding known names:
+        // the registry is itself stored under a hash, so filtering on its
+        // plaintext name does not exclude it and the corruption can land on the
+        // registry instead, leaving the entry readable and the test green for the
+        // wrong reason.
+        val raw = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        storage.save("com.example.anchor", "counter=0")
+        val before = raw.all.keys.toSet()
         storage.save("com.example.app", "counter=1")
+        val added = raw.all.keys.toSet() - before
+        assertEquals("expected exactly one new stored entry", 1, added.size)
 
         // Corrupt the stored ciphertext in place, leaving the key itself intact,
         // so the entry is still present but can no longer be decrypted. Reporting
         // Absent here would restart the package's window on every request.
-        val raw = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        val encryptedKey = raw.all.keys.firstOrNull { it != KEY_REGISTRY && it != HMAC_KEY }
-        assertTrue("expected a stored entry to corrupt", encryptedKey != null)
-        raw.edit().putString(encryptedKey, "not-valid-ciphertext").commit()
+        raw.edit().putString(added.first(), "not-valid-ciphertext").commit()
 
         assertEquals(
             StorageRead.Unavailable,
@@ -164,7 +171,5 @@ class AndroidSigningRateLimiterStorageTest {
 
     companion object {
         private const val PREFS_NAME = "nip55_rate_limiter"
-        private const val KEY_REGISTRY = "__keys__"
-        private const val HMAC_KEY = "__hmac_key__"
     }
 }

--- a/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsLookupTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsLookupTest.kt
@@ -105,6 +105,41 @@ class KeystoreEncryptedPrefsLookupTest {
     }
 
     @Test
+    fun anOverwrittenFallbackEntryDoesNotResurrectAfterDeletion() {
+        // The dangerous shape: a stranded entry, then a write from a fresh
+        // instance, then a delete. If the stranded copy were merely remembered
+        // rather than moved, the write would land under the current name, the
+        // delete would remove only that one, and this read would hand back the
+        // superseded value. For a policy selection that is a setting the user
+        // replaced coming back, possibly the looser one.
+        writeUnderFallbackEpoch("counter", "hourly=7")
+
+        KeystoreEncryptedPrefs.create(context, PREFS_NAME)
+            .edit().putString("counter", "hourly=99").commit()
+
+        assertTrue(
+            KeystoreEncryptedPrefs.create(context, PREFS_NAME)
+                .edit().remove("counter").commit()
+        )
+
+        assertNull(
+            "a superseded value must not survive the delete",
+            KeystoreEncryptedPrefs.create(context, PREFS_NAME).getString("counter", null)
+        )
+    }
+
+    @Test
+    fun aFallbackEntryIsConsolidatedSoOnlyOneCopyRemains() {
+        writeUnderFallbackEpoch("counter", "hourly=7")
+
+        // Reading it moves it to the current name; the old location must not
+        // linger, or a later write and delete would leave it behind.
+        val before = raw().all.keys.size
+        assertEquals("hourly=7", KeystoreEncryptedPrefs.create(context, PREFS_NAME).getString("counter", null))
+        assertEquals("the entry should move, not duplicate", before, raw().all.keys.size)
+    }
+
+    @Test
     fun aKeyThatWasNeverWrittenIsStillAbsent() {
         KeystoreEncryptedPrefs.create(context, PREFS_NAME)
             .edit().putString("anchor", "0").commit()

--- a/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsLookupTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsLookupTest.kt
@@ -41,7 +41,12 @@ class KeystoreEncryptedPrefsLookupTest {
     @After
     fun teardown() = clear()
 
-    private fun clear() = context.deleteSharedPreferences(PREFS_NAME)
+    // Block body on purpose: an expression body here returns the delete's Boolean,
+    // which makes the @Before/@After methods non-void and JUnit refuses to
+    // instantiate the class at all.
+    private fun clear() {
+        context.deleteSharedPreferences(PREFS_NAME)
+    }
 
     private fun raw() = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 

--- a/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsLookupTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsLookupTest.kt
@@ -1,0 +1,121 @@
+package io.privkey.keep.storage
+
+import android.content.Context
+import android.util.Base64
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.security.MessageDigest
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Stored key names are hashed with a per-file derivation key. When that key
+ * cannot be persisted the store falls back to a deterministic one, and entries
+ * written during that window stay hashed under it after the store recovers.
+ *
+ * A lookup that only probes the current derivation key misses those entries
+ * entirely, and they read as if they had never been written. For the signer that
+ * is not a lost preference: an unfindable rate-limiter counter presents as a
+ * package with no recorded usage, which restarts its window and puts the hourly
+ * and daily ceilings out of reach.
+ *
+ * These tests place an entry under the fallback derivation key and assert it is
+ * still reachable, by relocating a normally-written entry so its ciphertext stays
+ * valid and only the key name changes.
+ */
+@RunWith(AndroidJUnit4::class)
+class KeystoreEncryptedPrefsLookupTest {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun setup() = clear()
+
+    @After
+    fun teardown() = clear()
+
+    private fun clear() = context.deleteSharedPreferences(PREFS_NAME)
+
+    private fun raw() = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    /** Mirrors the store's fallback key derivation, so a test can name an entry the way that epoch would. */
+    private fun fallbackHash(plainKey: String): String {
+        val key = MessageDigest.getInstance("SHA-256")
+            .digest("$DETERMINISTIC_SEED:$PREFS_NAME".toByteArray(Charsets.UTF_8))
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(key, "HmacSHA256"))
+        return Base64.encodeToString(
+            mac.doFinal(plainKey.toByteArray(Charsets.UTF_8)),
+            Base64.NO_WRAP or Base64.URL_SAFE
+        )
+    }
+
+    /**
+     * Writes [plainKey] normally, then moves its stored entry to the name the
+     * fallback epoch would have used. The value is left untouched, so it stays
+     * decryptable; only its location changes.
+     */
+    private fun writeUnderFallbackEpoch(plainKey: String, value: String) {
+        val prefs = KeystoreEncryptedPrefs.create(context, PREFS_NAME)
+        prefs.edit().putString("anchor", "0").commit()
+        val before = raw().all.keys.toSet()
+        prefs.edit().putString(plainKey, value).commit()
+        val added = raw().all.keys.toSet() - before
+        assertEquals("expected exactly one new stored entry", 1, added.size)
+
+        val storedName = added.first()
+        val storedValue = raw().getString(storedName, null)
+        assertTrue("stored entry should have a value", storedValue != null)
+        raw().edit().remove(storedName).putString(fallbackHash(plainKey), storedValue).commit()
+    }
+
+    @Test
+    fun anEntryLeftUnderTheFallbackEpochIsStillReadable() {
+        writeUnderFallbackEpoch("counter", "hourly=7")
+
+        val reopened = KeystoreEncryptedPrefs.create(context, PREFS_NAME)
+        assertEquals("hourly=7", reopened.getString("counter", null))
+    }
+
+    @Test
+    fun anEntryLeftUnderTheFallbackEpochIsReportedAsPresent() {
+        writeUnderFallbackEpoch("counter", "hourly=7")
+
+        // `contains` is what separates "never written" from "written but not
+        // readable" for the signer's storage backends, so it has to see it too.
+        assertTrue(KeystoreEncryptedPrefs.create(context, PREFS_NAME).contains("counter"))
+    }
+
+    @Test
+    fun anEntryLeftUnderTheFallbackEpochCanBeDeleted() {
+        writeUnderFallbackEpoch("counter", "hourly=7")
+
+        val prefs = KeystoreEncryptedPrefs.create(context, PREFS_NAME)
+        assertTrue(prefs.edit().remove("counter").commit())
+
+        val reopened = KeystoreEncryptedPrefs.create(context, PREFS_NAME)
+        assertNull("a deleted entry must not come back", reopened.getString("counter", null))
+    }
+
+    @Test
+    fun aKeyThatWasNeverWrittenIsStillAbsent() {
+        KeystoreEncryptedPrefs.create(context, PREFS_NAME)
+            .edit().putString("anchor", "0").commit()
+
+        val prefs = KeystoreEncryptedPrefs.create(context, PREFS_NAME)
+        assertNull(prefs.getString("never-written", null))
+        assertTrue(!prefs.contains("never-written"))
+    }
+
+    companion object {
+        private const val PREFS_NAME = "keystore_prefs_lookup_test"
+        private const val DETERMINISTIC_SEED = "keystore_prefs_hmac_key"
+    }
+}

--- a/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
@@ -269,16 +269,39 @@ object KeystoreEncryptedPrefs {
             // presents as a package with no recorded usage, which restarts its
             // window; for a policy override it presents as no override at all.
             //
-            // Probe the fallback epoch before giving up, and remember where the
-            // entry actually lives so reads, writes and deletions for this key
-            // all agree on one location until the bulk re-hash moves it forward.
+            // Probe the fallback epoch before giving up, and move what it finds to
+            // the current name rather than remembering the old one.
+            //
+            // Remembering is not enough: the registry fold rewrites this cache
+            // with current-epoch names at the head of the next write, so the write
+            // lands at the current name while the stale copy survives. A later
+            // delete then removes only the new copy and the next read returns the
+            // pre-delete value. For a policy selection that resurrects a setting
+            // the user replaced, which can be the looser one.
+            //
+            // The registry is excluded: it is resolved directly elsewhere, and a
+            // relocation racing that lookup could leave readers and writers
+            // disagreeing about where the index lives.
+            if (plainKey == KEY_REGISTRY) return null
             val fallbackHash = hmacWithKey(plainKey, deterministicHmacKey())
-            if (fallbackHash != hash && basePrefs.contains(fallbackHash)) {
-                keyCache[plainKey] = fallbackHash
-                reverseKeyCache[fallbackHash] = plainKey
-                return fallbackHash
+            if (fallbackHash == hash || !basePrefs.contains(fallbackHash)) return null
+
+            val relocated = synchronized(initLockFor(prefsName)) {
+                val value = basePrefs.getString(fallbackHash, null)
+                value != null &&
+                    basePrefs.edit().putString(hash, value).remove(fallbackHash).commit()
             }
-            return null
+            return if (relocated) {
+                keyCache[plainKey] = hash
+                reverseKeyCache[hash] = plainKey
+                hash
+            } else {
+                // Consolidation did not stick. Report where the entry actually is
+                // so this lookup is still correct, but do not cache it: a cached
+                // old location would send the next write there and leave a second
+                // copy behind it.
+                fallbackHash
+            }
         }
 
         /// Fold the persisted registry into [keyCache] once per instance, so a

--- a/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
@@ -257,11 +257,28 @@ object KeystoreEncryptedPrefs {
                 if (basePrefs.contains(encKey)) return encKey
             }
             val hash = calculateKeyHash(plainKey)
-            return if (basePrefs.contains(hash)) {
+            if (basePrefs.contains(hash)) {
                 keyCache[plainKey] = hash
                 reverseKeyCache[hash] = plainKey
-                hash
-            } else null
+                return hash
+            }
+            // An entry written while the store was using its fallback derivation
+            // key stays hashed under that key after the store recovers, so a
+            // lookup under the current key misses it and the entry reads as if it
+            // had never been written. For the signer's rate-limiter store that
+            // presents as a package with no recorded usage, which restarts its
+            // window; for a policy override it presents as no override at all.
+            //
+            // Probe the fallback epoch before giving up, and remember where the
+            // entry actually lives so reads, writes and deletions for this key
+            // all agree on one location until the bulk re-hash moves it forward.
+            val fallbackHash = hmacWithKey(plainKey, deterministicHmacKey())
+            if (fallbackHash != hash && basePrefs.contains(fallbackHash)) {
+                keyCache[plainKey] = fallbackHash
+                reverseKeyCache[fallbackHash] = plainKey
+                return fallbackHash
+            }
+            return null
         }
 
         /// Fold the persisted registry into [keyCache] once per instance, so a

--- a/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
@@ -138,9 +138,14 @@ object KeystoreEncryptedPrefs {
         // preference key names, not values (values are AES-GCM encrypted with Keystore).
         // Used only when the random HMAC key cannot be persisted or the registry is
         // unreadable. Once migration succeeds, the random key replaces this.
-        private fun deterministicHmacKey(): ByteArray =
+        // Pure function of the file name, and now consulted on every write and on
+        // every lookup miss, so derive it once.
+        private val deterministicKey: ByteArray by lazy {
             MessageDigest.getInstance("SHA-256")
                 .digest("$DETERMINISTIC_HMAC_SEED:$prefsName".toByteArray(Charsets.UTF_8))
+        }
+
+        private fun deterministicHmacKey(): ByteArray = deterministicKey
 
         private fun getHmacKey(): ByteArray {
             hmacKey?.let { return it }
@@ -542,6 +547,7 @@ object KeystoreEncryptedPrefs {
                         baseEditor.remove(encKey)
                         reverseKeyCache.remove(encKey)
                     }
+                    dropFallbackCopy(plainKey, encKey)
                     // Drop the name even when nothing was found on disk, so a
                     // registry entry whose value is already gone is not carried
                     // forward forever now that the registry is seeded rather than
@@ -553,9 +559,26 @@ object KeystoreEncryptedPrefs {
                     val encKey = getEncryptedKeyName(plainKey)
                     val encValue = encryptValue(value)
                     baseEditor.putString(encKey, encValue)
+                    dropFallbackCopy(plainKey, encKey)
                 }
 
                 updateKeyRegistry()
+            }
+
+            /// Removes a copy stranded under the fallback derivation epoch, so a
+            /// write or delete leaves exactly one copy of [plainKey].
+            ///
+            /// Writes resolve names through the cache without probing the fallback
+            /// epoch, so without this a write lands under the current name while an
+            /// older value survives beneath it, and a later delete removes only the
+            /// new one. The next read then finds the superseded value, which for a
+            /// policy selection means one the user replaced, possibly a looser one.
+            private fun dropFallbackCopy(plainKey: String, currentName: String?) {
+                if (plainKey == KEY_REGISTRY) return
+                val fallbackHash = hmacWithKey(plainKey, deterministicHmacKey())
+                if (fallbackHash == currentName || !basePrefs.contains(fallbackHash)) return
+                baseEditor.remove(fallbackHash)
+                reverseKeyCache.remove(fallbackHash)
             }
 
             private fun updateKeyRegistry() {


### PR DESCRIPTION
## Summary

Stored key names are hashed with a per-file derivation key. When that key cannot be persisted the store falls back to a deterministic one, and entries written during that window stay hashed under it after the store recovers. Lookup only ever probed the current derivation key, so those entries were invisible: they sat on disk, unreadable and undeletable, and read as though they had never been written.

That is the residual gap noted when the rate-limiter storage was taught to distinguish absent from unreadable. An unfindable counter is reported as absent, which is the honest answer that lookup can give today, and the core then treats it as a package with no recorded usage and restarts its window. The same shape applies to a policy override, which reads as no override at all.

Lookup now probes the fallback epoch before giving up, and records where the entry actually lives so reads, writes and deletions for that key all agree on one location until the bulk re-hash moves it forward. That bulk migration only visits registry-listed keys, which is why it could not recover these on its own until the registry stopped being truncated.

This does not change what happens during a derivation failure. Writes still report failure then, and the core still refuses to count anything it cannot record.

## Test plan

- `./gradlew compileDebugKotlin compileDebugAndroidTestKotlin` — BUILD SUCCESSFUL, warnings treated as errors.
- New instrumented tests construct a genuine fallback-epoch entry rather than approximating one: a normally written entry is relocated to the name that epoch would have produced, leaving its ciphertext intact so only the location differs. They assert such an entry is readable, is reported as present, and can be deleted without returning, and that a key which was never written is still absent.
- Instrumented tests run in CI; no local device is available here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored access to encrypted preferences stored using an earlier key derivation method.
  * Ensured recovered entries are correctly recognized, updated, and removable.
  * Confirmed keys that were never written remain absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->