### PR TITLE
Stop recommending a destructive clean when the keep worktree is dirty

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -148,7 +148,9 @@ tasks.register("verifyKeepVersion") {
                 "If these are yours (scratch output, editor files), do NOT clean the checkout. " +
                 "Build against a throwaway worktree instead, which leaves your files alone:\n" +
                 "  git -C $keepPath worktree add --detach /tmp/keep-$pinnedSha $pinnedSha\n" +
-                "  KEEP_REPO=/tmp/keep-$pinnedSha ./gradlew <task>\n" +
+                // A literal <task> would be shell input redirection, so the line
+                // could not be pasted as-is. Name a real task instead.
+                "  KEEP_REPO=/tmp/keep-$pinnedSha ./gradlew assembleDebug\n" +
                 "Only if the checkout is genuinely disposable: " +
                 "git -C $keepPath reset --hard $pinnedSha && git -C $keepPath clean -fdx " +
                 "(this DELETES every untracked file listed above)."

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -141,9 +141,17 @@ tasks.register("verifyKeepVersion") {
             "Fix: git -C $keepPath reset --hard $pinnedSha && git -C $keepPath clean -fdx"
         }
         if (statusOutput.isNotBlank()) {
+            val dirtyPaths = statusOutput.trim().lines().joinToString("\n") { "  $it" }
             throw GradleException(
-                "keep checkout at $keepPath has a dirty worktree, which bypasses SHA pinning. " +
-                "Fix: git -C $keepPath reset --hard $pinnedSha && git -C $keepPath clean -fdx"
+                "keep checkout at $keepPath has a dirty worktree, which bypasses SHA pinning.\n" +
+                "Dirty paths:\n$dirtyPaths\n" +
+                "If these are yours (scratch output, editor files), do NOT clean the checkout. " +
+                "Build against a throwaway worktree instead, which leaves your files alone:\n" +
+                "  git -C $keepPath worktree add --detach /tmp/keep-$pinnedSha $pinnedSha\n" +
+                "  KEEP_REPO=/tmp/keep-$pinnedSha ./gradlew <task>\n" +
+                "Only if the checkout is genuinely disposable: " +
+                "git -C $keepPath reset --hard $pinnedSha && git -C $keepPath clean -fdx " +
+                "(this DELETES every untracked file listed above)."
             )
         }
     }


### PR DESCRIPTION
`verifyKeepVersion` fails when the keep checkout has any dirty path, which is right: untracked files can bypass SHA pinning. The remedy it printed was the problem.

The message offered `git -C <keep> reset --hard <sha> && git -C <keep> clean -fdx` as *the* fix, with no indication of what that deletes. On a sibling `../keep` checkout used for feature-branch work, the dirty paths are routinely the developer's own untracked scratch (build output, `mutants.out/`, `contrib/`), and following the suggestion destroys all of it. The guard also did not say which paths were dirty, so there was no way to judge before running it.

Now it lists the offending paths, leads with the non-destructive route, and keeps the destructive one last with an explicit warning:

```
keep checkout at /path/to/keep has a dirty worktree, which bypasses SHA pinning.
Dirty paths:
  ?? mutants.out/
  ?? contrib/apt/
If these are yours (scratch output, editor files), do NOT clean the checkout. Build
against a throwaway worktree instead, which leaves your files alone:
  git -C /path/to/keep worktree add --detach /tmp/keep-<sha> <sha>
  KEEP_REPO=/tmp/keep-<sha> ./gradlew <task>
Only if the checkout is genuinely disposable: git -C /path/to/keep reset --hard <sha>
&& git -C /path/to/keep clean -fdx (this DELETES every untracked file listed above).
```

The `worktree` + `KEEP_REPO` path is what the existing sibling-repo workflow already supports, so this points at a supported route rather than inventing one.

No change to when the guard fires or what it accepts. Message only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for dirty checkouts by listing modified files.
  * Added guidance for resolving checkout issues using a temporary worktree.
  * Clearly identifies destructive reset-and-clean actions as an optional remediation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->