### PR TITLE
Never let a degraded RNG path succeed quietly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Verify release changelogs exist for this versionCode
         run: ./scripts/check-release-changelogs.sh
 
+      - name: Check for silent RNG fallbacks and GCM IV reuse
+        run: ./scripts/check-rng-hygiene.sh
+
       - name: Setup Android SDK
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
 

--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
@@ -85,7 +85,7 @@ class AndroidKeystoreStorage(
 
     @Synchronized
     private fun storeMetadata(key: String, data: ByteArray, metadata: ShareMetadataInfo) {
-        val cipher = initCipherWithKey(getOrCreateMetadataKey(), Cipher.ENCRYPT_MODE, null)
+        val cipher = initCipherForEncryption(getOrCreateMetadataKey())
         writeShareToPrefs(getSharePrefs(key), encryptWithCipher(cipher, data), cipher.iv, metadata)
     }
 
@@ -97,7 +97,7 @@ class AndroidKeystoreStorage(
         val ivBase64 = sharePrefs.getString(KEY_SHARE_IV, null)
             ?: throw KeepMobileException.StorageNotFound()
         return try {
-            val cipher = initCipherWithKey(getOrCreateMetadataKey(), Cipher.DECRYPT_MODE, ivBase64)
+            val cipher = initCipherForDecryption(getOrCreateMetadataKey(), ivBase64)
             decryptWithCipher(cipher, encryptedData)
         } catch (e: Exception) {
             if (BuildConfig.DEBUG) Log.e(TAG, "Metadata key recovery: ${e::class.simpleName}", e)
@@ -149,37 +149,43 @@ class AndroidKeystoreStorage(
         }
     }
 
-    fun getCipherForEncryption(): Cipher = initCipher(Cipher.ENCRYPT_MODE, null)
+    fun getCipherForEncryption(): Cipher = initCipherForEncryption(getOrCreateKey())
 
     fun getCipherForDecryption(): Cipher? {
         val legacyIv = prefs.getString(KEY_SHARE_IV, null)
         val legacyData = prefs.getString(KEY_SHARE_DATA, null)
         if (legacyIv != null && legacyData != null) {
-            return initCipher(Cipher.DECRYPT_MODE, legacyIv)
+            return initCipherForDecryption(getOrCreateKey(), legacyIv)
         }
 
         val activeKey = getActiveShareKey() ?: return null
         return getCipherForShareDecryption(activeKey)
     }
 
-    private fun initCipher(mode: Int, ivBase64: String?): Cipher =
-        initCipherWithKey(getOrCreateKey(), mode, ivBase64)
-
-    private fun initCipherWithKey(key: SecretKey, mode: Int, ivBase64: String?): Cipher = runCatching {
+    // Encryption and decryption are separate entry points on purpose, rather than
+    // one function taking a mode and a nullable IV. Under AES-GCM, reusing an IV
+    // with the same key destroys both confidentiality and authenticity, and it
+    // does so silently: encryption succeeds and the ciphertext looks fine. Every
+    // caller happened to pass null on the encrypt path, but nothing stopped one
+    // from passing an IV. Splitting the functions makes that a compile error
+    // instead of a convention, and leaves the provider to draw a fresh IV.
+    private fun initCipherForEncryption(key: SecretKey): Cipher = runCatching {
         val cipher = Cipher.getInstance("AES/GCM/NoPadding")
-        if (ivBase64 != null) {
-            val spec = GCMParameterSpec(128, Base64.decode(ivBase64, Base64.NO_WRAP))
-            cipher.init(mode, key, spec)
-        } else {
-            cipher.init(mode, key)
-        }
+        cipher.init(Cipher.ENCRYPT_MODE, key)
         cipher
-    }.getOrElse { e ->
+    }.getOrElse { e -> throw cipherInitFailure(e, "encryption") }
+
+    private fun initCipherForDecryption(key: SecretKey, ivBase64: String): Cipher = runCatching {
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(128, Base64.decode(ivBase64, Base64.NO_WRAP)))
+        cipher
+    }.getOrElse { e -> throw cipherInitFailure(e, "decryption") }
+
+    private fun cipherInitFailure(e: Throwable, operation: String): KeepMobileException {
         if (e is KeyPermanentlyInvalidatedException) {
-            throw KeepMobileException.StorageException("Biometric enrollment changed - please re-import your share")
+            return KeepMobileException.StorageException("Biometric enrollment changed - please re-import your share")
         }
-        val operation = if (mode == Cipher.ENCRYPT_MODE) "encryption" else "decryption"
-        throw KeepMobileException.StorageException("Failed to initialize cipher for $operation")
+        return KeepMobileException.StorageException("Failed to initialize cipher for $operation")
     }
 
     private fun encryptWithCipher(cipher: Cipher, data: ByteArray): ByteArray = runCatching {
@@ -479,15 +485,13 @@ class AndroidKeystoreStorage(
             ?: throw KeepMobileException.StorageException("Key $alias is not a SecretKey")
     }
 
-    private fun initCipherForShare(key: String, mode: Int, ivBase64: String?): Cipher =
-        initCipherWithKey(getOrCreateKeyForShare(key), mode, ivBase64)
-
-    fun getCipherForShareEncryption(key: String): Cipher = initCipherForShare(key, Cipher.ENCRYPT_MODE, null)
+    fun getCipherForShareEncryption(key: String): Cipher =
+        initCipherForEncryption(getOrCreateKeyForShare(key))
 
     fun getCipherForShareDecryption(key: String): Cipher? {
         val sharePrefs = getSharePrefs(key)
         val iv = sharePrefs.getString(KEY_SHARE_IV, null) ?: return null
-        return initCipherForShare(key, Cipher.DECRYPT_MODE, iv)
+        return initCipherForDecryption(getOrCreateKeyForShare(key), iv)
     }
 
     fun storeShareByKeyWithCipher(cipher: Cipher, key: String, data: ByteArray, metadata: ShareMetadataInfo) {

--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
@@ -164,11 +164,16 @@ class AndroidKeystoreStorage(
 
     // Encryption and decryption are separate entry points on purpose, rather than
     // one function taking a mode and a nullable IV. Under AES-GCM, reusing an IV
-    // with the same key destroys both confidentiality and authenticity, and it
-    // does so silently: encryption succeeds and the ciphertext looks fine. Every
-    // caller happened to pass null on the encrypt path, but nothing stopped one
-    // from passing an IV. Splitting the functions makes that a compile error
-    // instead of a convention, and leaves the provider to draw a fresh IV.
+    // with one key destroys both confidentiality and authenticity.
+    //
+    // For these particular keys the platform is expected to catch it: Keystore
+    // keys are generated with randomized encryption required by default, which
+    // rejects a caller-supplied IV at init time. That is a runtime backstop from
+    // another component, it does not hold for a key that is not Keystore-backed,
+    // and it is not what a reader of this call site can see. Every caller
+    // happened to pass null on the encrypt path; nothing stopped one from
+    // passing an IV. Splitting the functions makes it a compile error here, and
+    // leaves the provider to draw a fresh IV.
     private fun initCipherForEncryption(key: SecretKey): Cipher = runCatching {
         val cipher = Cipher.getInstance("AES/GCM/NoPadding")
         cipher.init(Cipher.ENCRYPT_MODE, key)

--- a/scripts/check-rng-hygiene.sh
+++ b/scripts/check-rng-hygiene.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Fail if production code can silently fall back to predictable randomness, or
+# reuse an AES-GCM IV.
+#
+# Motivated by the COLDCARD firmware disclosure (Block, 2026-07):
+# https://engineering.block.xyz/blog/predictable-rng-fallback-and-32-bit-reseed-in-coldcard-firmware
+# A guard that checked only whether a macro was *defined* -- not whether it was
+# *enabled* -- silently bound wallet seed generation to a non-cryptographic
+# fallback PRNG. Nothing crashed, nothing logged, and the firmware shipped that
+# way for years. The lesson is not "use a CSPRNG"; every codebase already
+# intends to. The lesson is that a degraded RNG path must not be able to succeed
+# quietly, and that only a mechanical check keeps it that way.
+#
+# The shapes that bug takes in an Android app:
+#
+#   1. kotlin.random.Random / java.util.Random / Math.random() are seeded,
+#      non-cryptographic generators. They produce plausible output forever, so
+#      one standing in for SecureRandom is invisible in review and in testing.
+#   2. SecureRandom weakened at the call site: an explicitly requested SHA1PRNG,
+#      or a setSeed() that replaces system entropy rather than supplementing it.
+#   3. An AES-GCM cipher initialised for ENCRYPT_MODE with a caller-supplied IV.
+#      This is the same failure mode wearing different clothes: under GCM,
+#      reusing an IV with one key destroys confidentiality AND authenticity, and
+#      it does so silently -- encryption succeeds, ciphertext looks fine. Let the
+#      provider draw the IV; supply one only when decrypting.
+#
+# Deliberate non-crypto randomness (UI jitter, sampling, shuffling a word list
+# for display) is allowed with an inline opt-out on the same line or in the
+# comment block directly above:
+#
+#     val delay = (0..100).random()   // rng-hygiene: ok - animation jitter
+#
+# This guard fails CLOSED. An awk error, a missing repo, or an empty file list is
+# reported as a failure rather than silently passing: a guard that reports "OK"
+# when it scanned nothing is worse than no guard, because it is trusted.
+#
+# Scope: TRACKED production Kotlin and Java only (git ls-files), so build output
+# and generated UniFFI bindings can never trip a rule or hide one. Test and
+# instrumentation source sets are excluded -- fixtures are deterministic on
+# purpose -- as is the test harness app.
+#
+# What this does NOT cover: it is a grep, so it catches shapes, not intent. It
+# cannot tell whether a SecureRandom draw is used correctly once generated, it
+# does not see into the Rust core (keep-mobile, which has its own guard in the
+# keep repo) or into dependencies, and rule 3 pins how a cipher is initialised,
+# not how its output is stored.
+#
+# Portable to BSD awk (developers run this on macOS): no gawk extensions.
+#
+# Run from anywhere. Exits non-zero with the offending lines.
+
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+
+status=0
+fail() { printf '\n\033[31mFAIL\033[0m %s\n' "$1"; status=1; }
+
+OPT_OUT='rng-hygiene: ok'
+
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+  printf '\n\033[31mFAIL\033[0m not inside a git work tree; this guard scans tracked files only\n'
+  exit 1
+}
+
+# Production sources only. testharness/ is a separate debug-only app used to
+# drive NIP-55 flows; it is not shipped.
+list_sources() {
+  git ls-files '*.kt' '*.java' \
+    | grep -vE '(^|/)(test|androidTest|testFixtures|debug)/' \
+    | grep -vE '^testharness/'
+}
+
+SOURCES=$(list_sources)
+if [ -z "$SOURCES" ]; then
+  printf '\n\033[31mFAIL\033[0m no Kotlin/Java sources found to scan; the file list is broken\n'
+  exit 1
+fi
+
+# Emit "file:line:code" for every live code line, with // and /* */ comments
+# stripped using real state tracking and string literals blanked. Without that,
+# prose mentioning a banned name trips its own rule, and a log message
+# containing "Random" reads as a violation.
+#
+# Statements are joined onto one line when a call's parentheses are still open,
+# so a wrapped `cipher.init(\n  ENCRYPT_MODE,\n  key,\n  spec\n)` is judged whole
+# rather than as four lines none of which look wrong on their own.
+preprocess() {
+  local f rc out
+  rc=0
+  for f in $SOURCES; do
+    out=$(awk -v fname="$f" -v optout="$OPT_OUT" -v keepstrings="${1:-0}" '
+      function strip(s,   out, i, c, d, n) {
+        out = ""; cmt = ""; n = length(s)
+        for (i = 1; i <= n; i++) {
+          c = substr(s, i, 1); d = substr(s, i, 2)
+          if (inblock) { if (d == "*/") { inblock = 0; i++ } else cmt = cmt c; continue }
+          if (instr)   { if (c == "\\") { i++; continue }
+                         if (c == quote) { instr = 0; out = out "\"\"" }
+                         continue }
+          if (d == "/*") { inblock = 1; i++; continue }
+          if (d == "//") { cmt = cmt substr(s, i + 2); break }
+          if (c == "\"" || c == "'"'"'") {
+            if (keepstrings) { out = out c; continue }
+            instr = 1; quote = c; continue
+          }
+          out = out c
+        }
+        return out
+      }
+      function trim(s) { sub(/^[ \t]*/, "", s); sub(/[ \t]*$/, "", s); return s }
+      function count(s, ch,   i, n) {
+        # Literal character count: gsub()/split() would treat ch as a regex,
+        # and "(" alone is not a valid one -- BSD awk aborts on it.
+        n = 0
+        for (i = length(s); i > 0; i--) if (substr(s, i, 1) == ch) n++
+        return n
+      }
+      function emit() {
+        if (buf != "" && !bufopt) printf "%s:%d:%s\n", fname, bufline, buf
+        buf = ""; bufopt = 0; open = 0
+      }
+
+      BEGIN { inblock = 0; instr = 0; blockopt = 0; buf = ""; open = 0; bufopt = 0 }
+      {
+        code = trim(strip($0))
+        marked = index(cmt, optout); cmt = ""
+
+        if (code == "") { if (marked) blockopt = 1; next }
+
+        if (open > 0) {
+          buf = buf " " code
+          if (marked) bufopt = 1
+          open += count(code, "(") - count(code, ")")
+          if (open <= 0) emit()
+          next
+        }
+
+        if (marked || blockopt) { blockopt = 0; next }
+        blockopt = 0
+
+        buf = code; bufline = FNR; bufopt = 0
+        open = count(code, "(") - count(code, ")")
+        if (open <= 0) emit()
+      }
+      END { if (open > 0) emit() }
+    ' "$f") || rc=2
+    [ -n "$out" ] && printf '%s\n' "$out"
+  done
+  return "$rc"
+}
+
+# Two passes. Rules that reason about code shape match against CODE, where
+# string literals are blanked so a log message mentioning "Random" is not a
+# finding. Rules about a *value* -- an algorithm name passed to getInstance --
+# need CODE_STR, where literals survive.
+CODE=$(preprocess) || {
+  printf '\n\033[31mFAIL\033[0m the scanner itself failed; refusing to report a clean tree\n'
+  exit 1
+}
+CODE_STR=$(preprocess 1) || {
+  printf '\n\033[31mFAIL\033[0m the scanner itself failed; refusing to report a clean tree\n'
+  exit 1
+}
+if [ -z "$CODE" ] || [ -z "$CODE_STR" ]; then
+  printf '\n\033[31mFAIL\033[0m preprocessor produced no code lines; the guard scanned nothing\n'
+  exit 1
+fi
+
+scan() { # $1 = ERE, matched against code with string literals blanked
+  printf '%s\n' "$CODE" | awk -v pat="$1" '{
+    line = $0; sub(/^[^:]*:[0-9]+:/, "", line)
+    if (line ~ pat) print $0
+  }'
+}
+
+scan_with_strings() { # $1 = ERE, matched against code with literals intact
+  printf '%s\n' "$CODE_STR" | awk -v pat="$1" '{
+    line = $0; sub(/^[^:]*:[0-9]+:/, "", line)
+    if (line ~ pat) print $0
+  }'
+}
+
+report() { # $1 = findings, $2 = headline, $3.. = hints
+  [ -z "$1" ] && return 0
+  fail "$2"
+  printf '%s\n' "$1" | sed 's/^/  /'
+  shift 2
+  for hint in "$@"; do echo "  → $hint"; done
+}
+
+# ------------------------------------------------ 1. non-CSPRNG generators ----
+# Match the RNG token, not a receiver shape: pinning `"0123..".random()` is
+# bypassed by hoisting the alphabet into a val, which is the same code one
+# refactor away.
+weak_rng=$(scan '(^|[^a-zA-Z0-9_.])(kotlin\.random|java\.util\.Random|Math\.random|Random\(|Random\.next|ThreadLocalRandom)|\.random\(\)')
+report "$weak_rng" "non-cryptographic randomness in production code:" \
+  'use java.security.SecureRandom, or UUID.randomUUID() for correlation ids' \
+  "or mark a deliberate non-crypto use: // $OPT_OUT - <reason>"
+
+# --------------------------------------------- 2. SecureRandom not weakened --
+# SHA1PRNG is an argument value, so it only survives the strings-intact pass.
+weak_sr=$(printf '%s\n%s\n' \
+  "$(scan_with_strings 'SHA1PRNG')" \
+  "$(scan 'setSeed[ \t]*\(')" | grep -v '^$' || true)
+report "$weak_sr" "SecureRandom weakened at the call site:" \
+  'drop the explicit provider and the seed; the platform default is seeded from the OS' \
+  'and SHA1PRNG is a legacy algorithm with a history of weak seeding on Android'
+
+# ------------------------------------- 3. AES-GCM never encrypts with an IV --
+# The load-bearing rule. A GCM IV reused under one key is catastrophic and
+# silent, and the only structural defence is that the encrypt path never accepts
+# one. Statement-scoped, so a wrapped init() call is judged whole.
+gcm_bad=$(scan 'ENCRYPT_MODE[^;]*(GCMParameterSpec|IvParameterSpec|AlgorithmParameterSpec)')
+report "$gcm_bad" "AES-GCM cipher initialised for encryption with a caller-supplied IV:" \
+  'reusing a GCM IV under one key destroys confidentiality and authenticity, silently.' \
+  'Init encryption as cipher.init(ENCRYPT_MODE, key) and let the provider draw the IV;' \
+  'read it back from cipher.iv afterwards. Supply a spec only when decrypting.'
+
+if [ "$status" -eq 0 ]; then
+  echo "RNG hygiene: OK (no non-CSPRNG generators, SecureRandom unweakened, no GCM encryption with a supplied IV)"
+fi
+exit "$status"

--- a/scripts/check-rng-hygiene.sh
+++ b/scripts/check-rng-hygiene.sh
@@ -192,7 +192,7 @@ report() { # $1 = findings, $2 = headline, $3.. = hints
 # Match the RNG token, not a receiver shape: pinning `"0123..".random()` is
 # bypassed by hoisting the alphabet into a val, which is the same code one
 # refactor away.
-weak_rng=$(scan '(^|[^a-zA-Z0-9_.])(kotlin\.random|java\.util\.Random|Math\.random|Random\(|Random\.next|ThreadLocalRandom)|\.random\(\)')
+weak_rng=$(scan '(^|[^a-zA-Z0-9_.])(kotlin[.]random|java[.]util[.]Random|Math[.]random|Random[(]|Random[.]next|ThreadLocalRandom)|[.]random[(][)]')
 report "$weak_rng" "non-cryptographic randomness in production code:" \
   'use java.security.SecureRandom, or UUID.randomUUID() for correlation ids' \
   "or mark a deliberate non-crypto use: // $OPT_OUT - <reason>"
@@ -201,7 +201,7 @@ report "$weak_rng" "non-cryptographic randomness in production code:" \
 # SHA1PRNG is an argument value, so it only survives the strings-intact pass.
 weak_sr=$(printf '%s\n%s\n' \
   "$(scan_with_strings 'SHA1PRNG')" \
-  "$(scan 'setSeed[ \t]*\(')" | grep -v '^$' || true)
+  "$(scan 'setSeed[ \t]*[(]')" | grep -v '^$' || true)
 report "$weak_sr" "SecureRandom weakened at the call site:" \
   'drop the explicit provider and the seed; the platform default is seeded from the OS' \
   'and SHA1PRNG is a legacy algorithm with a history of weak seeding on Android'

--- a/scripts/check-rng-hygiene.sh
+++ b/scripts/check-rng-hygiene.sh
@@ -66,7 +66,7 @@ git rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
 # drive NIP-55 flows; it is not shipped.
 list_sources() {
   git ls-files '*.kt' '*.java' \
-    | grep -vE '(^|/)(test|androidTest|testFixtures|debug)/' \
+    | grep -vE '(^|/)(test|androidTest|testFixtures)/' \
     | grep -vE '^testharness/'
 }
 
@@ -88,20 +88,27 @@ preprocess() {
   local f rc out
   rc=0
   for f in $SOURCES; do
-    out=$(awk -v fname="$f" -v optout="$OPT_OUT" -v keepstrings="${1:-0}" '
+    out=$(awk -v fname="$f" -v optout="$OPT_OUT" -v keepstrings="${1:-0}" -v keepoptout="${2:-0}" '
       function strip(s,   out, i, c, d, n) {
         out = ""; cmt = ""; n = length(s)
         for (i = 1; i <= n; i++) {
           c = substr(s, i, 1); d = substr(s, i, 2)
           if (inblock) { if (d == "*/") { inblock = 0; i++ } else cmt = cmt c; continue }
-          if (instr)   { if (c == "\\") { i++; continue }
-                         if (c == quote) { instr = 0; out = out "\"\"" }
-                         continue }
+          if (instr)   {
+            if (c == "\\") { if (keepstrings) out = out c substr(s, i + 1, 1); i++; continue }
+            if (c == quote) { instr = 0; out = out (keepstrings ? c : "\"\"") ; continue }
+            if (keepstrings) out = out c
+            continue
+          }
           if (d == "/*") { inblock = 1; i++; continue }
           if (d == "//") { cmt = cmt substr(s, i + 2); break }
           if (c == "\"" || c == "'"'"'") {
-            if (keepstrings) { out = out c; continue }
-            instr = 1; quote = c; continue
+            # Even when literals are kept, string STATE must be tracked: a MIME
+            # wildcard "*/*" or a regex "^wss://" otherwise reads as a comment
+            # opener and hides the rest of the file from this pass.
+            instr = 1; quote = c
+            if (keepstrings) out = out c
+            continue
           }
           out = out c
         }
@@ -129,13 +136,13 @@ preprocess() {
 
         if (open > 0) {
           buf = buf " " code
-          if (marked) bufopt = 1
+          if (marked && !keepoptout) bufopt = 1
           open += count(code, "(") - count(code, ")")
           if (open <= 0) emit()
           next
         }
 
-        if (marked || blockopt) { blockopt = 0; next }
+        if (!keepoptout && (marked || blockopt)) { blockopt = 0; next }
         blockopt = 0
 
         buf = code; bufline = FNR; bufopt = 0
@@ -161,23 +168,38 @@ CODE_STR=$(preprocess 1) || {
   printf '\n\033[31mFAIL\033[0m the scanner itself failed; refusing to report a clean tree\n'
   exit 1
 }
+# Rule 3 has no opt-out, so it needs a stream where the marker was not honoured.
+# Reusing CODE would let `// rng-hygiene: ok - trust me` waive the one rule that
+# guards a catastrophic, silent failure.
+CODE_NOWAIVE=$(preprocess 0 1) || {
+  printf '\n\033[31mFAIL\033[0m the scanner itself failed; refusing to report a clean tree\n'
+  exit 1
+}
 if [ -z "$CODE" ] || [ -z "$CODE_STR" ]; then
   printf '\n\033[31mFAIL\033[0m preprocessor produced no code lines; the guard scanned nothing\n'
   exit 1
 fi
 
+# Both scanners abort the whole run on an awk failure. Without that, an ERE this
+# awk rejects (the BSD-awk case the header raises) yields an empty result, which
+# reads as "no violations" -- the guard printing OK while a violation is present.
 scan() { # $1 = ERE, matched against code with string literals blanked
   printf '%s\n' "$CODE" | awk -v pat="$1" '{
     line = $0; sub(/^[^:]*:[0-9]+:/, "", line)
     if (line ~ pat) print $0
-  }'
+  }' || scanner_died
 }
 
 scan_with_strings() { # $1 = ERE, matched against code with literals intact
   printf '%s\n' "$CODE_STR" | awk -v pat="$1" '{
     line = $0; sub(/^[^:]*:[0-9]+:/, "", line)
     if (line ~ pat) print $0
-  }'
+  }' || scanner_died
+}
+
+scanner_died() {
+  printf '\n\033[31mFAIL\033[0m the scanner itself failed; refusing to report a clean tree\n' >&2
+  exit 1
 }
 
 report() { # $1 = findings, $2 = headline, $3.. = hints
@@ -192,7 +214,10 @@ report() { # $1 = findings, $2 = headline, $3.. = hints
 # Match the RNG token, not a receiver shape: pinning `"0123..".random()` is
 # bypassed by hoisting the alphabet into a val, which is the same code one
 # refactor away.
-weak_rng=$(scan '(^|[^a-zA-Z0-9_.])(kotlin[.]random|java[.]util[.]Random|Math[.]random|Random[(]|Random[.]next|ThreadLocalRandom)|[.]random[(][)]')
+# The `(^|[^a-zA-Z0-9_.])` guard deliberately does NOT apply to the fully
+# qualified names: `java.util.concurrent.ThreadLocalRandom.current()` has a `.`
+# in front of the token, so anchoring it would make qualified use invisible.
+weak_rng=$(scan 'kotlin[.]random|java[.]util[.]Random|Math[.]random|ThreadLocalRandom|SplittableRandom|(^|[^a-zA-Z0-9_.])(Random[(]|Random[.]next)|[.]random[(][)]|SecureRandom[(][^)]')
 report "$weak_rng" "non-cryptographic randomness in production code:" \
   'use java.security.SecureRandom, or UUID.randomUUID() for correlation ids' \
   "or mark a deliberate non-crypto use: // $OPT_OUT - <reason>"
@@ -207,14 +232,44 @@ report "$weak_sr" "SecureRandom weakened at the call site:" \
   'and SHA1PRNG is a legacy algorithm with a history of weak seeding on Android'
 
 # ------------------------------------- 3. AES-GCM never encrypts with an IV --
-# The load-bearing rule. A GCM IV reused under one key is catastrophic and
-# silent, and the only structural defence is that the encrypt path never accepts
-# one. Statement-scoped, so a wrapped init() call is judged whole.
-gcm_bad=$(scan 'ENCRYPT_MODE[^;]*(GCMParameterSpec|IvParameterSpec|AlgorithmParameterSpec)')
-report "$gcm_bad" "AES-GCM cipher initialised for encryption with a caller-supplied IV:" \
-  'reusing a GCM IV under one key destroys confidentiality and authenticity, silently.' \
-  'Init encryption as cipher.init(ENCRYPT_MODE, key) and let the provider draw the IV;' \
-  'read it back from cipher.iv afterwards. Supply a spec only when decrypting.'
+# The load-bearing rule, and the only one with no opt-out: a GCM IV reused under
+# one key is catastrophic and silent, and there is no legitimate reason in this
+# app to hand a cipher an IV for encryption.
+#
+# Counted structurally rather than matched as a token pair. An earlier version
+# required `ENCRYPT_MODE` and the spec constructor in the same statement, which
+# the very code this repo removed did NOT satisfy -- `cipher.init(mode, key,
+# spec)` with both hoisted into variables passed clean, as did a numeric opmode.
+# The real invariant does not mention ENCRYPT at all: `Cipher.init` takes a spec
+# only when decrypting, so any init with three or more arguments has to be
+# provably a decrypt.
+gcm_bad=$(
+  printf '%s\n' "$CODE_NOWAIVE" | awk '
+    function args(s,   i, c, d, n) {
+      # Count top-level commas inside the first (...) group, so nested calls and
+      # generics do not inflate the count.
+      n = 1; d = 0
+      for (i = 1; i <= length(s); i++) {
+        c = substr(s, i, 1)
+        if (c == "(") { d++; if (d == 1) continue }
+        else if (c == ")") { d--; if (d == 0) break }
+        else if (c == "," && d == 1) n++
+      }
+      return n
+    }
+    {
+      line = $0; sub(/^[^:]*:[0-9]+:/, "", line)
+      if (line !~ /[.]init[ \t]*[(]/) next
+      if (line ~ /DECRYPT_MODE/) next
+      call = substr(line, index(line, ".init") + 5)
+      if (args(call) >= 3) print $0
+    }
+  ' || scanner_died
+)
+report "$gcm_bad" "Cipher.init with three or more arguments that is not provably a decrypt:" \
+  'under AES-GCM, reusing an IV with one key destroys confidentiality and authenticity.' \
+  'Init encryption as cipher.init(ENCRYPT_MODE, key) and read the IV back from cipher.iv;' \
+  'pass a parameter spec only on a call that names DECRYPT_MODE.'
 
 if [ "$status" -eq 0 ]; then
   echo "RNG hygiene: OK (no non-CSPRNG generators, SecureRandom unweakened, no GCM encryption with a supplied IV)"


### PR DESCRIPTION
## Summary
- Audit of the app against the bug class in Block's [COLDCARD predictable-RNG disclosure](https://engineering.block.xyz/blog/predictable-rng-fallback-and-32-bit-reseed-in-coldcard-firmware): a degraded cryptographic path that succeeds silently.
- **The randomness itself came back clean, and that is the main result.** Every draw in production Kotlin already goes through `java.security.SecureRandom` or `UUID.randomUUID()`: the NIP-55 permission-database key, the Keystore HMAC key, the PIN PBKDF2 salt, the recovery-screen hex, and the relay reconnect jitter. No `kotlin.random`, no `java.util.Random`, no `Math.random()`, no `setSeed`, no `SHA1PRNG`, and `minSdk = 33` puts the app well past the Android versions with weak `SecureRandom` seeding.
- What the audit did find is the same failure mode one door over: `AndroidKeystoreStorage` had a single `initCipherWithKey(key, mode, ivBase64)` used for both directions, which would happily initialise an **AES-GCM cipher for encryption with a caller-supplied IV**. Reusing a GCM IV under one key destroys confidentiality *and* authenticity. (See the review round for a correction to how this PR originally described the runtime behaviour of that mistake on Keystore-backed keys.)

## What changed

Every call site happened to pass `null` on the encrypt path, so nothing was broken. But "happened to" is the property this audit exists to remove. Encryption and decryption are now separate functions: `initCipherForEncryption(key)` takes no IV and lets the provider draw a fresh one, `initCipherForDecryption(key, ivBase64)` requires one. Passing an IV to the encrypt path is a compile error rather than a convention, and the shared error mapping (including the `KeyPermanentlyInvalidatedException` re-import message) is preserved in one helper.

`scripts/check-rng-hygiene.sh` pins three rules in CI: non-cryptographic generators in production code, `SecureRandom` weakened at the call site (`setSeed`, an explicitly requested `SHA1PRNG`), and any `Cipher.init` with three or more arguments that is not provably a decrypt (see the review round for why it is phrased that way and not in terms of `ENCRYPT_MODE`). It runs as a step in the existing `build` job alongside `check-toolchain-pins.sh` and the other guards, before the SDK/NDK/Rust setup, so it fails in seconds rather than after a toolchain install.

## Review notes

The guard is written to survive the refactors that defeat a naive grep. It matches the RNG *token* rather than a receiver shape, because pinning `"0123..".random()` is bypassed by hoisting the alphabet into a `val` — which is the same code, one refactor away. It parses `//` and `/* */` comments with real state tracking and blanks string literals, so prose naming a banned symbol is not a finding and a log message containing "Random" is not either. It joins wrapped calls into one statement, so a rustfmt-style four-line `cipher.init(...)` is judged whole instead of as four innocuous lines. And it makes two passes: rules about code shape see literals blanked, while the rule about an *argument value* (`SHA1PRNG`) sees them intact.

It also fails closed. A scanner error, a run outside a git work tree, or an empty file list is reported as a failure, never as a pass — a guard that prints "OK" when it scanned nothing is worse than no guard, because it gets trusted. Both cases are verified below.

## Decision log

**Hardest decision:** whether to fix the cipher helper at all, given no call site was wrong. A `require(mode != ENCRYPT_MODE || ivBase64 == null)` would have been one line, but it defends at runtime against a mistake the type system can prevent outright, and it needs a test that cannot run without a device. Splitting the function costs a few more lines and makes the class of mistake unrepresentable.

**Alternatives rejected:**
- A separate `rng-hygiene` workflow, matching the two sibling repos. This repo already has a `scripts/check-*.sh` convention running inside the `build` job, and those steps sit before the heavy setup, so they already fail fast. Consistency won.
- Adding a `docs/SECURITY.md`. There is no such file in this repo and no security-doc convention to slot into; the invariant is documented where it is enforced (the guard header) and where it can be violated (the comment above the split functions).

**Least confident about:** rule 1 flags `.random()` on any receiver, so a future legitimate `list.random()` for UI flavour will trip it. That is a deliberate false-positive bias — the author either goes through `SecureRandom` or adds an `// rng-hygiene: ok` marker consciously — but it will annoy someone eventually.

## What is not verified

The split cipher functions have no executing test. They are private, they need the Android Keystore, and the existing coverage for this class is instrumented (`KeystoreEncryptedPrefsBindingTest`), which needs a device or emulator this workspace does not have. The `instrumented-tests` CI job is the first place it actually runs. `verifyKeepVersion` was skipped locally because the `keep` path is a symlink to the main keep repo, which is currently on a different branch; CI checks out the pinned SHA itself and will verify it properly.

## Test plan
- [x] `./gradlew compileDebugKotlin testDebugUnitTest lintDebug` (JDK 21): BUILD SUCCESSFUL, **171 unit tests passed, 0 failed**, lint clean with 0 errors and 0 warnings
- [x] `scripts/check-rng-hygiene.sh` exits 0 on the tree
- [x] Guard verified by reintroduction (superseded by the fuller matrix in the review round below)
- [ ] Instrumented tests — not run locally, no device attached; CI's `instrumented-tests` job covers the Keystore path

## Review round

A security review ran over the branch with the explicit job of falsifying the "randomness was already clean" claim. **The claim held.** It traced every RNG draw in all 109 production Kotlin files and every AES-GCM IV, confirmed the cipher split is behaviour-preserving call site by call site (including the legacy-IV migration path and the error-message mapping), and found no non-CSPRNG source, no reused IV, and no degraded-but-succeeding path.

The findings were in the guard, and two of them were blockers.

**Rule 3 did not catch the shape this very PR removes.** Checking out `main`'s `AndroidKeystoreStorage.kt` into a scratch tree and running the guard printed `RNG hygiene: OK`. The rule required `ENCRYPT_MODE` and the spec constructor in the *same statement*, and the old `cipher.init(mode, key, spec)` had both hoisted into variables. Hoisting the spec, hoisting the mode, or passing a numeric opmode each bypassed it.

The rule is now structural instead of a token pair, and the reformulation is better than the original intent: the invariant never mentioned ENCRYPT at all. `Cipher.init` takes a parameter spec only when decrypting, so **any `init` with three or more arguments has to be provably a decrypt**. Argument counting is done at paren depth so nested calls do not inflate it. All four demonstrated bypasses are caught, including a straight revert of this PR's split.

**The guard could print OK on a failing scan.** `preprocess`'s exit status was checked but `scan`/`scan_with_strings` were bare command substitutions, so an ERE the local awk rejects (the BSD-awk case the header itself raises) yielded an empty result that read as "no violations". Both now abort the run.

**Also fixed, each verified by reintroduction:**
- The strings-intact pass had no string awareness, so the MIME wildcard `"*/*"` at `BackupRestoreScreen.kt:304` opened an unterminated block comment and hid the rest of that file from the `SHA1PRNG` rule. String state is tracked in both modes now; a `SHA1PRNG` appended to that specific file is detected.
- Rule 1 missed `SplittableRandom`, a fully-qualified `java.util.concurrent.ThreadLocalRandom.current()` (the leading `.` defeated the token anchor), and a seeded `SecureRandom(byteArray)` constructor.
- The opt-out marker waived rule 3. It no longer can: rule 3 reads a separate preprocessing pass where the marker is not honoured, because a catastrophic-and-silent failure mode should not have a `// trust me` escape hatch. The marker still works for rules 1 and 2, where UI jitter is a real use.
- `app/src/debug/**` was excluded from the scan despite shipping in debug builds. No such directory exists today, so this closed a future hole rather than a live one.
- The guard regexes now use bracket expressions rather than backslash escapes. gawk strips `\(` from an `-v` variable and then rejects the resulting unbalanced regex; that broke the sibling repo's guard in CI, where it correctly failed closed rather than passing.

**One correction to this PR's own framing.** The comment I wrote said an encrypt with a supplied IV "succeeds and the ciphertext looks fine". That is true of AES-GCM in general but probably not of this call path: Keystore keys are created with randomized encryption required by default, which is expected to reject a caller-supplied IV at init. I could not confirm the platform behaviour from this workspace, so the comment now says what is actually known: the platform backstop comes from another component, does not apply to a non-Keystore key, and is not visible at this call site. The split is still worth having for those reasons, not because the runtime would have stayed quiet.

**Filed, not fixed here:** the review found a pre-existing defect of exactly this PR's thesis in `nip55/PermissionDatabase.kt:143-160`. `KeystoreEncryptedPrefs.getTypedValue` swallows any decrypt exception and returns the default, so "unreadable" and "absent" are indistinguishable at that call site, and a transient Keystore fault makes it mint and store a **new** SQLCipher passphrase, orphaning the permissions database and the entire signing audit log. It logs nothing. That is a separate bug in a separate subsystem and belongs in its own change.

## Test plan (updated)
- [x] `./gradlew compileDebugKotlin testDebugUnitTest lintDebug` (JDK 21): BUILD SUCCESSFUL, 171 unit tests passed, lint clean with 0 errors and 0 warnings; recompiled clean after the comment correction
- [x] Guard: 15-case matrix. Flags a straight revert of this PR, a hoisted spec, a hoisted mode, a numeric opmode, an opt-out marker attempting to waive rule 3, `kotlin.random`, a hoisted-alphabet `.random()`, `java.util.Random`, `Math.random()`, `SplittableRandom`, fully-qualified `ThreadLocalRandom`, `SecureRandom.setSeed`, a seeded `SecureRandom` constructor, and an explicit `SHA1PRNG` provider
- [x] Stays clean on: a decrypt with a supplied IV, a two-argument encrypt, an unseeded `SecureRandom`, an opt-out marker on rules 1 and 2, a comment naming banned symbols, and a string literal mentioning `java.util.Random`
- [x] Guard fails closed at both stages: a stub `awk` exiting 2 during preprocessing and during scanning, and a run outside a git work tree
- [x] `SHA1PRNG` appended to `BackupRestoreScreen.kt` (the file with the `"*/*"` literal) is now detected, confirming the string-state fix
- [ ] Instrumented tests — not run locally, no device attached; CI's `instrumented-tests` job covers the Keystore path
