### PR TITLE
Bind stored values to the key they are stored under

### DIFF
--- a/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsBindingTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsBindingTest.kt
@@ -1,0 +1,141 @@
+package io.privkey.keep.storage
+
+import android.content.Context
+import android.util.Base64
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.SecretKey
+
+/**
+ * Values are authenticated, which proves nobody altered them. It does not prove
+ * where they belong: without binding, any ciphertext from this file decrypts
+ * under any other entry's name. That is enough to grant a package auto-signing
+ * by copying another package's stored `true` onto its name, with no forgery and
+ * no key access.
+ *
+ * These tests move real ciphertext between entries and assert the value does not
+ * follow, and that values written before binding existed are still readable.
+ */
+@RunWith(AndroidJUnit4::class)
+class KeystoreEncryptedPrefsBindingTest {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    @Before fun setup() = clear()
+    @After fun teardown() = clear()
+
+    private fun clear() {
+        context.deleteSharedPreferences(PREFS_NAME)
+    }
+
+    private fun raw() = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private fun open() = KeystoreEncryptedPrefs.create(context, PREFS_NAME)
+
+    /** The stored name a write lands on, identified by what the write adds. */
+    private fun writeAndFindStoredName(key: String, value: String): String {
+        open().edit().putString("anchor", "0").commit()
+        val before = raw().all.keys.toSet()
+        open().edit().putString(key, value).commit()
+        val added = raw().all.keys.toSet() - before
+        assertEquals("expected exactly one new stored entry", 1, added.size)
+        return added.first()
+    }
+
+    @Test
+    fun a_value_cannot_be_moved_onto_another_key() {
+        // The whole point. `victim` is what an attacker wants to overwrite;
+        // `donor` is a value they can already read off the device.
+        val donorName = writeAndFindStoredName("donor", "attacker-chosen")
+        val victimName = writeAndFindStoredName("victim", "real")
+        val donorCiphertext = raw().getString(donorName, null)!!
+
+        raw().edit().putString(victimName, donorCiphertext).commit()
+
+        assertNull(
+            "a value must not decrypt under a key it was not written for",
+            open().getString("victim", null)
+        )
+    }
+
+    @Test
+    fun a_transplanted_value_does_not_surface_through_enumeration_either() {
+        val donorName = writeAndFindStoredName("donor", "attacker-chosen")
+        val victimName = writeAndFindStoredName("victim", "real")
+        raw().edit()
+            .putString(victimName, raw().getString(donorName, null)!!)
+            .commit()
+
+        val all = open().all
+        assertTrue(
+            "enumeration must not serve the moved value: $all",
+            all["victim"] != "attacker-chosen"
+        )
+    }
+
+    @Test
+    fun a_value_still_round_trips_under_its_own_key() {
+        // Binding must not break the ordinary case it protects.
+        open().edit().putString("alpha", "1").putInt("beta", 7).commit()
+
+        val reopened = open()
+        assertEquals("1", reopened.getString("alpha", null))
+        assertEquals(7, reopened.getInt("beta", 0))
+    }
+
+    @Test
+    fun a_value_written_before_binding_existed_is_still_readable() {
+        // Upgrading must not orphan anything. A legacy value carries no marker
+        // and is read as it was written, unbound.
+        val storedName = writeAndFindStoredName("legacy", "written-before")
+        raw().edit().putString(storedName, legacyCiphertext("written-before")).commit()
+
+        assertEquals("written-before", open().getString("legacy", null))
+    }
+
+    @Test
+    fun a_legacy_value_gains_the_binding_when_it_is_next_written() {
+        val storedName = writeAndFindStoredName("legacy", "written-before")
+        raw().edit().putString(storedName, legacyCiphertext("written-before")).commit()
+        assertTrue(
+            "precondition: staged value is unmarked",
+            !raw().getString(storedName, null)!!.startsWith("v2:")
+        )
+
+        open().edit().putString("legacy", "written-after").commit()
+
+        val nowStored = raw().all.entries.first { it.value == raw().getString(storedName, null) }
+        assertTrue(
+            "a rewritten value should carry the binding: ${nowStored.value}",
+            (nowStored.value as String).startsWith("v2:")
+        )
+        assertEquals("written-after", open().getString("legacy", null))
+    }
+
+    /**
+     * Builds a value the way it was written before binding existed: same
+     * Keystore key, no associated data, no marker. Mirrors the production
+     * derivation rather than assuming a format.
+     */
+    private fun legacyCiphertext(plaintext: String): String {
+        val keyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+        val key = keyStore.getKey("keep_prefs_$PREFS_NAME", null) as SecretKey
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, key)
+        val iv = cipher.iv
+        val body = cipher.doFinal("s:$plaintext".toByteArray(Charsets.UTF_8))
+        return Base64.encodeToString(iv + body, Base64.NO_WRAP)
+    }
+
+    companion object {
+        private const val PREFS_NAME = "keystore_prefs_binding_test"
+    }
+}

--- a/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsBindingTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsBindingTest.kt
@@ -76,8 +76,8 @@ class KeystoreEncryptedPrefsBindingTest {
 
         val all = open().all
         assertTrue(
-            "enumeration must not serve the moved value: $all",
-            all["victim"] != "attacker-chosen"
+            "enumeration must refuse the moved value outright: $all",
+            !all.containsKey("victim")
         )
     }
 
@@ -119,6 +119,93 @@ class KeystoreEncryptedPrefsBindingTest {
         )
         assertEquals("written-after", open().getString("legacy", null))
     }
+
+    @Test
+    fun a_legacy_registry_still_decodes_so_every_key_stays_enumerable() {
+        // The registry is what makes keys visible after a restart. If a value
+        // written before binding stopped decoding here, the whole file would
+        // read as empty even though every entry was intact.
+        open().edit().putString("alpha", "1").putString("beta", "2").commit()
+        val registryName = registryStoredName()
+        val plain = registryPlaintext()
+        raw().edit().putString(registryName, legacyBlob(plain)).commit()
+        assertTrue(
+            "precondition: the staged registry is unmarked",
+            !raw().getString(registryName, null)!!.startsWith("v2:")
+        )
+
+        val visible = open().all.keys
+        assertTrue("alpha must survive a legacy registry: $visible", visible.contains("alpha"))
+        assertTrue("beta must survive a legacy registry: $visible", visible.contains("beta"))
+    }
+
+    @Test
+    fun a_legacy_derivation_key_still_decrypts() {
+        // This one is not a lost value, it is a lost file: every stored name is
+        // derived from this key, and a failure here throws out of the read path
+        // rather than returning a default.
+        open().edit().putString("alpha", "1").commit()
+        val stored = raw().getString("__hmac_key__", null)!!
+        val decoded = decryptWithAad(stored, "__hmac_key__")
+        raw().edit().putString("__hmac_key__", legacyBlobRaw(decoded)).commit()
+
+        assertEquals("1", open().getString("alpha", null))
+    }
+
+    @Test
+    fun stripping_the_marker_from_a_bound_value_fails_closed() {
+        // The format's security claim: a bound value must not become readable by
+        // deleting three characters.
+        val storedName = writeAndFindStoredName("alpha", "real")
+        val bound = raw().getString(storedName, null)!!
+        assertTrue("precondition: value is bound", bound.startsWith("v2:"))
+
+        raw().edit().putString(storedName, bound.removePrefix("v2:")).commit()
+
+        assertNull(
+            "a value must not read once its binding marker is removed",
+            open().getString("alpha", null)
+        )
+    }
+
+    /** The registry is the entry rewritten on every commit; identify it that way. */
+    private fun registryStoredName(): String {
+        val before = raw().all.mapValues { it.value as String }
+        open().edit().putString("probe", "x").commit()
+        val after = raw().all.mapValues { it.value as String }
+        return before.keys.single { after[it] != null && after[it] != before[it] }
+    }
+
+    private fun registryPlaintext(): String =
+        decryptWithAad(raw().getString(registryStoredName(), null)!!, "__keys__")
+
+    private fun keystoreKey(): SecretKey {
+        val keyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+        return keyStore.getKey("keep_prefs_$PREFS_NAME", null) as SecretKey
+    }
+
+    private fun decryptWithAad(value: String, aad: String): String {
+        val combined = Base64.decode(value.removePrefix("v2:"), Base64.NO_WRAP)
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(
+            Cipher.DECRYPT_MODE,
+            keystoreKey(),
+            javax.crypto.spec.GCMParameterSpec(128, combined.copyOfRange(0, 12))
+        )
+        if (value.startsWith("v2:")) cipher.updateAAD(aad.toByteArray(Charsets.UTF_8))
+        return String(cipher.doFinal(combined.copyOfRange(12, combined.size)), Charsets.UTF_8)
+    }
+
+    /** Re-encrypts an already-prefixed plaintext the old way: no AAD, no marker. */
+    private fun legacyBlobRaw(plaintextWithPrefix: String): String {
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, keystoreKey())
+        val iv = cipher.iv
+        val body = cipher.doFinal(plaintextWithPrefix.toByteArray(Charsets.UTF_8))
+        return Base64.encodeToString(iv + body, Base64.NO_WRAP)
+    }
+
+    private fun legacyBlob(plaintextWithPrefix: String): String = legacyBlobRaw(plaintextWithPrefix)
 
     /**
      * Builds a value the way it was written before binding existed: same

--- a/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsBindingTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsBindingTest.kt
@@ -126,8 +126,7 @@ class KeystoreEncryptedPrefsBindingTest {
         // written before binding stopped decoding here, the whole file would
         // read as empty even though every entry was intact.
         open().edit().putString("alpha", "1").putString("beta", "2").commit()
-        val registryName = registryStoredName()
-        val plain = registryPlaintext()
+        val (registryName, plain) = registryNameAndPlaintext()
         raw().edit().putString(registryName, legacyBlob(plain)).commit()
         assertTrue(
             "precondition: the staged registry is unmarked",
@@ -168,16 +167,20 @@ class KeystoreEncryptedPrefsBindingTest {
         )
     }
 
-    /** The registry is the entry rewritten on every commit; identify it that way. */
-    private fun registryStoredName(): String {
+    /**
+     * The registry is the one pre-existing entry rewritten by every commit, so a
+     * write identifies it. Resolved in a single pass: probing twice would rewrite
+     * the first probe's own value under a fresh nonce, leaving two changed
+     * entries and no way to tell which is the registry. The probe key is unique
+     * for the same reason.
+     */
+    private fun registryNameAndPlaintext(): Pair<String, String> {
         val before = raw().all.mapValues { it.value as String }
-        open().edit().putString("probe", "x").commit()
+        open().edit().putString("probe-${System.nanoTime()}", "x").commit()
         val after = raw().all.mapValues { it.value as String }
-        return before.keys.single { after[it] != null && after[it] != before[it] }
+        val name = before.keys.single { after[it] != null && after[it] != before[it] }
+        return name to decryptWithAad(after.getValue(name), "__keys__")
     }
-
-    private fun registryPlaintext(): String =
-        decryptWithAad(raw().getString(registryStoredName(), null)!!, "__keys__")
 
     private fun keystoreKey(): SecretKey {
         val keyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }

--- a/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsRegistryEpochTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefsRegistryEpochTest.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -296,14 +297,18 @@ class KeystoreEncryptedPrefsRegistryEpochTest {
     }
 
     @Test
-    fun enumerationAgreesWithDirectReads() {
+    fun enumerationAgreesWithDirectReadsAndBothRefuseATransplant() {
         // Enumeration used to resolve stored names through a reverse table while
         // the typed getters recomputed the hash, so the two could disagree and
-        // enumeration could serve a superseded or transplanted entry. They must
-        // now resolve identically. This does not assert that a transplanted
-        // value is rejected: resolving a stranded entry by probing the previous
-        // epoch is deliberate, and binding a ciphertext to its key name is a
-        // separate change.
+        // enumeration could serve a transplanted entry the typed getter refused.
+        // They must resolve identically.
+        //
+        // This previously asserted that alpha's value resolved under beta's
+        // name, because probing the previous epoch is deliberate and nothing
+        // bound a value to the key it was written for. Values are now bound, so
+        // the same setup must be refused by both paths instead. The stranded
+        // recovery this was guarding is still covered, by moving alpha's own
+        // value to alpha's fallback name where the binding still matches.
         val registry = seedAndCaptureRegistry()
         val alphaCiphertext = raw().getString(registry.alphaName, null)!!
         // Beta's own entry has to go, or neither path ever reaches the fallback
@@ -312,8 +317,8 @@ class KeystoreEncryptedPrefsRegistryEpochTest {
         raw().edit().remove(betaName).putString(fallbackHashOfKey("beta"), alphaCiphertext).commit()
 
         val prefs = open()
-        assertEquals("the stranded entry must resolve", "1", prefs.all["beta"])
-        assertEquals("enumeration must not diverge from a direct read", prefs.getString("beta", null), prefs.all["beta"])
+        assertNull("alpha's value must not resolve under beta's name", prefs.getString("beta", null))
+        assertTrue("enumeration must refuse it too: ${prefs.all}", !prefs.all.containsKey("beta"))
     }
 
     @Test

--- a/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
@@ -102,8 +102,22 @@ object KeystoreEncryptedPrefs {
     ///
     /// Values written before this existed carry no marker and are still read,
     /// unbound, so upgrading loses nothing. They gain the binding when they are
-    /// next written. Until then a legacy value remains transplantable, which is
-    /// the pre-existing behaviour rather than a new weakness.
+    /// next written.
+    ///
+    /// There is no convergence: a value that is never rewritten stays unbound
+    /// for the life of the install, and stays transplantable. That is the
+    /// pre-existing behaviour rather than a new weakness, but it means an
+    /// upgraded device keeps the exposure for exactly the entries that predate
+    /// the upgrade, which is where existing grants live. Closing it needs the
+    /// reader to re-encrypt a legacy value once it has decrypted it, and then a
+    /// per-file marker so unbound values stop being accepted at all. Deliberately
+    /// not done here: that adds a write to the read path in the file that holds
+    /// share material, and belongs in its own change.
+    ///
+    /// The delimiter is outside the Base64 alphabet on purpose. A marker made of
+    /// alphabet characters could occur at the start of a legacy value and would
+    /// make it decrypt as bound, which fails. No legacy value can contain a
+    /// colon at all.
     private const val BOUND_PREFIX = "v2:"
 
     /// Encrypts `plaintext` bound to `aad`, the logical key name it is stored
@@ -121,6 +135,9 @@ object KeystoreEncryptedPrefs {
     /// stored name would invalidate the value the moment it was recovered.
     private fun encrypt(key: SecretKey, plaintext: String, aad: String): String {
         require(plaintext.isNotEmpty()) { "Plaintext must not be empty" }
+        // An empty AAD is the same as no AAD to GCM, so it would produce a value
+        // that looks bound and carries no binding.
+        require(aad.isNotEmpty()) { "Associated data must not be empty" }
         val cipher = Cipher.getInstance(TRANSFORMATION)
         cipher.init(Cipher.ENCRYPT_MODE, key)
         cipher.updateAAD(aad.toByteArray(Charsets.UTF_8))

--- a/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/KeystoreEncryptedPrefs.kt
@@ -98,25 +98,55 @@ object KeystoreEncryptedPrefs {
         return keyGenerator.generateKey()
     }
 
-    private fun encrypt(key: SecretKey, plaintext: String): String {
+    /// Marks a value whose ciphertext is bound to the key it is stored under.
+    ///
+    /// Values written before this existed carry no marker and are still read,
+    /// unbound, so upgrading loses nothing. They gain the binding when they are
+    /// next written. Until then a legacy value remains transplantable, which is
+    /// the pre-existing behaviour rather than a new weakness.
+    private const val BOUND_PREFIX = "v2:"
+
+    /// Encrypts `plaintext` bound to `aad`, the logical key name it is stored
+    /// under.
+    ///
+    /// Without this, authentication covers the value alone and says nothing
+    /// about where it belongs, so any ciphertext from this file can be copied
+    /// onto another entry's name and still decrypt and authenticate. That is
+    /// enough to grant a package auto-signing by copying another package's
+    /// stored `true` onto its name.
+    ///
+    /// Bound to the logical name rather than the stored one on purpose: the
+    /// same logical key legitimately moves between stored names when an entry
+    /// left under a previous derivation epoch is relocated, and binding to the
+    /// stored name would invalidate the value the moment it was recovered.
+    private fun encrypt(key: SecretKey, plaintext: String, aad: String): String {
         require(plaintext.isNotEmpty()) { "Plaintext must not be empty" }
         val cipher = Cipher.getInstance(TRANSFORMATION)
         cipher.init(Cipher.ENCRYPT_MODE, key)
+        cipher.updateAAD(aad.toByteArray(Charsets.UTF_8))
         val iv = cipher.iv
         val encrypted = cipher.doFinal(plaintext.toByteArray(Charsets.UTF_8))
         val combined = ByteArray(iv.size + encrypted.size)
         System.arraycopy(iv, 0, combined, 0, iv.size)
         System.arraycopy(encrypted, 0, combined, iv.size, encrypted.size)
-        return Base64.encodeToString(combined, Base64.NO_WRAP)
+        return BOUND_PREFIX + Base64.encodeToString(combined, Base64.NO_WRAP)
     }
 
-    private fun decrypt(key: SecretKey, ciphertext: String): String {
+    private fun decrypt(key: SecretKey, ciphertext: String, aad: String): String {
         require(ciphertext.isNotEmpty()) { "Ciphertext must not be empty" }
-        val combined = Base64.decode(ciphertext, Base64.NO_WRAP)
+        val bound = ciphertext.startsWith(BOUND_PREFIX)
+        val body = if (bound) ciphertext.removePrefix(BOUND_PREFIX) else ciphertext
+        val combined = Base64.decode(body, Base64.NO_WRAP)
         val iv = combined.copyOfRange(0, GCM_IV_BYTES)
         val encrypted = combined.copyOfRange(GCM_IV_BYTES, combined.size)
         val cipher = Cipher.getInstance(TRANSFORMATION)
         cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, iv))
+        // Only the marked format carries the binding. An unmarked value predates
+        // it and is read as it was written; authentication still covers the
+        // value itself, just not its location.
+        if (bound) {
+            cipher.updateAAD(aad.toByteArray(Charsets.UTF_8))
+        }
         return String(cipher.doFinal(encrypted), Charsets.UTF_8)
     }
 
@@ -187,7 +217,7 @@ object KeystoreEncryptedPrefs {
                 hmacKey?.let { return it }
                 val stored = basePrefs.getString(HMAC_KEY_PREF, null)
                 if (stored != null) {
-                    val decrypted = decrypt(secretKey, stored)
+                    val decrypted = decrypt(secretKey, stored, HMAC_KEY_PREF)
                     val key = Base64.decode(decrypted, Base64.NO_WRAP)
                     // Our own 32-byte key, stored base64 then GCM-encrypted; GCM authentication
                     // rules out external tampering, so a wrong length here is an internal bug.
@@ -199,7 +229,7 @@ object KeystoreEncryptedPrefs {
                 }
                 val key = ByteArray(HMAC_KEY_LENGTH).also { SecureRandom().nextBytes(it) }
                 val encoded = Base64.encodeToString(key, Base64.NO_WRAP)
-                val encryptedHmacKey = encrypt(secretKey, encoded)
+                val encryptedHmacKey = encrypt(secretKey, encoded, HMAC_KEY_PREF)
                 val registryHash = hmacWithKey(KEY_REGISTRY, deterministicHmacKey())
                 val hasExistingEntries = basePrefs.contains(registryHash)
                 val persisted = if (hasExistingEntries) {
@@ -228,7 +258,7 @@ object KeystoreEncryptedPrefs {
             val registryHash = hmacWithKey(KEY_REGISTRY, oldKey)
             val encryptedRegistry = basePrefs.getString(registryHash, null) ?: return null
             return try {
-                val decrypted = decrypt(secretKey, encryptedRegistry)
+                val decrypted = decrypt(secretKey, encryptedRegistry, KEY_REGISTRY)
                 if (!decrypted.startsWith(PREFIX_STRING)) return null
                 val registryContent = decrypted.removePrefix(PREFIX_STRING)
                 if (registryContent.isEmpty()) return emptyList()
@@ -410,7 +440,7 @@ object KeystoreEncryptedPrefs {
          * the next commit, where nothing ever removes them.
          */
         private fun decodeRegistry(blob: String): RegistryRead = try {
-            val decrypted = decrypt(secretKey, blob)
+            val decrypted = decrypt(secretKey, blob, KEY_REGISTRY)
             if (!decrypted.startsWith(PREFIX_STRING)) {
                 RegistryRead.Malformed
             } else {
@@ -549,7 +579,7 @@ object KeystoreEncryptedPrefs {
                 // unauthenticated data placed at a derivable name.
                 val encValue = stored[name] as? String ?: continue
                 try {
-                    result[plainKey] = decryptValue(encValue)
+                    result[plainKey] = decryptValue(encValue, plainKey)
                 } catch (e: Exception) {
                     // The stored name, not the plaintext one: these files key on
                     // caller package names, which are hashed before logging
@@ -561,8 +591,8 @@ object KeystoreEncryptedPrefs {
             result
         }
 
-        private fun decryptValue(encrypted: String): Any? {
-            val decrypted = decrypt(secretKey, encrypted)
+        private fun decryptValue(encrypted: String, plainKey: String): Any? {
+            val decrypted = decrypt(secretKey, encrypted, plainKey)
             return when {
                 decrypted.startsWith(PREFIX_STRING) -> decrypted.removePrefix(PREFIX_STRING)
                 decrypted.startsWith(PREFIX_INT) -> decrypted.removePrefix(PREFIX_INT).toIntOrNull()
@@ -574,7 +604,7 @@ object KeystoreEncryptedPrefs {
             }
         }
 
-        private fun encryptValue(value: Any?): String {
+        private fun encryptValue(value: Any?, plainKey: String): String {
             val prefixed = when (value) {
                 is String -> PREFIX_STRING + value
                 is Int -> PREFIX_INT + value
@@ -584,7 +614,7 @@ object KeystoreEncryptedPrefs {
                 is Set<*> -> PREFIX_STRING_SET + value.joinToString(STRING_SET_DELIMITER)
                 else -> throw IllegalArgumentException("Unsupported type: ${value?.javaClass}")
             }
-            return encrypt(secretKey, prefixed)
+            return encrypt(secretKey, prefixed, plainKey)
         }
 
         private inline fun <T> getTypedValue(
@@ -596,7 +626,7 @@ object KeystoreEncryptedPrefs {
             val encKey = findEncryptedKey(key) ?: return defValue
             val encValue = basePrefs.getString(encKey, null) ?: return defValue
             return try {
-                val decrypted = decrypt(secretKey, encValue)
+                val decrypted = decrypt(secretKey, encValue, key)
                 if (decrypted.startsWith(prefix)) parse(decrypted.removePrefix(prefix)) else defValue
             } catch (e: Exception) {
                 if (BuildConfig.DEBUG) Log.w("KeystoreEncryptedPrefs", "Failed to decrypt typed value for key $key", e)
@@ -764,7 +794,7 @@ object KeystoreEncryptedPrefs {
 
                 for ((plainKey, value) in pendingPuts) {
                     val encKey = getEncryptedKeyName(plainKey)
-                    val encValue = encryptValue(value)
+                    val encValue = encryptValue(value, plainKey)
                     baseEditor.putString(encKey, encValue)
                     dropFallbackCopy(plainKey, encKey)
                 }
@@ -811,7 +841,7 @@ object KeystoreEncryptedPrefs {
                 }
                 val registryContent = allKeys.joinToString(KEY_REGISTRY_DELIMITER)
                 val encKey = getEncryptedKeyName(KEY_REGISTRY)
-                val encValue = encryptValue(registryContent)
+                val encValue = encryptValue(registryContent, KEY_REGISTRY)
                 baseEditor.putString(encKey, encValue)
                 // The current name now carries the full list, so drop a registry
                 // stranded under the previous epoch. The read path falls back to


### PR DESCRIPTION
## Summary

Stored values were authenticated but not bound to their location. Authentication proves nobody altered a value; it says nothing about where that value belongs, so any ciphertext in the file decrypted and authenticated under any other entry's name. No forgery and no key access needed: copying one entry's bytes onto another entry's name was enough.

That is not theoretical here. Opt-in state for background auto-signing is stored per package as a boolean, so every opted-in package's entry is an interchangeable ciphertext of the same known plaintext. Copying one onto another package's name grants that package auto-signing. It is the root cause behind several fixes that worked around it rather than closing it.

Values are now encrypted with the key name as associated data, so a value only decrypts under the name it was written for.

## The two decisions that carry the risk

**Bound to the logical key name, not the stored one.** Stored names are derived and the same logical key legitimately moves between them: an entry left under a previous derivation epoch is relocated when found. Binding to the stored name would invalidate a value at the moment it was recovered, turning a recovery path into data loss. Binding to the logical name survives relocation.

**Migration is lazy and non-destructive.** Bound values carry a marker. A value without one predates this change and is read as it was written, so upgrading orphans nothing, including share material and the derivation key itself. Nothing is eagerly rewritten, so there is no window where a failed migration write loses data. A legacy value gains the binding the next time it is written normally.

The cost of that choice, stated plainly: a value stays transplantable until it is next written. That is the behaviour that exists today, so nothing regresses, but the protection arrives per entry rather than all at once. Eager rewriting would close it sooner and would mean rewriting every stored value, including FROST share material, on first open after an upgrade. That trade is not worth it for a weakness that has existed for the life of the store.

## Test plan

Five instrumented tests. The central one moves real ciphertext from one entry onto another and asserts the value does not follow, with a second asserting the same through enumeration, since that path resolves differently. One covers ordinary round-tripping so the binding does not break what it protects. Two cover the upgrade: a value written the old way is still readable, and it gains the binding when next written.

Legacy values are built in the test using the same Keystore key with no associated data, mirroring the old write path rather than assuming a format.

These need real Android Keystore, so they only run on the emulator. Local compilation is not possible on this branch either, because the generated bindings are not checked in and the ones on disk predate a recent core change. CI regenerates and runs both, which is the authoritative check for this change rather than a fallback.

Closes the root cause tracked for the transplant primitive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Encrypted preference values are now cryptographically bound to their original keys, preventing values from being moved and decrypted under different keys.
  * Key binding is applied to newly written values while preserving access to existing legacy values.
* **Compatibility**
  * Legacy encrypted preferences remain readable and become key-bound when updated.
* **Bug Fixes**
  * Key-bound values no longer appear incorrectly when enumerating encrypted preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->