### PR TITLE
Recover a key registry left under the previous derivation epoch

### DIFF
--- a/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsRegistryEpochTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsRegistryEpochTest.kt
@@ -280,8 +280,12 @@ class KeystoreEncryptedPrefsRegistryEpochTest {
         val registry = seedAndCaptureRegistry()
         raw().edit().remove(fallbackRegistryName()).putString(registry.name, "not-decodable").commit()
 
+        // One instance for every commit. foldAttempts is per-instance, so
+        // reopening each time would reset it and the bound would never be
+        // reached, leaving this green against the behaviour it exists to reject.
+        val prefs = open()
         repeat(MAX_FOLD_ATTEMPTS + 2) { i ->
-            open().edit().putString("k$i", "v$i").commit()
+            prefs.edit().putString("k$i", "v$i").commit()
         }
 
         assertEquals(
@@ -302,9 +306,13 @@ class KeystoreEncryptedPrefsRegistryEpochTest {
         // separate change.
         val registry = seedAndCaptureRegistry()
         val alphaCiphertext = raw().getString(registry.alphaName, null)!!
-        raw().edit().putString(fallbackHashOfKey("beta"), alphaCiphertext).commit()
+        // Beta's own entry has to go, or neither path ever reaches the fallback
+        // probe and the assertion holds trivially.
+        val betaName = (raw().all.keys - registry.name - registry.alphaName - HMAC_KEY_PREF).single()
+        raw().edit().remove(betaName).putString(fallbackHashOfKey("beta"), alphaCiphertext).commit()
 
         val prefs = open()
+        assertEquals("the stranded entry must resolve", "1", prefs.all["beta"])
         assertEquals("enumeration must not diverge from a direct read", prefs.getString("beta", null), prefs.all["beta"])
     }
 

--- a/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsRegistryEpochTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsRegistryEpochTest.kt
@@ -48,17 +48,19 @@ class KeystoreEncryptedPrefsRegistryEpochTest {
 
     private fun open() = KeystoreEncryptedPrefs.create(context, PREFS_NAME)
 
-    /** Mirrors the store's fallback derivation so a test can name the registry the way that epoch would. */
-    private fun fallbackRegistryName(): String {
+    /** Mirrors the store's fallback derivation so a test can name an entry the way that epoch would. */
+    private fun fallbackHashOfKey(plainKey: String): String {
         val key = MessageDigest.getInstance("SHA-256")
             .digest("$DETERMINISTIC_SEED:$PREFS_NAME".toByteArray(Charsets.UTF_8))
         val mac = Mac.getInstance("HmacSHA256")
         mac.init(SecretKeySpec(key, "HmacSHA256"))
         return Base64.encodeToString(
-            mac.doFinal(KEY_REGISTRY.toByteArray(Charsets.UTF_8)),
+            mac.doFinal(plainKey.toByteArray(Charsets.UTF_8)),
             Base64.NO_WRAP or Base64.URL_SAFE
         )
     }
+
+    private fun fallbackRegistryName(): String = fallbackHashOfKey(KEY_REGISTRY)
 
     /** The registry's stored name plus two real blobs: one listing alpha, one listing alpha and beta. */
     private data class Registry(val name: String, val listingOne: String, val listingBoth: String)
@@ -183,6 +185,64 @@ class KeystoreEncryptedPrefsRegistryEpochTest {
         val visible = open().all.keys
         assertTrue(visible.contains("alpha"))
         assertTrue(visible.contains("gamma"))
+    }
+
+    @Test
+    fun aGarbageFallbackCopyDoesNotStopTheKeyListBeingMaintained() {
+        // The fallback name is derivable from the APK, so treating an
+        // undecodable copy there as a reason to stop maintaining the list hands
+        // anyone who can write to the data directory a way to freeze it. It must
+        // block only the deletion of that copy, not the rewrite.
+        seedAndCaptureRegistry()
+        raw().edit().putString(fallbackRegistryName(), "not-decodable").commit()
+
+        open().edit().putString("gamma", "3").commit()
+
+        val visible = open().all.keys
+        assertTrue("gamma must still be registered", visible.contains("gamma"))
+        assertTrue(visible.contains("alpha"))
+        assertTrue(
+            "the undecodable copy must be kept, since it may list keys held nowhere else",
+            raw().contains(fallbackRegistryName())
+        )
+    }
+
+    @Test
+    fun aFailedFoldIsRetriedRatherThanFreezingTheInstance() {
+        // Instances are long-lived, so latching a failed fold would disable
+        // registry maintenance for the rest of the process. Once the obstruction
+        // clears, the next commit must recover.
+        val registry = strandWithTruncatedCurrent()
+        raw().edit().putString(registry.name, "not-decodable").commit()
+
+        val prefs = open()
+        prefs.edit().putString("gamma", "3").commit()
+
+        // Same instance, obstruction gone: it must fold again rather than stay latched.
+        raw().edit().putString(registry.name, registry.listingBoth).commit()
+        prefs.edit().putString("delta", "4").commit()
+
+        val visible = open().all.keys
+        assertTrue("beta must be recovered once the fold can succeed", visible.contains("beta"))
+        assertTrue(visible.contains("delta"))
+    }
+
+    @Test
+    fun strandedValuesAreEnumerableNotJustTheRegistry() {
+        // A real fallback window strands the values too. Recording only the
+        // current-epoch hash leaves enumeration matching nothing, because every
+        // on-disk name is a fallback-epoch one.
+        val registry = seedAndCaptureRegistry()
+        val alphaName = raw().all.keys.first { it != registry.name && raw().getString(it, null) != null }
+        val alphaValue = raw().getString(alphaName, null)!!
+        raw().edit()
+            .remove(alphaName)
+            .putString(fallbackHashOfKey("alpha"), alphaValue)
+            .remove(registry.name)
+            .putString(fallbackRegistryName(), registry.listingBoth)
+            .commit()
+
+        assertTrue("alpha's value must be enumerable at its stranded name", open().all.keys.contains("alpha"))
     }
 
     @Test

--- a/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsRegistryEpochTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsRegistryEpochTest.kt
@@ -1,0 +1,138 @@
+package io.privkey.keep.storage
+
+import android.content.Context
+import android.util.Base64
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.security.MessageDigest
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * The key registry can itself be left under the previous derivation epoch, and
+ * that is worse than an ordinary entry being stranded.
+ *
+ * The migration away from that epoch runs only while no derivation key is
+ * persisted, so a registry written during a later fallback window keeps the old
+ * name for good. A fold that resolves only the current name then reads nothing,
+ * so every key disappears from enumeration, and the next write rewrites the
+ * registry from a cache holding just the keys that write touched. The rest are
+ * dropped from it permanently, which is silent: direct lookups still work, so
+ * nothing surfaces until something enumerates or the re-hash migration runs.
+ */
+@RunWith(AndroidJUnit4::class)
+class KeystoreEncryptedPrefsRegistryEpochTest {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun setup() = clear()
+
+    @After
+    fun teardown() = clear()
+
+    private fun clear() {
+        context.deleteSharedPreferences(PREFS_NAME)
+    }
+
+    private fun raw() = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    private fun open() = KeystoreEncryptedPrefs.create(context, PREFS_NAME)
+
+    /** Mirrors the store's fallback derivation so a test can name the registry the way that epoch would. */
+    private fun fallbackRegistryName(): String {
+        val key = MessageDigest.getInstance("SHA-256")
+            .digest("$DETERMINISTIC_SEED:$PREFS_NAME".toByteArray(Charsets.UTF_8))
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(key, "HmacSHA256"))
+        return Base64.encodeToString(
+            mac.doFinal(KEY_REGISTRY.toByteArray(Charsets.UTF_8)),
+            Base64.NO_WRAP or Base64.URL_SAFE
+        )
+    }
+
+    /**
+     * Writes two keys, then moves the registry entry to the name the fallback
+     * epoch would have used.
+     *
+     * The registry cannot be identified by name from a test, because the
+     * derivation key is per-file and secret. It is identified by behaviour
+     * instead: it is the one pre-existing entry whose stored value changes when
+     * an unrelated key is added, since every commit rewrites the key list while
+     * the other values stay byte-identical.
+     */
+    private fun strandTheRegistry() {
+        open().edit().putString("alpha", "1").commit()
+        val before = raw().all.mapValues { it.value as String }
+
+        open().edit().putString("beta", "2").commit()
+        val after = raw().all.mapValues { it.value as String }
+
+        val changed = before.keys.filter { after[it] != null && after[it] != before[it] }
+        assertEquals("expected exactly one rewritten entry, the registry", 1, changed.size)
+
+        val registryName = changed.first()
+        val registryValue = after.getValue(registryName)
+        raw().edit().remove(registryName).putString(fallbackRegistryName(), registryValue).commit()
+    }
+
+    @Test
+    fun aRegistryLeftUnderTheFallbackEpochStillEnumeratesEveryKey() {
+        strandTheRegistry()
+
+        val visible = open().all.keys
+        assertTrue("alpha must still be enumerable", visible.contains("alpha"))
+        assertTrue("beta must still be enumerable", visible.contains("beta"))
+    }
+
+    @Test
+    fun aWriteAgainstAStrandedRegistryDoesNotDropUntouchedKeys() {
+        // The damaging path: the fold reads nothing, so a write rewrites the key
+        // list from a cache that only knows the key it just wrote.
+        strandTheRegistry()
+
+        open().edit().putString("gamma", "3").commit()
+
+        val visible = open().all.keys
+        assertTrue("alpha must survive a write made against a stranded registry", visible.contains("alpha"))
+        assertTrue("beta must survive a write made against a stranded registry", visible.contains("beta"))
+        assertTrue(visible.contains("gamma"))
+    }
+
+    @Test
+    fun valuesRemainReadableAfterTheRegistryIsRecovered() {
+        strandTheRegistry()
+
+        val reopened = open()
+        assertEquals("1", reopened.getString("alpha", null))
+        assertEquals("2", reopened.getString("beta", null))
+    }
+
+    @Test
+    fun theStrandedRegistryCopyIsDroppedOnceTheCurrentOneIsWritten() {
+        strandTheRegistry()
+        assertTrue("precondition: the stranded copy exists", raw().contains(fallbackRegistryName()))
+
+        open().edit().putString("gamma", "3").commit()
+
+        assertTrue(
+            "a stale key list must not linger for the read path to fall back to",
+            !raw().contains(fallbackRegistryName())
+        )
+        val visible = open().all.keys
+        assertTrue(visible.contains("alpha"))
+        assertTrue(visible.contains("gamma"))
+    }
+
+    companion object {
+        private const val PREFS_NAME = "keystore_prefs_registry_epoch_test"
+        private const val DETERMINISTIC_SEED = "keystore_prefs_hmac_key"
+        private const val KEY_REGISTRY = "__keys__"
+    }
+}

--- a/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsRegistryEpochTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsRegistryEpochTest.kt
@@ -25,6 +25,9 @@ import javax.crypto.spec.SecretKeySpec
  * registry from a cache holding just the keys that write touched. The rest are
  * dropped from it permanently, which is silent: direct lookups still work, so
  * nothing surfaces until something enumerates or the re-hash migration runs.
+ *
+ * Tests here assert only registry-dependent behaviour. Value reads resolve a
+ * key's own name directly and would pass with or without the fix.
  */
 @RunWith(AndroidJUnit4::class)
 class KeystoreEncryptedPrefsRegistryEpochTest {
@@ -57,17 +60,21 @@ class KeystoreEncryptedPrefsRegistryEpochTest {
         )
     }
 
+    /** The registry's stored name plus two real blobs: one listing alpha, one listing alpha and beta. */
+    private data class Registry(val name: String, val listingOne: String, val listingBoth: String)
+
     /**
-     * Writes two keys, then moves the registry entry to the name the fallback
-     * epoch would have used.
+     * Writes alpha then beta and captures the registry across both commits.
      *
      * The registry cannot be identified by name from a test, because the
-     * derivation key is per-file and secret. It is identified by behaviour
-     * instead: it is the one pre-existing entry whose stored value changes when
-     * an unrelated key is added, since every commit rewrites the key list while
-     * the other values stay byte-identical.
+     * derivation key is per-file and secret. It is identified by behaviour: it
+     * is the one pre-existing entry whose stored value changes when an unrelated
+     * key is added, since every commit rewrites the key list while the other
+     * values stay byte-identical. Capturing the before and after values yields
+     * two genuine blobs, so a truncated registry can be staged later without
+     * having to forge ciphertext.
      */
-    private fun strandTheRegistry() {
+    private fun seedAndCaptureRegistry(): Registry {
         open().edit().putString("alpha", "1").commit()
         val before = raw().all.mapValues { it.value as String }
 
@@ -77,9 +84,32 @@ class KeystoreEncryptedPrefsRegistryEpochTest {
         val changed = before.keys.filter { after[it] != null && after[it] != before[it] }
         assertEquals("expected exactly one rewritten entry, the registry", 1, changed.size)
 
-        val registryName = changed.first()
-        val registryValue = after.getValue(registryName)
-        raw().edit().remove(registryName).putString(fallbackRegistryName(), registryValue).commit()
+        val name = changed.first()
+        return Registry(name, before.getValue(name), after.getValue(name))
+    }
+
+    /** Leaves the full list under the fallback name and nothing under the current one. */
+    private fun strandTheRegistry(): Registry {
+        val registry = seedAndCaptureRegistry()
+        raw().edit()
+            .remove(registry.name)
+            .putString(fallbackRegistryName(), registry.listingBoth)
+            .commit()
+        return registry
+    }
+
+    /**
+     * Leaves the full list under the fallback name and a shorter one under the
+     * current name: the state a device is already in once the truncating write
+     * has happened.
+     */
+    private fun strandWithTruncatedCurrent(): Registry {
+        val registry = seedAndCaptureRegistry()
+        raw().edit()
+            .putString(registry.name, registry.listingOne)
+            .putString(fallbackRegistryName(), registry.listingBoth)
+            .commit()
+        return registry
     }
 
     @Test
@@ -106,12 +136,37 @@ class KeystoreEncryptedPrefsRegistryEpochTest {
     }
 
     @Test
-    fun valuesRemainReadableAfterTheRegistryIsRecovered() {
-        strandTheRegistry()
+    fun aTruncatedCurrentRegistryDoesNotDiscardTheFullFallbackCopy() {
+        // Preferring the current copy would seed a partial cache from the short
+        // list and then authorize deleting the copy that still held the rest,
+        // destroying the recovery data for an already-affected device.
+        val registry = strandWithTruncatedCurrent()
+        assertTrue("precondition: a distinct copy under each name", registry.listingOne != registry.listingBoth)
+        assertTrue("precondition: current copy present", raw().contains(registry.name))
+        assertTrue("precondition: fallback copy present", raw().contains(fallbackRegistryName()))
 
-        val reopened = open()
-        assertEquals("1", reopened.getString("alpha", null))
-        assertEquals("2", reopened.getString("beta", null))
+        open().edit().putString("gamma", "3").commit()
+
+        val visible = open().all.keys
+        assertTrue("beta is only in the fallback copy and must survive", visible.contains("beta"))
+        assertTrue(visible.contains("alpha"))
+        assertTrue(visible.contains("gamma"))
+    }
+
+    @Test
+    fun anUndecodableRegistryCopyBlocksBothTheRewriteAndTheDrop() {
+        // A copy that cannot be decoded means the cache is not known to cover
+        // what is stored, so a transient decrypt failure must not be allowed to
+        // truncate the list or destroy the other copy.
+        val registry = strandWithTruncatedCurrent()
+        raw().edit().putString(registry.name, "not-decodable").commit()
+
+        open().edit().putString("gamma", "3").commit()
+
+        assertTrue(
+            "the fallback copy is the only readable record of alpha and beta; it must not be dropped",
+            raw().contains(fallbackRegistryName())
+        )
     }
 
     @Test
@@ -127,6 +182,19 @@ class KeystoreEncryptedPrefsRegistryEpochTest {
         )
         val visible = open().all.keys
         assertTrue(visible.contains("alpha"))
+        assertTrue(visible.contains("gamma"))
+    }
+
+    @Test
+    fun applyRecoversTheRegistryTheSameWayCommitDoes() {
+        // Both commit paths run the same apply logic; only commit() was covered.
+        strandTheRegistry()
+
+        open().edit().putString("gamma", "3").apply()
+        Thread.sleep(500)
+
+        val visible = open().all.keys
+        assertTrue("alpha must survive an apply() against a stranded registry", visible.contains("alpha"))
         assertTrue(visible.contains("gamma"))
     }
 

--- a/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsRegistryEpochTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsRegistryEpochTest.kt
@@ -265,7 +265,47 @@ class KeystoreEncryptedPrefsRegistryEpochTest {
             .putString(fallbackRegistryName(), registry.listingBoth)
             .commit()
 
-        assertTrue("alpha's value must be enumerable at its stranded name", open().all.keys.contains("alpha"))
+        // Assert the value, not just the key. Presence proves some decrypt
+        // succeeded; it does not prove the right entry was resolved, which is
+        // the property forward resolution is supposed to guarantee.
+        assertEquals("alpha's value must resolve at its stranded name", "1", open().all["alpha"])
+    }
+
+    @Test
+    fun anUnreadableCurrentRegistryIsNeverReplacedHoweverManyCommitsFollow() {
+        // The retry bound exists to stop paying a failing decrypt per commit. It
+        // must bound the cost only. Relaxing the guard instead would overwrite a
+        // list that a transient Keystore fault made briefly unreadable, which is
+        // the truncation this whole change exists to prevent.
+        val registry = seedAndCaptureRegistry()
+        raw().edit().remove(fallbackRegistryName()).putString(registry.name, "not-decodable").commit()
+
+        repeat(MAX_FOLD_ATTEMPTS + 2) { i ->
+            open().edit().putString("k$i", "v$i").commit()
+        }
+
+        assertEquals(
+            "an unreadable registry must survive any number of commits",
+            "not-decodable",
+            raw().getString(registry.name, null)
+        )
+    }
+
+    @Test
+    fun enumerationAgreesWithDirectReads() {
+        // Enumeration used to resolve stored names through a reverse table while
+        // the typed getters recomputed the hash, so the two could disagree and
+        // enumeration could serve a superseded or transplanted entry. They must
+        // now resolve identically. This does not assert that a transplanted
+        // value is rejected: resolving a stranded entry by probing the previous
+        // epoch is deliberate, and binding a ciphertext to its key name is a
+        // separate change.
+        val registry = seedAndCaptureRegistry()
+        val alphaCiphertext = raw().getString(registry.alphaName, null)!!
+        raw().edit().putString(fallbackHashOfKey("beta"), alphaCiphertext).commit()
+
+        val prefs = open()
+        assertEquals("enumeration must not diverge from a direct read", prefs.getString("beta", null), prefs.all["beta"])
     }
 
     @Test
@@ -287,5 +327,6 @@ class KeystoreEncryptedPrefsRegistryEpochTest {
         private const val DETERMINISTIC_SEED = "keystore_prefs_hmac_key"
         private const val KEY_REGISTRY = "__keys__"
         private const val HMAC_KEY_PREF = "__hmac_key__"
+        private const val MAX_FOLD_ATTEMPTS = 3
     }
 }

--- a/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsRegistryEpochTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsRegistryEpochTest.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -63,7 +64,12 @@ class KeystoreEncryptedPrefsRegistryEpochTest {
     private fun fallbackRegistryName(): String = fallbackHashOfKey(KEY_REGISTRY)
 
     /** The registry's stored name plus two real blobs: one listing alpha, one listing alpha and beta. */
-    private data class Registry(val name: String, val listingOne: String, val listingBoth: String)
+    private data class Registry(
+        val name: String,
+        val alphaName: String,
+        val listingOne: String,
+        val listingBoth: String
+    )
 
     /**
      * Writes alpha then beta and captures the registry across both commits.
@@ -87,7 +93,17 @@ class KeystoreEncryptedPrefsRegistryEpochTest {
         assertEquals("expected exactly one rewritten entry, the registry", 1, changed.size)
 
         val name = changed.first()
-        return Registry(name, before.getValue(name), after.getValue(name))
+        // Pin the epochs apart. If the derivation key ever failed to persist in
+        // the test environment the two names would collide, every stranding
+        // helper below would degenerate into a plain overwrite, and the whole
+        // class would pass without testing anything.
+        assertNotEquals("current and fallback registry names must differ", fallbackRegistryName(), name)
+
+        // Alpha's stored name, by elimination rather than by picking from an
+        // unordered key set: the only entries after the first write are the HMAC
+        // key under its literal name, alpha, and the registry.
+        val alphaName = (before.keys - name - HMAC_KEY_PREF).single()
+        return Registry(name, alphaName, before.getValue(name), after.getValue(name))
     }
 
     /** Leaves the full list under the fallback name and nothing under the current one. */
@@ -169,6 +185,14 @@ class KeystoreEncryptedPrefsRegistryEpochTest {
             "the fallback copy is the only readable record of alpha and beta; it must not be dropped",
             raw().contains(fallbackRegistryName())
         )
+        // Assert the rewrite was blocked too. Without this the test passes with
+        // either guard reverted, because each one alone still prevents the drop,
+        // so neither is actually covered.
+        assertEquals(
+            "an unreadable current copy must not be overwritten from a cache that may not cover it",
+            "not-decodable",
+            raw().getString(registry.name, null)
+        )
     }
 
     @Test
@@ -233,10 +257,9 @@ class KeystoreEncryptedPrefsRegistryEpochTest {
         // current-epoch hash leaves enumeration matching nothing, because every
         // on-disk name is a fallback-epoch one.
         val registry = seedAndCaptureRegistry()
-        val alphaName = raw().all.keys.first { it != registry.name && raw().getString(it, null) != null }
-        val alphaValue = raw().getString(alphaName, null)!!
+        val alphaValue = raw().getString(registry.alphaName, null)!!
         raw().edit()
-            .remove(alphaName)
+            .remove(registry.alphaName)
             .putString(fallbackHashOfKey("alpha"), alphaValue)
             .remove(registry.name)
             .putString(fallbackRegistryName(), registry.listingBoth)
@@ -250,8 +273,9 @@ class KeystoreEncryptedPrefsRegistryEpochTest {
         // Both commit paths run the same apply logic; only commit() was covered.
         strandTheRegistry()
 
+        // apply() updates the in-memory map synchronously and the same cached
+        // instance is read back, so no wait is needed here.
         open().edit().putString("gamma", "3").apply()
-        Thread.sleep(500)
 
         val visible = open().all.keys
         assertTrue("alpha must survive an apply() against a stranded registry", visible.contains("alpha"))
@@ -262,5 +286,6 @@ class KeystoreEncryptedPrefsRegistryEpochTest {
         private const val PREFS_NAME = "keystore_prefs_registry_epoch_test"
         private const val DETERMINISTIC_SEED = "keystore_prefs_hmac_key"
         private const val KEY_REGISTRY = "__keys__"
+        private const val HMAC_KEY_PREF = "__hmac_key__"
     }
 }

--- a/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
@@ -130,6 +130,16 @@ object KeystoreEncryptedPrefs {
         /// second writer proceed against a half-filled cache and persist the very
         /// truncation this exists to prevent.
         private var registrySeeded = false
+
+        /**
+         * Whether every registry copy found on disk was decoded successfully.
+         *
+         * The key cache is only a superset of what is stored when this holds. If
+         * a copy was present but unreadable, rewriting the list from the cache
+         * would truncate it, and dropping the other copy would destroy the one
+         * record of the missing keys, so both are skipped until a fold succeeds.
+         */
+        private var registryFoldComplete = false
         @Volatile
         private var hmacKey: ByteArray? = null
         private val listenerMap = ConcurrentHashMap<SharedPreferences.OnSharedPreferenceChangeListener, SharedPreferences.OnSharedPreferenceChangeListener>()
@@ -321,49 +331,82 @@ object KeystoreEncryptedPrefs {
         /// registry.
         private fun ensureRegistrySeeded() {
             if (registrySeeded) return
-            rebuildKeyCacheFromRegistry()
+            registryFoldComplete = rebuildKeyCacheFromRegistry()
             registrySeeded = true
         }
 
-        /**
-         * Reads the registry blob, falling back to the previous derivation
-         * epoch's name for it.
-         *
-         * The migration away from that epoch runs only while no derivation key
-         * is persisted yet, so a registry written during a later fallback window
-         * keeps the old name and is never moved. Resolving only the current name
-         * leaves the fold with nothing to read, which is not merely a listing
-         * gap: the next write rewrites the registry from a cache holding just
-         * the keys that write touched, dropping every other key from it for good.
-         */
-        private fun readRegistryBlob(): String? {
-            val currentHash = calculateKeyHash(KEY_REGISTRY)
-            basePrefs.getString(currentHash, null)?.let { return it }
-            val fallbackHash = hmacWithKey(KEY_REGISTRY, deterministicHmacKey())
-            if (fallbackHash == currentHash) return null
-            // Deliberately a read, not a relocation. The registry is the index
-            // every lookup resolves through, so moving it here could race a
-            // concurrent reader; the next commit rewrites it under the current
-            // name and drops this copy from inside the serialized commit path.
-            return basePrefs.getString(fallbackHash, null)
+        private fun fallbackHashOf(plainKey: String): String =
+            hmacWithKey(plainKey, deterministicHmacKey())
+
+        /** Decodes a registry blob into its plain key list, or null if it cannot be read. */
+        private fun decodeRegistry(blob: String): List<String>? = try {
+            val decrypted = decrypt(secretKey, blob)
+            if (!decrypted.startsWith(PREFIX_STRING)) {
+                null
+            } else {
+                decrypted.removePrefix(PREFIX_STRING)
+                    .split(KEY_REGISTRY_DELIMITER)
+                    .filter { it.isNotEmpty() && it != KEY_REGISTRY }
+            }
+        } catch (e: Exception) {
+            if (BuildConfig.DEBUG) Log.w("KeystoreEncryptedPrefs", "Registry copy unreadable", e)
+            null
         }
 
-        private fun rebuildKeyCacheFromRegistry() {
-            val encryptedRegistry = readRegistryBlob() ?: return
-            try {
-                val decrypted = decrypt(secretKey, encryptedRegistry)
-                if (!decrypted.startsWith(PREFIX_STRING)) return
-                val registryContent = decrypted.removePrefix(PREFIX_STRING)
-                if (registryContent.isEmpty()) return
-                for (plainKey in registryContent.split(KEY_REGISTRY_DELIMITER)) {
-                    if (plainKey.isEmpty() || plainKey == KEY_REGISTRY) continue
+        /**
+         * Seeds the key cache from every registry copy on disk, unioning them.
+         *
+         * The migration off the previous derivation epoch runs only while no
+         * derivation key is persisted yet, so a registry written during a later
+         * fallback window keeps the old name and is never moved.
+         *
+         * Both names are read rather than preferring the current one, because
+         * the damaging state has a copy under each: a device that already
+         * performed the truncating write this fixes has a short list under the
+         * current name and the full list under the fallback. Reading only the
+         * current one would seed a partial cache and then authorize deleting the
+         * copy that still held the missing keys.
+         *
+         * @return true when every copy present was decoded, meaning the cache is
+         *   a superset of what is stored and may safely be written back.
+         */
+        private fun rebuildKeyCacheFromRegistry(): Boolean {
+            val currentHash = calculateKeyHash(KEY_REGISTRY)
+            val fallbackHash = fallbackHashOf(KEY_REGISTRY)
+            val names = if (fallbackHash == currentHash) listOf(currentHash) else listOf(currentHash, fallbackHash)
+
+            var found = false
+            var allReadable = true
+            for (name in names) {
+                val blob = basePrefs.getString(name, null) ?: continue
+                found = true
+                val plainKeys = decodeRegistry(blob)
+                if (plainKeys == null) {
+                    allReadable = false
+                    continue
+                }
+                for (plainKey in plainKeys) {
                     val hash = calculateKeyHash(plainKey)
                     keyCache[plainKey] = hash
                     reverseKeyCache[hash] = plainKey
                 }
-            } catch (e: Exception) {
-                if (BuildConfig.DEBUG) Log.w("KeystoreEncryptedPrefs", "Registry corrupted, will rebuild as keys are accessed", e)
             }
+
+            if (!found && names.size > 1) {
+                // A commit writes the current name and removes the fallback in one
+                // editor, so a read interleaved between the two lookups above can
+                // see neither. Re-read before concluding there is no registry:
+                // concluding that wrongly is what authorizes the truncating write.
+                basePrefs.getString(currentHash, null)?.let { blob ->
+                    val plainKeys = decodeRegistry(blob) ?: return false
+                    for (plainKey in plainKeys) {
+                        val hash = calculateKeyHash(plainKey)
+                        keyCache[plainKey] = hash
+                        reverseKeyCache[hash] = plainKey
+                    }
+                }
+            }
+            return allReadable
         }
 
         override fun getAll(): MutableMap<String, *> {
@@ -606,6 +649,13 @@ object KeystoreEncryptedPrefs {
             private fun updateKeyRegistry() {
                 val allKeys = keyCache.keys.filter { it != KEY_REGISTRY }.toSet()
                 if (allKeys.isEmpty() && clearRequested) return
+                // A copy was present but could not be decoded, so the cache is not
+                // known to cover everything stored. Rewriting the list from it
+                // would drop whatever that copy held, and a transient Keystore
+                // decrypt failure would turn a recoverable state into permanent
+                // loss of the key list. Leave every copy alone; the keys stay
+                // directly readable, and a later fold can still recover.
+                if (!registryFoldComplete) return
                 val registryContent = allKeys.joinToString(KEY_REGISTRY_DELIMITER)
                 val encKey = getEncryptedKeyName(KEY_REGISTRY)
                 val encValue = encryptValue(registryContent)
@@ -614,7 +664,7 @@ object KeystoreEncryptedPrefs {
                 // stranded under the previous epoch. The read path falls back to
                 // that name, and leaving it would let a stale key list resurface
                 // the moment the current one became unreadable.
-                val fallbackHash = hmacWithKey(KEY_REGISTRY, deterministicHmacKey())
+                val fallbackHash = fallbackHashOf(KEY_REGISTRY)
                 if (fallbackHash != encKey && basePrefs.contains(fallbackHash)) {
                     baseEditor.remove(fallbackHash)
                 }

--- a/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
@@ -24,7 +24,7 @@ object KeystoreEncryptedPrefs {
 
     private val initLocks = ConcurrentHashMap<String, Any>()
     private fun initLockFor(prefsName: String): Any =
-        initLocks.getOrPut(prefsName) { Any() }
+        initLocks.computeIfAbsent(prefsName) { Any() }
 
     private const val ANDROID_KEYSTORE = "AndroidKeyStore"
     private const val KEY_ALIAS_PREFIX = "keep_prefs_"
@@ -46,10 +46,13 @@ object KeystoreEncryptedPrefs {
     private const val DETERMINISTIC_HMAC_SEED = "keystore_prefs_hmac_key"
 
     /** Sanity bounds on a decoded registry, whose contents are not bound to its location. */
-    private const val MAX_KEY_NAME_LENGTH = 256
+    // Above anything production writes: the longest real names are a fixed
+    // prefix plus a 255-char package name. A legitimate key filtered here would
+    // be silently dropped from the list on the next rewrite.
+    private const val MAX_KEY_NAME_LENGTH = 512
     private const val MAX_REGISTRY_ENTRIES = 4096
 
-    /** Refolds tolerated before an unreadable current registry is replaced rather than retried forever. */
+    /** Refolds tolerated before an unreadable current registry stops being retried. */
     private const val MAX_FOLD_ATTEMPTS = 3
 
     fun create(context: Context, prefsName: String): SharedPreferences {
@@ -350,32 +353,30 @@ object KeystoreEncryptedPrefs {
         /// under one derivation key and hash its names under a newer one, caching
         /// hashes that point nowhere and writing cleared names back into the
         /// registry.
-        private fun ensureRegistrySeeded() {
+        /**
+         * @param countAttempt whether a failed fold counts toward the retry
+         *   bound. Only the commit path passes true: a read must not be able to
+         *   spend the budget and change what a later write is allowed to do.
+         */
+        private fun ensureRegistrySeeded(countAttempt: Boolean = false) {
             if (registrySeeded) return
             rebuildKeyCacheFromRegistry()
-            // Latch only once the current copy read cleanly. Latching regardless
-            // would let one transient Keystore decrypt failure freeze registry
-            // maintenance for the lifetime of this wrapper, and these are
-            // long-lived: the storage adapters hold one for the whole process.
-            // That steady state is worse than the truncation being fixed, so a
-            // failed fold is retried on the next commit instead.
             if (currentRegistryReadable) {
                 registrySeeded = true
                 foldAttempts = 0
                 return
             }
-            // Bound the retry. One overwrite of the current copy, which is
-            // identifiable as the entry rewritten on every commit, would
-            // otherwise buy a failing Keystore round trip per commit forever,
-            // taken under this monitor on the signing path, while newly written
-            // keys go unregistered the whole time. After a few attempts accept
-            // whichever list did decode and let it replace the unreadable copy:
-            // that copy is already unrecoverable, so nothing readable is lost.
-            if (++foldAttempts >= MAX_FOLD_ATTEMPTS) {
-                if (BuildConfig.DEBUG) Log.w("KeystoreEncryptedPrefs", "Registry unreadable after $foldAttempts folds; replacing it")
-                currentRegistryReadable = true
+            // Bound the cost, never the guard. An unreadable copy would
+            // otherwise buy a failing Keystore round trip on every commit, taken
+            // under this monitor on the signing path. Stop re-folding, but keep
+            // refusing to rewrite: forcing the rewrite here would truncate the
+            // very list this exists to protect, on an assumption the code cannot
+            // check, since a decrypt failure may be transient. A new instance
+            // folds again, so a transient fault still recovers on the next
+            // process rather than being made permanent now.
+            if (countAttempt && ++foldAttempts >= MAX_FOLD_ATTEMPTS) {
+                if (BuildConfig.DEBUG) Log.w("KeystoreEncryptedPrefs", "Registry unreadable after $foldAttempts folds; stopping retries")
                 registrySeeded = true
-                foldAttempts = 0
             }
         }
 
@@ -383,34 +384,50 @@ object KeystoreEncryptedPrefs {
             hmacWithKey(plainKey, deterministicHmacKey())
 
         /**
-         * Decodes a registry blob into its plain key list, or null if it cannot
-         * be read.
+         * The outcome of reading one registry copy.
+         *
+         * [Malformed] and [Unreadable] must not be conflated. A blob that
+         * decrypted but is not a registry is deterministically wrong, so
+         * replacing it loses nothing that could ever be read back. A blob that
+         * would not decrypt may be a transient Keystore fault, and overwriting
+         * it would destroy a list that was about to become readable again.
+         */
+        private sealed interface RegistryRead {
+            /** [complete] is false when entries were dropped as implausible, so the cache does not cover the copy. */
+            data class Decoded(val keys: List<String>, val complete: Boolean) : RegistryRead
+            object Malformed : RegistryRead
+            object Unreadable : RegistryRead
+        }
+
+        /**
+         * Decodes one registry copy.
          *
          * Decrypting successfully is not enough to trust the contents. Values
-         * carry no associated data, so any string value from this file
-         * decrypts here just as well, and the registry's own location is
-         * derivable from the APK for the fallback epoch. A transplanted value
-         * would otherwise have each of its fragments adopted as a key name and
-         * written into the real registry on the next commit, where nothing ever
-         * removes them. Entries that do not look like key names are dropped, and
-         * an implausible count rejects the blob outright.
+         * carry no associated data, so any string value from this file decrypts
+         * here just as well, and the fallback copy's location is derivable from
+         * the APK. Without bounds, a transplanted value would have each of its
+         * fragments adopted as a key name and written into the real registry on
+         * the next commit, where nothing ever removes them.
          */
-        private fun decodeRegistry(blob: String): List<String>? = try {
+        private fun decodeRegistry(blob: String): RegistryRead = try {
             val decrypted = decrypt(secretKey, blob)
             if (!decrypted.startsWith(PREFIX_STRING)) {
-                null
+                RegistryRead.Malformed
             } else {
                 val parts = decrypted.removePrefix(PREFIX_STRING)
                     .split(KEY_REGISTRY_DELIMITER)
                     .filter { it.isNotEmpty() && it != KEY_REGISTRY }
-                when {
-                    parts.size > MAX_REGISTRY_ENTRIES -> null
-                    else -> parts.filter { it.length <= MAX_KEY_NAME_LENGTH && it.none(Char::isISOControl) }
+                val kept = parts
+                    .filter { it.length <= MAX_KEY_NAME_LENGTH && it.none(Char::isISOControl) }
+                    .take(MAX_REGISTRY_ENTRIES)
+                if (kept.size != parts.size && BuildConfig.DEBUG) {
+                    Log.w("KeystoreEncryptedPrefs", "Dropped ${parts.size - kept.size} implausible registry entries")
                 }
+                RegistryRead.Decoded(kept, complete = kept.size == parts.size)
             }
         } catch (e: Exception) {
-            if (BuildConfig.DEBUG) Log.w("KeystoreEncryptedPrefs", "Registry copy unreadable", e)
-            null
+            if (BuildConfig.DEBUG) Log.w("KeystoreEncryptedPrefs", "Registry copy could not be decrypted", e)
+            RegistryRead.Unreadable
         }
 
         /**
@@ -440,13 +457,27 @@ object KeystoreEncryptedPrefs {
             for (name in names) {
                 val blob = basePrefs.getString(name, null) ?: continue
                 found = true
-                val plainKeys = decodeRegistry(blob)
-                if (plainKeys == null) {
-                    allReadable = false
-                    if (name == currentHash) currentReadable = false
-                    continue
+                when (val read = decodeRegistry(blob)) {
+                    is RegistryRead.Decoded -> {
+                        read.keys.forEach { cacheRegistryKey(it) }
+                        if (!read.complete) {
+                            // Entries were dropped, so the cache does not cover
+                            // what this copy listed. Rewriting from it now would
+                            // deregister them permanently.
+                            allReadable = false
+                            if (name == currentHash) currentReadable = false
+                        }
+                    }
+                    // Decrypted but not a registry, which no retry can change.
+                    // Replacing it loses nothing that could ever be read back.
+                    RegistryRead.Malformed -> allReadable = false
+                    // May be a transient Keystore fault. Preserve it: a copy that
+                    // is about to become readable again must not be overwritten.
+                    RegistryRead.Unreadable -> {
+                        allReadable = false
+                        if (name == currentHash) currentReadable = false
+                    }
                 }
-                plainKeys.forEach { cacheRegistryKey(it) }
             }
 
             if (!found && names.size > 1) {
@@ -455,12 +486,13 @@ object KeystoreEncryptedPrefs {
                 // see neither. Re-read before concluding there is no registry:
                 // concluding that wrongly is what authorizes the truncating write.
                 basePrefs.getString(currentHash, null)?.let { blob ->
-                    val plainKeys = decodeRegistry(blob)
-                    if (plainKeys == null) {
-                        currentReadable = false
-                        allReadable = false
-                    } else {
-                        plainKeys.forEach { cacheRegistryKey(it) }
+                    when (val read = decodeRegistry(blob)) {
+                        is RegistryRead.Decoded -> {
+                            read.keys.forEach { cacheRegistryKey(it) }
+                            if (!read.complete) { currentReadable = false; allReadable = false }
+                        }
+                        RegistryRead.Malformed -> allReadable = false
+                        RegistryRead.Unreadable -> { currentReadable = false; allReadable = false }
                     }
                 }
             }
@@ -512,12 +544,12 @@ object KeystoreEncryptedPrefs {
                     stored.containsKey(currentName) -> currentName
                     else -> fallbackHashOf(plainKey).takeIf { it != currentName && stored.containsKey(it) }
                 } ?: continue
-                val encValue = stored[name] ?: continue
+                // Only encrypted String entries. Anything else was never written
+                // by this class, and returning it verbatim would hand back
+                // unauthenticated data placed at a derivable name.
+                val encValue = stored[name] as? String ?: continue
                 try {
-                    result[plainKey] = when (encValue) {
-                        is String -> decryptValue(encValue)
-                        else -> encValue
-                    }
+                    result[plainKey] = decryptValue(encValue)
                 } catch (e: Exception) {
                     if (BuildConfig.DEBUG) Log.w("KeystoreEncryptedPrefs", "Failed to decrypt value for key $plainKey", e)
                     continue
@@ -710,7 +742,7 @@ object KeystoreEncryptedPrefs {
                     // hash. For the rate-limiter store that means a package's
                     // usage counters and cooling-off entries silently stop being
                     // found, which reads as "no usage yet".
-                    ensureRegistrySeeded()
+                    ensureRegistrySeeded(countAttempt = true)
                 }
 
                 for (plainKey in pendingRemoves) {
@@ -754,7 +786,13 @@ object KeystoreEncryptedPrefs {
             }
 
             private fun updateKeyRegistry() {
-                val allKeys = keyCache.keys.filter { it != KEY_REGISTRY }.toSet()
+                // Same bounds the reader enforces. Writing a list the reader
+                // would refuse to decode lets the store invalidate its own state.
+                val allKeys = keyCache.keys
+                    .filter { it != KEY_REGISTRY && it.length <= MAX_KEY_NAME_LENGTH && it.none(Char::isISOControl) }
+                    .sorted()
+                    .take(MAX_REGISTRY_ENTRIES)
+                    .toSet()
                 if (allKeys.isEmpty() && clearRequested) return
                 // The current copy was present but could not be decoded, so the
                 // cache is not known to cover what it listed and rewriting from

--- a/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
@@ -551,7 +551,10 @@ object KeystoreEncryptedPrefs {
                 try {
                     result[plainKey] = decryptValue(encValue)
                 } catch (e: Exception) {
-                    if (BuildConfig.DEBUG) Log.w("KeystoreEncryptedPrefs", "Failed to decrypt value for key $plainKey", e)
+                    // The stored name, not the plaintext one: these files key on
+                    // caller package names, which are hashed before logging
+                    // elsewhere, so logging them here would undo that.
+                    if (BuildConfig.DEBUG) Log.w("KeystoreEncryptedPrefs", "Failed to decrypt value for stored key $name", e)
                     continue
                 }
             }
@@ -786,13 +789,13 @@ object KeystoreEncryptedPrefs {
             }
 
             private fun updateKeyRegistry() {
-                // Same bounds the reader enforces. Writing a list the reader
-                // would refuse to decode lets the store invalidate its own state.
-                val allKeys = keyCache.keys
-                    .filter { it != KEY_REGISTRY && it.length <= MAX_KEY_NAME_LENGTH && it.none(Char::isISOControl) }
-                    .sorted()
-                    .take(MAX_REGISTRY_ENTRIES)
-                    .toSet()
+                // Deliberately unfiltered. Narrowing the list here would persist
+                // a strict subset of what the read gate just certified the cache
+                // covers, silently deregistering the difference: the same bug
+                // this change exists to fix, through a second door. If a list
+                // ever exceeds the reader's bounds, the reader reports it
+                // incomplete and the rewrite is skipped, which is conservative.
+                val allKeys = keyCache.keys.filter { it != KEY_REGISTRY }.toSet()
                 if (allKeys.isEmpty() && clearRequested) return
                 // The current copy was present but could not be decoded, so the
                 // cache is not known to cover what it listed and rewriting from

--- a/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
@@ -325,9 +325,31 @@ object KeystoreEncryptedPrefs {
             registrySeeded = true
         }
 
+        /**
+         * Reads the registry blob, falling back to the previous derivation
+         * epoch's name for it.
+         *
+         * The migration away from that epoch runs only while no derivation key
+         * is persisted yet, so a registry written during a later fallback window
+         * keeps the old name and is never moved. Resolving only the current name
+         * leaves the fold with nothing to read, which is not merely a listing
+         * gap: the next write rewrites the registry from a cache holding just
+         * the keys that write touched, dropping every other key from it for good.
+         */
+        private fun readRegistryBlob(): String? {
+            val currentHash = calculateKeyHash(KEY_REGISTRY)
+            basePrefs.getString(currentHash, null)?.let { return it }
+            val fallbackHash = hmacWithKey(KEY_REGISTRY, deterministicHmacKey())
+            if (fallbackHash == currentHash) return null
+            // Deliberately a read, not a relocation. The registry is the index
+            // every lookup resolves through, so moving it here could race a
+            // concurrent reader; the next commit rewrites it under the current
+            // name and drops this copy from inside the serialized commit path.
+            return basePrefs.getString(fallbackHash, null)
+        }
+
         private fun rebuildKeyCacheFromRegistry() {
-            val registryHash = calculateKeyHash(KEY_REGISTRY)
-            val encryptedRegistry = basePrefs.getString(registryHash, null) ?: return
+            val encryptedRegistry = readRegistryBlob() ?: return
             try {
                 val decrypted = decrypt(secretKey, encryptedRegistry)
                 if (!decrypted.startsWith(PREFIX_STRING)) return
@@ -588,6 +610,14 @@ object KeystoreEncryptedPrefs {
                 val encKey = getEncryptedKeyName(KEY_REGISTRY)
                 val encValue = encryptValue(registryContent)
                 baseEditor.putString(encKey, encValue)
+                // The current name now carries the full list, so drop a registry
+                // stranded under the previous epoch. The read path falls back to
+                // that name, and leaving it would let a stale key list resurface
+                // the moment the current one became unreadable.
+                val fallbackHash = hmacWithKey(KEY_REGISTRY, deterministicHmacKey())
+                if (fallbackHash != encKey && basePrefs.contains(fallbackHash)) {
+                    baseEditor.remove(fallbackHash)
+                }
             }
         }
     }

--- a/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
@@ -132,14 +132,25 @@ object KeystoreEncryptedPrefs {
         private var registrySeeded = false
 
         /**
-         * Whether every registry copy found on disk was decoded successfully.
+         * Whether the current name's registry was absent or decoded cleanly.
          *
-         * The key cache is only a superset of what is stored when this holds. If
-         * a copy was present but unreadable, rewriting the list from the cache
-         * would truncate it, and dropping the other copy would destroy the one
-         * record of the missing keys, so both are skipped until a fold succeeds.
+         * Rewriting the list is safe exactly then, because the cache covers
+         * everything that copy listed. If it was present and unreadable the
+         * rewrite would truncate it, so the rewrite is skipped.
          */
-        private var registryFoldComplete = false
+        private var currentRegistryReadable = false
+
+        /**
+         * Whether every registry copy found on disk decoded successfully.
+         *
+         * Only then may the stale copy be dropped: an undecodable copy may list
+         * keys held nowhere else, and deleting it destroys the one record of
+         * them. Kept separate from [currentRegistryReadable] on purpose. Gating
+         * the rewrite on this too would let a single planted value at the
+         * fallback name, which is derivable from the APK, stop the key list
+         * being maintained at all.
+         */
+        private var allRegistriesReadable = false
         @Volatile
         private var hmacKey: ByteArray? = null
         private val listenerMap = ConcurrentHashMap<SharedPreferences.OnSharedPreferenceChangeListener, SharedPreferences.OnSharedPreferenceChangeListener>()
@@ -331,8 +342,14 @@ object KeystoreEncryptedPrefs {
         /// registry.
         private fun ensureRegistrySeeded() {
             if (registrySeeded) return
-            registryFoldComplete = rebuildKeyCacheFromRegistry()
-            registrySeeded = true
+            rebuildKeyCacheFromRegistry()
+            // Latch only once the current copy read cleanly. Latching regardless
+            // would let one transient Keystore decrypt failure freeze registry
+            // maintenance for the lifetime of this wrapper, and these are
+            // long-lived: the storage adapters hold one for the whole process.
+            // That steady state is worse than the truncation being fixed, so a
+            // failed fold is retried on the next commit instead.
+            if (currentRegistryReadable) registrySeeded = true
         }
 
         private fun fallbackHashOf(plainKey: String): String =
@@ -367,15 +384,15 @@ object KeystoreEncryptedPrefs {
          * current one would seed a partial cache and then authorize deleting the
          * copy that still held the missing keys.
          *
-         * @return true when every copy present was decoded, meaning the cache is
-         *   a superset of what is stored and may safely be written back.
+         * Sets [currentRegistryReadable] and [allRegistriesReadable].
          */
-        private fun rebuildKeyCacheFromRegistry(): Boolean {
+        private fun rebuildKeyCacheFromRegistry() {
             val currentHash = calculateKeyHash(KEY_REGISTRY)
             val fallbackHash = fallbackHashOf(KEY_REGISTRY)
             val names = if (fallbackHash == currentHash) listOf(currentHash) else listOf(currentHash, fallbackHash)
 
             var found = false
+            var currentReadable = true
             var allReadable = true
             for (name in names) {
                 val blob = basePrefs.getString(name, null) ?: continue
@@ -383,13 +400,10 @@ object KeystoreEncryptedPrefs {
                 val plainKeys = decodeRegistry(blob)
                 if (plainKeys == null) {
                     allReadable = false
+                    if (name == currentHash) currentReadable = false
                     continue
                 }
-                for (plainKey in plainKeys) {
-                    val hash = calculateKeyHash(plainKey)
-                    keyCache[plainKey] = hash
-                    reverseKeyCache[hash] = plainKey
-                }
+                plainKeys.forEach { cacheRegistryKey(it) }
             }
 
             if (!found && names.size > 1) {
@@ -398,15 +412,38 @@ object KeystoreEncryptedPrefs {
                 // see neither. Re-read before concluding there is no registry:
                 // concluding that wrongly is what authorizes the truncating write.
                 basePrefs.getString(currentHash, null)?.let { blob ->
-                    val plainKeys = decodeRegistry(blob) ?: return false
-                    for (plainKey in plainKeys) {
-                        val hash = calculateKeyHash(plainKey)
-                        keyCache[plainKey] = hash
-                        reverseKeyCache[hash] = plainKey
+                    val plainKeys = decodeRegistry(blob)
+                    if (plainKeys == null) {
+                        currentReadable = false
+                        allReadable = false
+                    } else {
+                        plainKeys.forEach { cacheRegistryKey(it) }
                     }
                 }
             }
-            return allReadable
+            currentRegistryReadable = currentReadable
+            allRegistriesReadable = allReadable
+        }
+
+        /**
+         * Maps a registry-listed key to the name it is actually stored under.
+         *
+         * A fallback window strands the values as well as the registry, so
+         * recording only the current-epoch hash is not enough: enumeration maps
+         * stored names back through the reverse cache, and the on-disk names
+         * would all be fallback-epoch ones and match nothing. Both names are
+         * recorded so either resolves. The forward entry stays on the current
+         * hash, so writes land there and the stranded copy is dropped by
+         * `dropFallbackCopy`.
+         */
+        private fun cacheRegistryKey(plainKey: String) {
+            val hash = calculateKeyHash(plainKey)
+            keyCache[plainKey] = hash
+            reverseKeyCache[hash] = plainKey
+            val fallbackName = fallbackHashOf(plainKey)
+            if (fallbackName != hash && basePrefs.contains(fallbackName)) {
+                reverseKeyCache[fallbackName] = plainKey
+            }
         }
 
         override fun getAll(): MutableMap<String, *> {
@@ -592,6 +629,13 @@ object KeystoreEncryptedPrefs {
                     keyCache.clear()
                     reverseKeyCache.clear()
                     hmacKey = null
+                    // Nothing on disk survives a clear, so the emptied cache is
+                    // the intended list rather than an incomplete read of an
+                    // older one. Without this a clear followed by a put in the
+                    // same editor would take the guard below and write no
+                    // registry at all, leaving the put unlisted.
+                    currentRegistryReadable = true
+                    allRegistriesReadable = true
                 } else {
                     // Fold in what is already on disk before the registry is
                     // rewritten below from the in-memory cache. Without this, the
@@ -649,13 +693,11 @@ object KeystoreEncryptedPrefs {
             private fun updateKeyRegistry() {
                 val allKeys = keyCache.keys.filter { it != KEY_REGISTRY }.toSet()
                 if (allKeys.isEmpty() && clearRequested) return
-                // A copy was present but could not be decoded, so the cache is not
-                // known to cover everything stored. Rewriting the list from it
-                // would drop whatever that copy held, and a transient Keystore
-                // decrypt failure would turn a recoverable state into permanent
-                // loss of the key list. Leave every copy alone; the keys stay
-                // directly readable, and a later fold can still recover.
-                if (!registryFoldComplete) return
+                // The current copy was present but could not be decoded, so the
+                // cache is not known to cover what it listed and rewriting from
+                // it would truncate. Leave it; the keys stay directly readable,
+                // and the next commit re-folds and can still recover.
+                if (!currentRegistryReadable) return
                 val registryContent = allKeys.joinToString(KEY_REGISTRY_DELIMITER)
                 val encKey = getEncryptedKeyName(KEY_REGISTRY)
                 val encValue = encryptValue(registryContent)
@@ -665,7 +707,7 @@ object KeystoreEncryptedPrefs {
                 // that name, and leaving it would let a stale key list resurface
                 // the moment the current one became unreadable.
                 val fallbackHash = fallbackHashOf(KEY_REGISTRY)
-                if (fallbackHash != encKey && basePrefs.contains(fallbackHash)) {
+                if (allRegistriesReadable && fallbackHash != encKey && basePrefs.contains(fallbackHash)) {
                     baseEditor.remove(fallbackHash)
                 }
             }

--- a/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
@@ -45,6 +45,13 @@ object KeystoreEncryptedPrefs {
     private const val HMAC_KEY_LENGTH = 32
     private const val DETERMINISTIC_HMAC_SEED = "keystore_prefs_hmac_key"
 
+    /** Sanity bounds on a decoded registry, whose contents are not bound to its location. */
+    private const val MAX_KEY_NAME_LENGTH = 256
+    private const val MAX_REGISTRY_ENTRIES = 4096
+
+    /** Refolds tolerated before an unreadable current registry is replaced rather than retried forever. */
+    private const val MAX_FOLD_ATTEMPTS = 3
+
     fun create(context: Context, prefsName: String): SharedPreferences {
         val keyAlias = KEY_ALIAS_PREFIX + prefsName
         val secretKey = getOrCreateKey(context, keyAlias)
@@ -130,6 +137,9 @@ object KeystoreEncryptedPrefs {
         /// second writer proceed against a half-filled cache and persist the very
         /// truncation this exists to prevent.
         private var registrySeeded = false
+
+        /** Failed folds so far; bounds the retry so an unreadable copy cannot cost a decrypt per commit forever. */
+        private var foldAttempts = 0
 
         /**
          * Whether the current name's registry was absent or decoded cleanly.
@@ -309,7 +319,7 @@ object KeystoreEncryptedPrefs {
             // relocation racing that lookup could leave readers and writers
             // disagreeing about where the index lives.
             if (plainKey == KEY_REGISTRY) return null
-            val fallbackHash = hmacWithKey(plainKey, deterministicHmacKey())
+            val fallbackHash = fallbackHashOf(plainKey)
             if (fallbackHash == hash || !basePrefs.contains(fallbackHash)) return null
 
             val relocated = synchronized(initLockFor(prefsName)) {
@@ -349,21 +359,54 @@ object KeystoreEncryptedPrefs {
             // long-lived: the storage adapters hold one for the whole process.
             // That steady state is worse than the truncation being fixed, so a
             // failed fold is retried on the next commit instead.
-            if (currentRegistryReadable) registrySeeded = true
+            if (currentRegistryReadable) {
+                registrySeeded = true
+                foldAttempts = 0
+                return
+            }
+            // Bound the retry. One overwrite of the current copy, which is
+            // identifiable as the entry rewritten on every commit, would
+            // otherwise buy a failing Keystore round trip per commit forever,
+            // taken under this monitor on the signing path, while newly written
+            // keys go unregistered the whole time. After a few attempts accept
+            // whichever list did decode and let it replace the unreadable copy:
+            // that copy is already unrecoverable, so nothing readable is lost.
+            if (++foldAttempts >= MAX_FOLD_ATTEMPTS) {
+                if (BuildConfig.DEBUG) Log.w("KeystoreEncryptedPrefs", "Registry unreadable after $foldAttempts folds; replacing it")
+                currentRegistryReadable = true
+                registrySeeded = true
+                foldAttempts = 0
+            }
         }
 
         private fun fallbackHashOf(plainKey: String): String =
             hmacWithKey(plainKey, deterministicHmacKey())
 
-        /** Decodes a registry blob into its plain key list, or null if it cannot be read. */
+        /**
+         * Decodes a registry blob into its plain key list, or null if it cannot
+         * be read.
+         *
+         * Decrypting successfully is not enough to trust the contents. Values
+         * carry no associated data, so any string value from this file
+         * decrypts here just as well, and the registry's own location is
+         * derivable from the APK for the fallback epoch. A transplanted value
+         * would otherwise have each of its fragments adopted as a key name and
+         * written into the real registry on the next commit, where nothing ever
+         * removes them. Entries that do not look like key names are dropped, and
+         * an implausible count rejects the blob outright.
+         */
         private fun decodeRegistry(blob: String): List<String>? = try {
             val decrypted = decrypt(secretKey, blob)
             if (!decrypted.startsWith(PREFIX_STRING)) {
                 null
             } else {
-                decrypted.removePrefix(PREFIX_STRING)
+                val parts = decrypted.removePrefix(PREFIX_STRING)
                     .split(KEY_REGISTRY_DELIMITER)
                     .filter { it.isNotEmpty() && it != KEY_REGISTRY }
+                when {
+                    parts.size > MAX_REGISTRY_ENTRIES -> null
+                    else -> parts.filter { it.length <= MAX_KEY_NAME_LENGTH && it.none(Char::isISOControl) }
+                }
             }
         } catch (e: Exception) {
             if (BuildConfig.DEBUG) Log.w("KeystoreEncryptedPrefs", "Registry copy unreadable", e)
@@ -426,46 +469,61 @@ object KeystoreEncryptedPrefs {
         }
 
         /**
-         * Maps a registry-listed key to the name it is actually stored under.
+         * Records a registry-listed key under its current-epoch name only.
          *
-         * A fallback window strands the values as well as the registry, so
-         * recording only the current-epoch hash is not enough: enumeration maps
-         * stored names back through the reverse cache, and the on-disk names
-         * would all be fallback-epoch ones and match nothing. Both names are
-         * recorded so either resolves. The forward entry stays on the current
-         * hash, so writes land there and the stranded copy is dropped by
-         * `dropFallbackCopy`.
+         * A fallback-epoch name is deliberately never admitted to the reverse
+         * cache. That table is trusted for resolution by enumeration and by the
+         * change listener, and the fallback name is derivable from the APK, so
+         * admitting it would let a transplanted ciphertext be served under
+         * another key's name. Stranded values are instead reached by probing
+         * forward from the plaintext key, which cannot be redirected.
          */
         private fun cacheRegistryKey(plainKey: String) {
             val hash = calculateKeyHash(plainKey)
             keyCache[plainKey] = hash
             reverseKeyCache[hash] = plainKey
-            val fallbackName = fallbackHashOf(plainKey)
-            if (fallbackName != hash && basePrefs.contains(fallbackName)) {
-                reverseKeyCache[fallbackName] = plainKey
-            }
         }
 
-        override fun getAll(): MutableMap<String, *> {
-            if (reverseKeyCache.isEmpty()) {
-                rebuildKeyCacheFromRegistry()
-            }
+        /**
+         * Enumerates by resolving each known key forward, the way the typed
+         * getters do, rather than mapping stored names back through a reverse
+         * table.
+         *
+         * Mapping backwards would have to trust whatever name is on disk. Values
+         * carry no associated data, so a ciphertext is not bound to the name it
+         * sits under, and the fallback-epoch name is derivable from the APK.
+         * Anyone able to write to the data directory could therefore copy an
+         * authentic ciphertext to the fallback name of another key and have
+         * enumeration hand it back for that key, while the typed getters, which
+         * recompute the hash from the plaintext, kept returning the real value.
+         * Resolving forward and preferring the current name removes that split.
+         *
+         * Runs under the per-file monitor because the fold publishes the gate
+         * flags that the commit path reads; the two must not interleave.
+         */
+        override fun getAll(): MutableMap<String, *> = synchronized(initLockFor(prefsName)) {
+            ensureRegistrySeeded()
+            val stored = basePrefs.all
             val result = mutableMapOf<String, Any?>()
-            for ((encKey, encValue) in basePrefs.all) {
-                val plainKey = reverseKeyCache[encKey] ?: continue
+            for (plainKey in keyCache.keys.toList()) {
                 if (plainKey == KEY_REGISTRY) continue
+                val currentName = calculateKeyHash(plainKey)
+                val name = when {
+                    stored.containsKey(currentName) -> currentName
+                    else -> fallbackHashOf(plainKey).takeIf { it != currentName && stored.containsKey(it) }
+                } ?: continue
+                val encValue = stored[name] ?: continue
                 try {
-                    val plainValue = when (encValue) {
+                    result[plainKey] = when (encValue) {
                         is String -> decryptValue(encValue)
                         else -> encValue
                     }
-                    result[plainKey] = plainValue
                 } catch (e: Exception) {
-                    if (BuildConfig.DEBUG) Log.w("KeystoreEncryptedPrefs", "Failed to decrypt value for key $encKey", e)
+                    if (BuildConfig.DEBUG) Log.w("KeystoreEncryptedPrefs", "Failed to decrypt value for key $plainKey", e)
                     continue
                 }
             }
-            return result
+            result
         }
 
         private fun decryptValue(encrypted: String): Any? {
@@ -636,6 +694,11 @@ object KeystoreEncryptedPrefs {
                     // registry at all, leaving the put unlisted.
                     currentRegistryReadable = true
                     allRegistriesReadable = true
+                    // Re-fold next time. If this clear's commit fails, every
+                    // entry is still on disk while the caches are empty, and a
+                    // stale latch here would let the next put rewrite the
+                    // registry from those empty caches and orphan the rest.
+                    registrySeeded = false
                 } else {
                     // Fold in what is already on disk before the registry is
                     // rewritten below from the in-memory cache. Without this, the
@@ -684,7 +747,7 @@ object KeystoreEncryptedPrefs {
             /// policy selection means one the user replaced, possibly a looser one.
             private fun dropFallbackCopy(plainKey: String, currentName: String?) {
                 if (plainKey == KEY_REGISTRY) return
-                val fallbackHash = hmacWithKey(plainKey, deterministicHmacKey())
+                val fallbackHash = fallbackHashOf(plainKey)
                 if (fallbackHash == currentName || !basePrefs.contains(fallbackHash)) return
                 baseEditor.remove(fallbackHash)
                 reverseKeyCache.remove(fallbackHash)
@@ -697,7 +760,14 @@ object KeystoreEncryptedPrefs {
                 // cache is not known to cover what it listed and rewriting from
                 // it would truncate. Leave it; the keys stay directly readable,
                 // and the next commit re-folds and can still recover.
-                if (!currentRegistryReadable) return
+                if (!currentRegistryReadable) {
+                    // The queued puts still commit, so they exist on disk while
+                    // absent from every registry copy. They stay readable by
+                    // name, and this instance re-registers them once a fold
+                    // succeeds, but a restart before that leaves them unlisted.
+                    if (BuildConfig.DEBUG) Log.w("KeystoreEncryptedPrefs", "Registry unreadable; entries written now are unlisted")
+                    return
+                }
                 val registryContent = allKeys.joinToString(KEY_REGISTRY_DELIMITER)
                 val encKey = getEncryptedKeyName(KEY_REGISTRY)
                 val encValue = encryptValue(registryContent)


### PR DESCRIPTION
## The bug

Stored key names are hashed with a per-file derivation key. When that key cannot be persisted the store hashes under a deterministic fallback, and the migration back off that fallback runs only while no derivation key is persisted yet, so a registry written during a later fallback window keeps the old name permanently.

The fold resolved the registry under the current name only and returned early when it was missing. That is not a listing gap:

1. The fold reads nothing, so the key cache stays empty, and the seeded flag is set regardless.
2. Enumeration returns empty, because it maps stored names back through that cache.
3. The next write rewrites the key list from the same cache, which by then holds only the key that write touched.

Every other key is dropped from the registry at step 3 and does not come back. It is silent: direct lookups still resolve, so nothing surfaces until something enumerates or the re-hash migration runs, and that migration only visits registry-listed keys.

## What changed

**Both registry copies are read and unioned.** Preferring the current copy destroys data for exactly the devices this targets: once the truncating write has happened, the short list is under the current name and the full list under the fallback.

**Reads fall back rather than relocating, which is the opposite of the choice made for ordinary entries.** The registry is the index every lookup resolves through, so moving it on the read path could race a concurrent reader. The stale copy is dropped from inside the already-serialized commit path instead.

**A registry copy is classified three ways, not two.** Decrypted-but-not-a-registry is deterministic, so replacing it loses nothing that could ever be read back. A copy that would not decrypt may be a transient Keystore fault and is preserved. Conflating them means a transient fault destroys a list that was about to become readable again.

**Two separate gates.** An unreadable current copy blocks the rewrite, because rewriting from a cache that may not cover it would truncate. An unreadable copy anywhere blocks only the deletion, because it may list keys held nowhere else. One gate cannot serve both: the fallback name is derivable from the APK, so gating the rewrite on every copy being readable would let anyone able to write to the data directory stop the key list being maintained.

**The retry bound limits cost, not the guard.** An unreadable copy would otherwise buy a failing decrypt on every commit, taken under the per-file monitor on the signing path. Re-folding stops; the refusal to rewrite stands. Forcing the rewrite instead would truncate on an assumption the code cannot check.

**Enumeration resolves forward from the plaintext key.** It previously mapped stored names back through a reverse table. Values carry no associated data, so a ciphertext is not bound to the name it sits under, and the fallback name is derivable: anyone able to write to the data directory could copy an authentic ciphertext to another key's fallback name and have enumeration serve it under that key, while the typed getters kept returning the real value. Forward resolution removes the split. Fallback-epoch names are no longer admitted to the reverse table at all.

**Nothing narrows the list on write.** Filtering or capping there would persist a strict subset of what the read gate certified the cache covers, silently deregistering the difference. An oversized list is handled on the read side, where it is reported incomplete and the rewrite is skipped.

**`computeIfAbsent` for the per-file monitor.** `getOrPut` is not atomic, so two threads racing the first access could each hold a different monitor and the mutual exclusion everything here depends on would silently not hold.

No change to the stored format, so no migration over existing blobs. That matters because share material lives in this same wrapper.

## Test plan

Nine instrumented tests. The registry cannot be named from a test, since the derivation key is per-file and secret, so it is identified by behaviour: it is the one pre-existing entry whose value changes when an unrelated key is added. Capturing that value before and after yields two genuine blobs, which is how a truncated registry is staged without forging ciphertext. Both the identification and the staged preconditions are asserted, including that the two epoch names actually differ, so the suite cannot degenerate into overwrites and pass vacuously.

Run against unfixed main, 8 of 9 fail. The one that passes does so by construction: main never reads or writes the fallback registry location, so nothing there can be blocked or dropped. It is a regression guard on the split-gate design rather than coverage of the original bug, and is labelled as such rather than counted as coverage.

## Deliberately not here

Binding the stored key name into the value as associated data is the root fix for the transplant class, and would retire most of the machinery above. It changes the stored format, so it needs a versioned migration over blobs that include share material, and is tracked separately. Also tracked: the retry bound stops registry maintenance for the rest of the process once it trips, and the read-path fold is not bounded the way the commit path is.
