### PR TITLE
Add a host-only path for refreshing the Kotlin bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ git clone https://github.com/privkeyio/keep keep
 
 APK output: `app/build/outputs/apk/debug/app-debug.apk`. Gradle rebuilds the Rust libraries automatically when sources change. Set `KEEP_REPO` if the `keep` checkout lives elsewhere.
 
+## Typechecking against a changed core
+
+Changing keep-mobile's FFI leaves the generated Kotlin bindings stale, and regenerating them normally means a full Android cross-compile even though the Kotlin itself is platform independent. To refresh them from a plain host build instead:
+
+```bash
+KEEP_REPO=../keep ./scripts/refresh-bindings.sh
+./gradlew compileDebugKotlin
+```
+
+This needs no NDK, no `cargo-ndk` and no Android targets. It writes no `jniLibs`, so the app compiles but fails at runtime with an `UnsatisfiedLinkError` — use it while iterating on a core change, and `./gradlew assembleDebug` to run anything.
+
 Run `scripts/check-toolchain-pins.sh` to verify pinned versions are consistent across build scripts and CI workflows.
 
 # Contributing

--- a/scripts/refresh-bindings.sh
+++ b/scripts/refresh-bindings.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Regenerate the Kotlin FFI bindings without the Android toolchain.
+#
+# `build-rust.sh` cross-compiles keep-mobile for each Android ABI and then
+# generates bindings from one of the resulting .so files. That is what a
+# runnable APK needs, but it means a change to keep-mobile's FFI cannot be
+# typechecked here without the NDK, cargo-ndk and the Android targets, even
+# though the Kotlin it produces is platform independent.
+#
+# uniffi reads interface metadata from the library, not machine code, so a
+# plain host build carries the same metadata as a cross-compiled one. This
+# builds for the host and generates from that.
+#
+# This does NOT replace build-rust.sh. It writes no jniLibs, so the app will
+# compile and will fail at runtime with an UnsatisfiedLinkError. Use it to
+# typecheck against a changed core; use build-rust.sh to run anything.
+set -euo pipefail
+
+KEEP_REPO="${KEEP_REPO:-./keep}"
+if [ ! -d "$KEEP_REPO" ]; then
+    echo "error: KEEP_REPO path does not exist: $KEEP_REPO" >&2
+    exit 1
+fi
+KEEP_REPO="$(cd "$KEEP_REPO" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+RUST_PROJECT="$KEEP_REPO/keep-mobile"
+
+PROFILE="${PROFILE:-debug}"
+case "$PROFILE" in
+    debug) CARGO_PROFILE_ARGS=() ;;
+    release) CARGO_PROFILE_ARGS=(--release) ;;
+    *) echo "error: PROFILE must be debug or release, got: $PROFILE" >&2; exit 1 ;;
+esac
+
+cd "$RUST_PROJECT"
+
+echo "Building keep-mobile for the host ($PROFILE)..."
+cargo build "${CARGO_PROFILE_ARGS[@]}"
+
+# Resolve the target dir rather than assuming ../target: a workspace may set
+# CARGO_TARGET_DIR, and guessing would produce a confusing not-found on a
+# library that was built successfully.
+TARGET_DIR="$(cargo metadata --format-version 1 --no-deps | sed -nE 's/.*"target_directory":"([^"]*)".*/\1/p')"
+if [ -z "$TARGET_DIR" ]; then
+    echo "error: could not resolve cargo target directory" >&2
+    exit 1
+fi
+
+case "$(uname -s)" in
+    Darwin) LIB_NAME="libkeep_mobile.dylib" ;;
+    *)      LIB_NAME="libkeep_mobile.so" ;;
+esac
+LIB="$TARGET_DIR/$PROFILE/$LIB_NAME"
+if [ ! -f "$LIB" ]; then
+    echo "error: expected a cdylib at $LIB but it is not there." >&2
+    echo "keep-mobile must build as a cdylib for uniffi to read its metadata." >&2
+    exit 1
+fi
+
+echo "Generating Kotlin bindings from $LIB..."
+cargo run --features cli --bin uniffi-bindgen generate \
+    --library "$LIB" \
+    --language kotlin \
+    --out-dir "$SCRIPT_DIR/app/src/main/kotlin"
+
+GENERATED_KT="$SCRIPT_DIR/app/src/main/kotlin/io/privkey/keep/uniffi/keep_mobile.kt"
+if [ ! -f "$GENERATED_KT" ]; then
+    echo "error: bindings were not written to $GENERATED_KT" >&2
+    exit 1
+fi
+# Same suppression list build-rust.sh applies, so the two paths produce the
+# same file and switching between them does not show up as a diff.
+sed -i.bak 's/@file:Suppress([^)]*)/@file:Suppress("NAME_SHADOWING", "REDUNDANT_CALL_OF_CONVERSION_METHOD", "NOTHING_TO_INLINE", "UNUSED_PARAMETER", "UNUSED_EXPRESSION")/' "$GENERATED_KT"
+rm -f "$GENERATED_KT.bak"
+
+echo "Done. Bindings refreshed; no jniLibs were built, so this typechecks but does not run."


### PR DESCRIPTION
## Summary

Changing keep-mobile's FFI leaves the generated Kotlin stale, and the only way to refresh it was `build-rust.sh`, which cross-compiles for every Android ABI first. That is what a runnable APK needs, but it means the repository cannot be typechecked against a changed core without the NDK, cargo-ndk and the Android targets, even though the Kotlin uniffi emits is platform independent.

uniffi reads interface metadata from the library rather than machine code, so a host build carries the same metadata as a cross-compiled one. The new script builds for the host and generates from that.

It is deliberately not a replacement. No `jniLibs` are written, so the app compiles and then fails at runtime with an `UnsatisfiedLinkError`. The script says so on its last line and the README says so where it is introduced, because a faster path that quietly produces something unrunnable would cost more time than it saves.

Two details worth noting. The target directory is resolved through `cargo metadata` rather than assumed to be `../target`, since a workspace may set `CARGO_TARGET_DIR` and guessing would report a missing library that had in fact just built. And the same suppression rewrite `build-rust.sh` performs is applied here, so the two paths produce the same file and switching between them does not surface as a diff.

## Test plan

Verified end to end rather than by inspection. The script was run against this checkout, and the Kotlin it produced is byte-identical to the bindings the cross-compiled path had already written, confirmed with `diff`. The suppression line matches. `./gradlew compileDebugKotlin` then succeeds against the regenerated file, which is the thing the script exists to enable.

Shell syntax checked with `bash -n`. Both failure paths were written to fail loudly: a missing `KEEP_REPO`, and a library that is absent after a successful build, which would mean keep-mobile had stopped being a cdylib.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command-line workflow for refreshing generated Kotlin bindings after FFI changes.
  - Added validation and clear error reporting for missing build outputs or generated bindings.
  - Supports host-only builds without requiring Android NDK or Android targets.

- **Documentation**
  - Documented the binding refresh commands, limitations, and type-checking-only workflow.
  - Clarified that runtime execution is unavailable because JNI libraries are not generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->