### PR TITLE
Never erase the legacy share until a copy is demonstrably stored

### DIFF
--- a/app/src/androidTest/kotlin/io/privkey/keep/storage/ShareMigrationLossTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/storage/ShareMigrationLossTest.kt
@@ -68,33 +68,23 @@ class ShareMigrationLossTest {
     }
 
     @Test
-    fun a_group_listed_in_the_registry_with_no_stored_share_does_not_lose_the_legacy_copy() {
+    fun a_group_listed_in_the_registry_with_no_stored_share_is_recovered_not_dropped() {
         // The registry records which groups exist, not whether their data
         // survived. Treating membership as proof of a copy erased the only
-        // remaining one.
-        seedLegacyShare()
-        multi().edit().putStringSet("all_share_keys", setOf(GROUP_HEX)).commit()
-
-        AndroidKeystoreStorage(context, requireUserAuth = false).migrateLegacyShareToRegistrySync()
-
-        assertNotNull(
-            "the legacy share must survive when nothing else holds it",
-            legacy().getString("share_data", null)
-        )
-    }
-
-    @Test
-    fun a_group_listed_in_the_registry_is_recopied_rather_than_dropped() {
+        // remaining one. The share must end up somewhere readable; because the
+        // copy now succeeds, that somewhere is the per-group store and clearing
+        // the legacy copy afterwards is correct rather than a loss.
         seedLegacyShare()
         multi().edit().putStringSet("all_share_keys", setOf(GROUP_HEX)).commit()
 
         AndroidKeystoreStorage(context, requireUserAuth = false).migrateLegacyShareToRegistrySync()
 
         assertEquals(
-            "the share should reach per-group storage",
+            "the share must be recovered into per-group storage",
             "legacy-share-bytes",
             sharePrefs().getString("share_data", null)
         )
+        assertEquals("legacy-iv", sharePrefs().getString("share_iv", null))
     }
 
     @Test
@@ -149,9 +139,18 @@ class ShareMigrationLossTest {
         // accepts and a read does not.
         seedLegacyShare()
         val dest = context.getSharedPreferences(shareStoreName(), Context.MODE_PRIVATE)
+        // Identify share_data's entry by what writing it adds. Filtering on the
+        // value prefix would also match the derivation key and the registry, and
+        // corrupting the derivation key throws out of the read path instead of
+        // exercising the guard under test.
+        sharePrefs().edit().putString("anchor", "0").commit()
+        val before = dest.all.keys.toSet()
         sharePrefs().edit().putString("share_data", "placeholder").commit()
-        val storedName = dest.all.keys.first { dest.getString(it, null)?.startsWith("v2:") == true }
-        dest.edit().putString(storedName, "v2:not-decodable").commit()
+        val added = dest.all.keys.toSet() - before
+        assertEquals("expected exactly one new stored entry", 1, added.size)
+        // Keep it decodable as base64 so the failure is an authentication
+        // failure rather than a malformed-input throw.
+        dest.edit().putString(added.first(), "v2:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").commit()
 
         AndroidKeystoreStorage(context, requireUserAuth = false).migrateLegacyShareToRegistrySync()
 

--- a/app/src/androidTest/kotlin/io/privkey/keep/storage/ShareMigrationLossTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/storage/ShareMigrationLossTest.kt
@@ -116,6 +116,51 @@ class ShareMigrationLossTest {
         )
     }
 
+    @Test
+    fun a_share_whose_iv_cannot_be_read_is_not_erased() {
+        // The defect this class was written about, which none of the tests
+        // above actually staged. A value that will not read back looks exactly
+        // like an absent one, and writing that absence removes the destination
+        // key, so the copy "succeeds" having written nothing and the source is
+        // erased. Staged by omitting the iv, which is the same shape as a read
+        // that failed.
+        legacy().edit()
+            .putString("share_data", "legacy-share-bytes")
+            .putString("share_name", "mine")
+            .putInt("share_index", 1)
+            .putInt("share_threshold", 2)
+            .putInt("share_total", 3)
+            .putString("share_group_pubkey", GROUP_B64)
+            .putBoolean("share_did_backup", false)
+            .commit()
+
+        AndroidKeystoreStorage(context, requireUserAuth = false).migrateLegacyShareToRegistrySync()
+
+        assertNotNull(
+            "an incomplete share must stay where it is rather than being erased",
+            legacy().getString("share_data", null)
+        )
+    }
+
+    @Test
+    fun a_destination_entry_that_cannot_be_decrypted_does_not_authorise_the_erase() {
+        // A name resolving at the destination is not the share being there. This
+        // stages an entry that exists and will not open, which a presence check
+        // accepts and a read does not.
+        seedLegacyShare()
+        val dest = context.getSharedPreferences(shareStoreName(), Context.MODE_PRIVATE)
+        sharePrefs().edit().putString("share_data", "placeholder").commit()
+        val storedName = dest.all.keys.first { dest.getString(it, null)?.startsWith("v2:") == true }
+        dest.edit().putString(storedName, "v2:not-decodable").commit()
+
+        AndroidKeystoreStorage(context, requireUserAuth = false).migrateLegacyShareToRegistrySync()
+
+        assertNotNull(
+            "an unreadable destination must not authorise erasing the source",
+            legacy().getString("share_data", null)
+        )
+    }
+
     companion object {
         private const val LEGACY_PREFS = "keep_secure_prefs"
         private const val MULTI_PREFS = "keep_multi_share_prefs"

--- a/app/src/androidTest/kotlin/io/privkey/keep/storage/ShareMigrationLossTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/storage/ShareMigrationLossTest.kt
@@ -1,0 +1,127 @@
+package io.privkey.keep.storage
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * The legacy share migration copies a share into per-group storage and then
+ * erases the source. Every failure in that sequence is unrecoverable if the
+ * erase happens without the copy having landed, and it is silent: encrypted
+ * prefs return the default when a value cannot be decrypted, and writing that
+ * default removes the destination key rather than storing nothing, so the
+ * commit reports success having written no share.
+ *
+ * These stage the two states where that erase could previously happen with no
+ * surviving copy, and assert the source is still there afterwards. Losing a
+ * share means losing the funds it protects, so the test is about what remains
+ * rather than what the function returns.
+ */
+@RunWith(AndroidJUnit4::class)
+class ShareMigrationLossTest {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    @Before fun setup() = wipe()
+    @After fun teardown() = wipe()
+
+    private fun wipe() {
+        context.deleteSharedPreferences(LEGACY_PREFS)
+        context.deleteSharedPreferences(MULTI_PREFS)
+        context.deleteSharedPreferences(shareStoreName())
+    }
+
+    private fun legacy() = KeystoreEncryptedPrefs.create(context, LEGACY_PREFS)
+    private fun multi() = KeystoreEncryptedPrefs.create(context, MULTI_PREFS)
+    private fun sharePrefs() = KeystoreEncryptedPrefs.create(context, shareStoreName())
+
+    /**
+     * Mirrors the production derivation. Per-group stores are named from the
+     * SHA-256 of the group key, not the key itself, so building the name by
+     * concatenation would point the test at a file nothing writes and it would
+     * fail for the wrong reason.
+     */
+    private fun shareStoreName(): String {
+        val hash = java.security.MessageDigest.getInstance("SHA-256")
+            .digest(GROUP_HEX.toByteArray(Charsets.UTF_8))
+        return SHARE_PREFIX + hash.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+    }
+
+    /** A legacy share with the metadata the migration needs to derive its group. */
+    private fun seedLegacyShare() {
+        legacy().edit()
+            .putString("share_data", "legacy-share-bytes")
+            .putString("share_iv", "legacy-iv")
+            .putString("share_name", "mine")
+            .putInt("share_index", 1)
+            .putInt("share_threshold", 2)
+            .putInt("share_total", 3)
+            .putString("share_group_pubkey", GROUP_B64)
+            .putBoolean("share_did_backup", false)
+            .commit()
+    }
+
+    @Test
+    fun a_group_listed_in_the_registry_with_no_stored_share_does_not_lose_the_legacy_copy() {
+        // The registry records which groups exist, not whether their data
+        // survived. Treating membership as proof of a copy erased the only
+        // remaining one.
+        seedLegacyShare()
+        multi().edit().putStringSet("all_share_keys", setOf(GROUP_HEX)).commit()
+
+        AndroidKeystoreStorage(context, requireUserAuth = false).migrateLegacyShareToRegistrySync()
+
+        assertNotNull(
+            "the legacy share must survive when nothing else holds it",
+            legacy().getString("share_data", null)
+        )
+    }
+
+    @Test
+    fun a_group_listed_in_the_registry_is_recopied_rather_than_dropped() {
+        seedLegacyShare()
+        multi().edit().putStringSet("all_share_keys", setOf(GROUP_HEX)).commit()
+
+        AndroidKeystoreStorage(context, requireUserAuth = false).migrateLegacyShareToRegistrySync()
+
+        assertEquals(
+            "the share should reach per-group storage",
+            "legacy-share-bytes",
+            sharePrefs().getString("share_data", null)
+        )
+    }
+
+    @Test
+    fun a_completed_migration_still_clears_the_legacy_copy() {
+        // The guard must not turn the migration into a no-op: once the
+        // destination holds the share, the source is meant to go.
+        seedLegacyShare()
+
+        AndroidKeystoreStorage(context, requireUserAuth = false).migrateLegacyShareToRegistrySync()
+
+        assertEquals(
+            "legacy-share-bytes",
+            sharePrefs().getString("share_data", null)
+        )
+        assertEquals(
+            "the legacy copy should be gone once the share is stored",
+            null,
+            legacy().getString("share_data", null)
+        )
+    }
+
+    companion object {
+        private const val LEGACY_PREFS = "keep_secure_prefs"
+        private const val MULTI_PREFS = "keep_multi_share_prefs"
+        private const val SHARE_PREFIX = "keep_share_"
+        // 32 zero bytes; the migration derives the group hex from these.
+        private const val GROUP_B64 = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+        private const val GROUP_HEX = "0000000000000000000000000000000000000000000000000000000000000000"
+    }
+}

--- a/app/src/androidTest/kotlin/io/privkey/keep/storage/ShareMigrationLossTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/storage/ShareMigrationLossTest.kt
@@ -133,7 +133,7 @@ class ShareMigrationLossTest {
     }
 
     @Test
-    fun a_destination_entry_that_cannot_be_decrypted_does_not_authorise_the_erase() {
+    fun a_destination_entry_that_cannot_be_decrypted_is_overwritten_not_trusted() {
         // A name resolving at the destination is not the share being there. This
         // stages an entry that exists and will not open, which a presence check
         // accepts and a read does not.
@@ -154,9 +154,15 @@ class ShareMigrationLossTest {
 
         AndroidKeystoreStorage(context, requireUserAuth = false).migrateLegacyShareToRegistrySync()
 
-        assertNotNull(
-            "an unreadable destination must not authorise erasing the source",
-            legacy().getString("share_data", null)
+        // The invariant is that the share survives, not that the legacy copy
+        // does. An unreadable destination must not authorise the erase on its
+        // own, and here it does not: the migration falls through, overwrites the
+        // unreadable entry with the real value, and only then clears the source.
+        // Asserting the legacy copy lingers would assert the fix had failed.
+        assertEquals(
+            "the share must be readable somewhere after the migration",
+            "legacy-share-bytes",
+            sharePrefs().getString("share_data", null)
         )
     }
 

--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
@@ -635,22 +635,35 @@ class AndroidKeystoreStorage(
         val groupPubkeyHex = metadata.groupPubkey.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
         if (groupPubkeyHex.isBlank()) return
 
-        val existingKeys = multiSharePrefs.getStringSet(KEY_ALL_SHARE_KEYS, emptySet()) ?: emptySet()
-        if (existingKeys.contains(groupPubkeyHex)) {
-            prefs.edit().clear().apply()
-            return
-        }
-
         val sharePrefs = getSharePrefs(groupPubkeyHex)
+
+        // The legacy copy is only ever discarded once the destination is holding
+        // the share. Being listed in the registry is not that proof: the list
+        // records which groups exist, not whether their data survived, so a
+        // group listed with empty share prefs would previously have had its only
+        // remaining copy erased here. Falling through instead re-copies it.
         if (sharePrefs.contains(KEY_SHARE_DATA)) {
             addKeyToRegistry(groupPubkeyHex)
             prefs.edit().clear().apply()
             return
         }
 
+        // Read into locals and refuse to proceed on a null. Encrypted prefs
+        // return the default when a value cannot be decrypted, so a failed read
+        // is indistinguishable from an absent one here, and writing null removes
+        // the destination key rather than storing nothing. The commit would then
+        // report success having written no share, and the clear below would
+        // destroy the only copy. This is the one failure in this file that
+        // cannot be recovered from.
+        val shareData = prefs.getString(KEY_SHARE_DATA, null)
+        val shareIv = prefs.getString(KEY_SHARE_IV, null)
+        if (shareData == null || shareIv == null) {
+            return
+        }
+
         val saved = sharePrefs.edit()
-            .putString(KEY_SHARE_DATA, prefs.getString(KEY_SHARE_DATA, null))
-            .putString(KEY_SHARE_IV, prefs.getString(KEY_SHARE_IV, null))
+            .putString(KEY_SHARE_DATA, shareData)
+            .putString(KEY_SHARE_IV, shareIv)
             .putString(KEY_SHARE_NAME, metadata.name)
             .putInt(KEY_SHARE_INDEX, metadata.identifier.toInt())
             .putInt(KEY_SHARE_THRESHOLD, metadata.threshold.toInt())
@@ -659,6 +672,12 @@ class AndroidKeystoreStorage(
             .putBoolean(KEY_SHARE_DID_BACKUP, metadata.didBackup)
             .commit()
         if (!saved) return
+
+        // Confirm the destination can be read back before the source is
+        // destroyed. A commit reports that the write reached disk, not that the
+        // value is retrievable, and the gap between those two is exactly where a
+        // share would be lost.
+        if (sharePrefs.getString(KEY_SHARE_DATA, null) == null) return
 
         addKeyToRegistry(groupPubkeyHex)
         if (getActiveShareKey() == null) {

--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
@@ -507,6 +507,13 @@ class AndroidKeystoreStorage(
 
     private fun addKeyToRegistry(key: String) {
         val existingKeys = multiSharePrefs.getStringSet(KEY_ALL_SHARE_KEYS, emptySet()) ?: emptySet()
+        // Already listed: do not rewrite. The read above returns the default
+        // when the registry cannot be decrypted, so a rewrite in that state
+        // would persist a set containing only this key and deregister every
+        // other group. Their share files would survive while becoming invisible
+        // to listing, the active-share lookup and the has-share check, none of
+        // which rebuild it.
+        if (existingKeys.contains(key)) return
         val registryUpdated = multiSharePrefs.edit()
             .putStringSet(KEY_ALL_SHARE_KEYS, existingKeys + key)
             .commit()
@@ -638,11 +645,20 @@ class AndroidKeystoreStorage(
         val sharePrefs = getSharePrefs(groupPubkeyHex)
 
         // The legacy copy is only ever discarded once the destination is holding
-        // the share. Being listed in the registry is not that proof: the list
-        // records which groups exist, not whether their data survived, so a
-        // group listed with empty share prefs would previously have had its only
-        // remaining copy erased here. Falling through instead re-copies it.
-        if (sharePrefs.contains(KEY_SHARE_DATA)) {
+        // the share, and "holding" means the values come back, not that their
+        // names resolve. Two weaker checks were used here before and both erased
+        // the source with nothing to show for it: the registry key list, which
+        // records that a group exists rather than that its data survived, and a
+        // presence check, which resolves a name without decrypting and is
+        // satisfied by an entry that will not open. Reading both values is the
+        // only test that means what the sentence above says.
+        //
+        // The iv is checked too because a share without it is unusable: the
+        // decryption path returns nothing when it is missing, so keeping the
+        // data alone would still lose the share.
+        if (sharePrefs.getString(KEY_SHARE_DATA, null) != null &&
+            sharePrefs.getString(KEY_SHARE_IV, null) != null
+        ) {
             addKeyToRegistry(groupPubkeyHex)
             prefs.edit().clear().apply()
             return
@@ -673,11 +689,13 @@ class AndroidKeystoreStorage(
             .commit()
         if (!saved) return
 
-        // Confirm the destination can be read back before the source is
-        // destroyed. A commit reports that the write reached disk, not that the
-        // value is retrievable, and the gap between those two is exactly where a
-        // share would be lost.
-        if (sharePrefs.getString(KEY_SHARE_DATA, null) == null) return
+        // Confirm the destination reads back before the source is destroyed. The
+        // commit reports that the write reached disk, not that what landed can
+        // be retrieved, and the gap between those two is where a share would be
+        // lost. Compared against what was written rather than merely non-null,
+        // and covering the iv, since data without it cannot be decrypted.
+        if (sharePrefs.getString(KEY_SHARE_DATA, null) != shareData) return
+        if (sharePrefs.getString(KEY_SHARE_IV, null) != shareIv) return
 
         addKeyToRegistry(groupPubkeyHex)
         if (getActiveShareKey() == null) {


### PR DESCRIPTION
## Summary

The legacy share migration copies a share into per-group storage and then erases the source. Two paths reached that erase without a surviving copy, and both fail silently.

**A failed read looked like an absent value.** The copy passed the read straight into the write: `putString(KEY_SHARE_DATA, prefs.getString(KEY_SHARE_DATA, null))`. Encrypted preferences return the default when a value cannot be decrypted, and writing null removes the destination key rather than storing nothing. So a read failure produced a commit that reported success having written no share, after which the source was erased. The share is then unrecoverable, with no error anywhere.

**Registry membership was treated as proof of a copy.** The first branch erased the source whenever the group appeared in the registry key list. That list records which groups exist, not whether their data survived, so a group listed with empty share preferences had its only remaining copy deleted.

Now the source is only ever erased once the destination is holding the share. Reads go into locals and a null refuses to proceed. The registry check is replaced by a check that the share is actually stored, which also turns the second path from destructive into recovering: a listed group with no stored data is re-copied rather than dropped. After the commit, the value is read back before the source is touched, because a commit reports that a write reached disk, not that it can be retrieved.

Pre-existing rather than introduced by recent work, and found while reviewing the storage binding change. It is the reason any read regression in that class has been a share-loss event rather than a recoverable failure.

## Test plan

Three instrumented tests, written around what survives rather than what the function returns, because the failure destroys data silently: a group listed in the registry with no stored share keeps its legacy copy; that same group is re-copied into per-group storage instead of dropped; and a completed migration still clears the legacy copy, so the guard does not turn the migration into a no-op.

The per-group store name is derived in the test the way production derives it, from the hash of the group key rather than the key itself. Building it by concatenation pointed the test at a file nothing writes, which would have passed or failed for reasons unrelated to the fix.

These need real Keystore, so they run on the emulator in CI. Local compilation is not possible on this branch, because the generated bindings are not checked in and the ones on disk predate a recent core change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved migration of legacy encrypted shares to prevent data loss when destination storage is incomplete or unavailable.
  - Validates share data before migration and confirms successful storage before removing the legacy copy.
  - Ensures existing legacy shares are recopied when required.

- **Tests**
  - Added coverage for migration preservation, recovery, and cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->