### PR TITLE
Add recover/discard UI for pending DKG share

### DIFF
--- a/app/src/androidTest/kotlin/io/privkey/keep/storage/PendingDkgMarkerStateTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/storage/PendingDkgMarkerStateTest.kt
@@ -1,0 +1,97 @@
+package io.privkey.keep.storage
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import io.privkey.keep.uniffi.KeepMobile
+import io.privkey.keep.uniffi.ShareMetadataInfo
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * `pendingDkgShare()` has three outcomes and the UI has to tell them apart: a
+ * marker is present, no marker exists, or the marker could not be read. Only
+ * the first two are safe to render as state. Reporting an unreadable marker as
+ * absent hides the recover/discard dialog while `frost_run_dkg` keeps
+ * fail-closing on the same read, which leaves group creation blocked with no
+ * reachable control to unblock it.
+ *
+ * These run against the real Keystore rather than a fake, because the failure
+ * being pinned is a storage-layer read fault and a fake would decide the answer
+ * the test is asking about.
+ */
+@RunWith(AndroidJUnit4::class)
+class PendingDkgMarkerStateTest {
+
+    private val context get() = InstrumentationRegistry.getInstrumentation().targetContext
+    private lateinit var storage: AndroidKeystoreStorage
+    private lateinit var mobile: KeepMobile
+
+    @Before fun setup() {
+        storage = AndroidKeystoreStorage(context, requireUserAuth = false)
+        mobile = KeepMobile(storage)
+        clearMarker()
+    }
+
+    @After fun teardown() = clearMarker()
+
+    private fun clearMarker() {
+        runCatching { mobile.discardPendingDkgShare() }
+    }
+
+    private fun writeMarker(json: String) {
+        storage.storeShareByKey(
+            MARKER_KEY,
+            json.toByteArray(Charsets.UTF_8),
+            ShareMetadataInfo("dkg_pending", 0u, 0u, 0u, ByteArray(0), false)
+        )
+    }
+
+    @Test fun absent_marker_reads_as_null() {
+        assertNull(mobile.pendingDkgShare())
+    }
+
+    @Test fun stored_marker_is_returned() {
+        writeMarker(VALID_MARKER)
+        val pending = mobile.pendingDkgShare()
+        assertNotNull(pending)
+        assertEquals("Family Wallet", pending!!.name)
+        assertEquals(true, pending.vaultProtected)
+    }
+
+    /**
+     * The load path only maps `StorageNotFound` to "nothing pending". A marker
+     * that is present but undeserializable must surface as a thrown error, not
+     * as null: null is what makes the discard escape hatch unreachable.
+     */
+    @Test fun unreadable_marker_throws_rather_than_reading_as_absent() {
+        writeMarker("{ this is not the marker json }")
+        assertThrows(Exception::class.java) { mobile.pendingDkgShare() }
+    }
+
+    /** Discard is the escape hatch, so it has to work on a corrupt marker too. */
+    @Test fun discard_clears_an_unreadable_marker() {
+        writeMarker("{ this is not the marker json }")
+        assertThrows(Exception::class.java) { mobile.pendingDkgShare() }
+        mobile.discardPendingDkgShare()
+        assertNull(mobile.pendingDkgShare())
+    }
+
+    @Test fun discard_clears_a_valid_marker() {
+        writeMarker(VALID_MARKER)
+        assertNotNull(mobile.pendingDkgShare())
+        mobile.discardPendingDkgShare()
+        assertNull(mobile.pendingDkgShare())
+    }
+
+    private companion object {
+        const val MARKER_KEY = "__keep_dkg_pending_v1"
+        const val VALID_MARKER =
+            """{"schema_version":1,"name":"Family Wallet","group_pubkey_hex":"aa","vault_protected":true}"""
+    }
+}

--- a/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
+++ b/app/src/main/kotlin/io/privkey/keep/AccountActions.kt
@@ -529,8 +529,15 @@ internal class AccountActions(
      * mid-import. Reads only the non-auth marker, so it needs no biometric.
      * `null` when nothing is pending.
      */
-    suspend fun pendingDkgShare(): PendingShareInfo? = withContext(Dispatchers.IO) {
-        runCatching { keepMobile.pendingDkgShare() }.getOrNull()
+    /**
+     * `Ok(null)` means nothing is pending; a failure means the stash could not be
+     * read and must not be rendered as absence. The Rust draws the same
+     * distinction deliberately (`pending_dkg_share`), because a marker that reads
+     * as absent while `frost_run_dkg` still fail-closes on it strands the user
+     * with no way to reach the discard escape hatch.
+     */
+    suspend fun pendingDkgShare(): Result<PendingShareInfo?> = withContext(Dispatchers.IO) {
+        runCatching { keepMobile.pendingDkgShare() }
     }
 
     /**
@@ -556,24 +563,40 @@ internal class AccountActions(
         title: String,
         subtitle: String,
         onResult: (ShareInfo?) -> Unit,
-        onDismiss: () -> Unit
+        // Null reason means the user cancelled and needs no message. Any other stop
+        // must carry one: Recover sits in an undismissable dialog whose only other
+        // button destroys the share, so a silent no-op reads as a dead button.
+        onDismiss: (String?) -> Unit
     ) {
         coroutineScope.launch {
-            val pending = pendingDkgShare()
-            if (pending == null || !pending.vaultProtected) {
-                onDismiss()
+            val pendingResult = pendingDkgShare()
+            val pending = pendingResult.getOrNull()
+            if (pending == null) {
+                // Genuinely absent -> no exception -> nothing to say. A read failure
+                // here carries a message and must not look like a dead button.
+                onDismiss(pendingResult.exceptionOrNull()?.message)
                 return@launch
             }
-            val decryptCipher = withContext(Dispatchers.IO) {
-                runCatching { storage.getDkgSecretDecryptCipher() }.getOrNull()
+            if (!pending.vaultProtected) {
+                onDismiss(appContext.getString(R.string.main_pending_dkg_recover_passphrase_required))
+                return@launch
             }
+            // A re-enrolled fingerprint invalidates the alias, and the exception
+            // carries the only actionable text ("please re-import your share").
+            val decryptAttempt = withContext(Dispatchers.IO) {
+                runCatching { storage.getDkgSecretDecryptCipher() }
+            }
+            val decryptCipher = decryptAttempt.getOrNull()
             if (decryptCipher == null) {
-                onDismiss()
+                onDismiss(
+                    decryptAttempt.exceptionOrNull()?.message
+                        ?: appContext.getString(R.string.main_pending_dkg_recover_unavailable)
+                )
                 return@launch
             }
             onBiometricRequest(title, subtitle, decryptCipher) { authedDecrypt ->
                 if (authedDecrypt == null) {
-                    onDismiss()
+                    onDismiss(null)
                     return@onBiometricRequest
                 }
                 requestEncryptCipherAndRecover(pending.groupPubkey, title, subtitle, authedDecrypt, onResult, onDismiss)
@@ -587,19 +610,23 @@ internal class AccountActions(
         subtitle: String,
         authedDecrypt: Cipher,
         onResult: (ShareInfo?) -> Unit,
-        onDismiss: () -> Unit
+        onDismiss: (String?) -> Unit
     ) {
         coroutineScope.launch {
-            val encryptCipher = withContext(Dispatchers.IO) {
-                runCatching { storage.getCipherForShareEncryption(groupPubkeyHex) }.getOrNull()
+            val encryptAttempt = withContext(Dispatchers.IO) {
+                runCatching { storage.getCipherForShareEncryption(groupPubkeyHex) }
             }
+            val encryptCipher = encryptAttempt.getOrNull()
             if (encryptCipher == null) {
-                onDismiss()
+                onDismiss(
+                    encryptAttempt.exceptionOrNull()?.message
+                        ?: appContext.getString(R.string.main_pending_dkg_recover_unavailable)
+                )
                 return@launch
             }
             onBiometricRequest(title, subtitle, encryptCipher) { authedEncrypt ->
                 if (authedEncrypt == null) {
-                    onDismiss()
+                    onDismiss(null)
                     return@onBiometricRequest
                 }
                 finishRecoverDkgShare(authedDecrypt, authedEncrypt, onResult)

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -339,6 +339,13 @@ fun MainScreen(
     // same error, so collapsing it to null blocks group creation while hiding the only
     // control that can clear the block.
     var pendingDkgUnreadable by remember { mutableStateOf(false) }
+    // Bumped on every local mutation of the marker state. A poll captures it before its
+    // read and drops the result if it changed, so a read that started before a discard
+    // can't land afterward and resurrect the marker it just cleared. A plain
+    // in-progress flag can't cover this: the flag is already false by the time the
+    // stale result applies.
+    var pendingDkgEpoch by remember { mutableIntStateOf(0) }
+    var pendingDkgDeferred by remember { mutableStateOf(false) }
     var showDiscardDkgConfirm by remember { mutableStateOf(false) }
     var dkgDiscardInProgress by remember { mutableStateOf(false) }
     var dkgRecoveryInProgress by remember { mutableStateOf(false) }
@@ -548,6 +555,7 @@ fun MainScreen(
         }
         lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
             repeat(Int.MAX_VALUE) {
+                val dkgEpochAtRead = pendingDkgEpoch
                 val pollResult = withContext(Dispatchers.IO) {
                     val h = keepMobile.hasShare()
                     val s = keepMobile.getShareInfo()
@@ -574,7 +582,7 @@ fun MainScreen(
                 activeDidBackup = pollResult.activeDidBackup
                 // Don't clobber the dialog state mid-recovery: an in-flight biometric
                 // chain hasn't cleared the marker yet, so a poll would re-show it.
-                if (!dkgRecoveryInProgress) {
+                if (!dkgRecoveryInProgress && !dkgDiscardInProgress && pendingDkgEpoch == dkgEpochAtRead) {
                     // Keep the last known marker on a read failure rather than clearing it.
                     pollResult.pendingDkgShare
                         .onSuccess { pendingDkgShare = it; pendingDkgUnreadable = false }
@@ -1199,6 +1207,7 @@ fun MainScreen(
             if (ok) {
                 pendingDkgShare = null
                 pendingDkgUnreadable = false
+                pendingDkgEpoch++
             } else {
                 Toast.makeText(appContext, pendingDkgDiscardFailedMessage, Toast.LENGTH_LONG).show()
             }
@@ -1236,6 +1245,7 @@ fun MainScreen(
                                 if (info != null) {
                                     pendingDkgShare = null
                                     pendingDkgUnreadable = false
+                                    pendingDkgEpoch++
                                     Toast.makeText(appContext, pendingDkgRecoveredMessage, Toast.LENGTH_SHORT).show()
                                 } else {
                                     Toast.makeText(appContext, pendingDkgRecoverFailedMessage, Toast.LENGTH_LONG).show()
@@ -1256,12 +1266,13 @@ fun MainScreen(
                 onDiscard = { showDiscardDkgConfirm = true }
             )
         }
-        pendingDkgUnreadable -> {
+        pendingDkgUnreadable && !pendingDkgDeferred -> {
             PendingDkgUnreadableDialog(
+                onLater = { pendingDkgDeferred = true },
                 onRetry = {
                     coroutineScope.launch {
                         withContext(Dispatchers.IO) { runCatching { keepMobile.pendingDkgShare() } }
-                            .onSuccess { pendingDkgShare = it; pendingDkgUnreadable = false }
+                            .onSuccess { pendingDkgShare = it; pendingDkgUnreadable = false; pendingDkgEpoch++ }
                             .onFailure {
                                 Toast.makeText(appContext, pendingDkgStillUnreadableMessage, Toast.LENGTH_LONG).show()
                             }
@@ -2133,18 +2144,25 @@ private fun PendingDkgShareDialog(
 
 @Composable
 private fun PendingDkgUnreadableDialog(
+    onLater: () -> Unit,
     onRetry: () -> Unit,
     onDiscard: () -> Unit
 ) {
+    // Storage being unreadable must not corner the user into the destructive option to
+    // get their app back. Dismissing only hides the dialog for the session; the Rust
+    // still fail-closes group creation, so nothing unsafe is unlocked by deferring.
     AlertDialog(
-        onDismissRequest = {},
+        onDismissRequest = onLater,
         title = { Text(stringResource(R.string.main_pending_dkg_unreadable_title)) },
         text = { Text(stringResource(R.string.main_pending_dkg_unreadable_text)) },
         confirmButton = {
             TextButton(onClick = onRetry) { Text(stringResource(R.string.main_pending_dkg_retry)) }
         },
         dismissButton = {
-            TextButton(onClick = onDiscard) { Text(stringResource(R.string.main_pending_dkg_discard)) }
+            Row {
+                TextButton(onClick = onDiscard) { Text(stringResource(R.string.main_pending_dkg_discard)) }
+                TextButton(onClick = onLater) { Text(stringResource(R.string.main_pending_dkg_later)) }
+            }
         }
     )
 }

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -334,6 +334,9 @@ fun MainScreen(
     var showHistoryScreen by remember { mutableStateOf(false) }
     var showSignPolicyScreen by remember { mutableStateOf(false) }
     var showRelayAuthWhitelistScreen by remember { mutableStateOf(false) }
+    var pendingDkgShare by remember { mutableStateOf<PendingShareInfo?>(null) }
+    var showDiscardDkgConfirm by remember { mutableStateOf(false) }
+    var dkgRecoveryInProgress by remember { mutableStateOf(false) }
     var importState by remember { mutableStateOf<ImportState>(ImportState.Idle) }
     var createGroupState by remember { mutableStateOf<CreateGroupState>(CreateGroupState.Idle) }
     var createGroupRun by remember { mutableStateOf(0) }
@@ -504,12 +507,14 @@ fun MainScreen(
                 ?: RelayConfigInfo(emptyList(), emptyList(), emptyList())
             val r = config.frostRelays
             val pr = config.profileRelays
-            AccountInitial(a, k, r, pr)
+            val pdkg = runCatching { keepMobile.pendingDkgShare() }.getOrNull()
+            AccountInitial(a, k, r, pr, pdkg)
         }
         allAccounts = initial.accounts
         activeAccountKey = initial.activeKey
         relays = initial.relays
         profileRelays = initial.profileRelays
+        pendingDkgShare = initial.pendingDkgShare
     }
 
     LaunchedEffect(Unit) {
@@ -541,7 +546,11 @@ fun MainScreen(
                     val db = runCatching { keepMobile.getActiveShareMetadata()?.didBackup }
                         .onFailure { if (it is CancellationException) throw it }
                         .getOrNull()
-                    PollResult(h, s, a, k, dc, db)
+                    // Marker-only read, no biometric; safe to poll.
+                    val pdkg = runCatching { keepMobile.pendingDkgShare() }
+                        .onFailure { if (it is CancellationException) throw it }
+                        .getOrNull()
+                    PollResult(h, s, a, k, dc, db, pdkg)
                 }
                 hasShare = pollResult.hasShare
                 shareInfo = pollResult.shareInfo
@@ -549,6 +558,9 @@ fun MainScreen(
                 activeAccountKey = pollResult.activeAccountKey
                 descriptorCount = pollResult.descriptorCount
                 activeDidBackup = pollResult.activeDidBackup
+                // Don't clobber the dialog state mid-recovery: an in-flight biometric
+                // chain hasn't cleared the marker yet, so a poll would re-show it.
+                if (!dkgRecoveryInProgress) pendingDkgShare = pollResult.pendingDkgShare
                 refreshCertificatePins()
                 profileRelays = withContext(Dispatchers.IO) { loadProfileRelays(pollResult.activeAccountKey) }
                 delay(10_000)
@@ -1125,6 +1137,53 @@ fun MainScreen(
     val initEncryptionFailedMessage = stringResource(R.string.main_init_encryption_failed)
     val connectRelaysTitle = stringResource(R.string.main_connect_relays_title)
     val connectRelaysSubtitle = stringResource(R.string.main_connect_relays_subtitle)
+
+    val pendingDkgRecoverTitle = stringResource(R.string.main_pending_dkg_recover_title)
+    val pendingDkgRecoverSubtitle = stringResource(R.string.main_pending_dkg_recover_subtitle)
+    val pendingDkgRecoveredMessage = stringResource(R.string.main_pending_dkg_recovered)
+    val pendingDkgRecoverFailedMessage = stringResource(R.string.main_pending_dkg_recover_failed)
+
+    pendingDkgShare?.let { pending ->
+        if (showDiscardDkgConfirm) {
+            DiscardPendingDkgDialog(
+                onConfirm = {
+                    coroutineScope.launch {
+                        withContext(Dispatchers.IO) { accountActions.discardPendingDkgShare() }
+                        pendingDkgShare = null
+                        showDiscardDkgConfirm = false
+                    }
+                },
+                onDismiss = { showDiscardDkgConfirm = false }
+            )
+        } else if (!dkgRecoveryInProgress) {
+            PendingDkgShareDialog(
+                groupName = pending.name,
+                onRecover = {
+                    try {
+                        requireBiometricReady()
+                        dkgRecoveryInProgress = true
+                        accountActions.recoverPendingDkgShare(
+                            title = pendingDkgRecoverTitle,
+                            subtitle = pendingDkgRecoverSubtitle,
+                            onResult = { info ->
+                                dkgRecoveryInProgress = false
+                                if (info != null) {
+                                    pendingDkgShare = null
+                                    Toast.makeText(appContext, pendingDkgRecoveredMessage, Toast.LENGTH_SHORT).show()
+                                } else {
+                                    Toast.makeText(appContext, pendingDkgRecoverFailedMessage, Toast.LENGTH_LONG).show()
+                                }
+                            },
+                            onDismiss = { dkgRecoveryInProgress = false }
+                        )
+                    } catch (e: BiometricHelper.BiometricNotReadyException) {
+                        Toast.makeText(appContext, e.message ?: biometricUnavailableMessage, Toast.LENGTH_LONG).show()
+                    }
+                },
+                onDiscard = { showDiscardDkgConfirm = true }
+            )
+        }
+    }
 
     val navController = rememberNavController()
 
@@ -1908,7 +1967,8 @@ private data class AccountInitial(
     val accounts: List<AccountInfo>,
     val activeKey: String?,
     val relays: List<String>,
-    val profileRelays: List<String>
+    val profileRelays: List<String>,
+    val pendingDkgShare: PendingShareInfo?
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -1943,7 +2003,8 @@ private data class PollResult(
     val allAccounts: List<AccountInfo>,
     val activeAccountKey: String?,
     val descriptorCount: Int,
-    val activeDidBackup: Boolean?
+    val activeDidBackup: Boolean?,
+    val pendingDkgShare: PendingShareInfo?
 )
 
 @Composable
@@ -1957,6 +2018,48 @@ private fun KillSwitchConfirmDialog(
         text = { Text(stringResource(R.string.main_kill_switch_dialog_text)) },
         confirmButton = {
             TextButton(onClick = onConfirm) { Text(stringResource(R.string.main_enable)) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.main_cancel)) }
+        }
+    )
+}
+
+@Composable
+private fun PendingDkgShareDialog(
+    groupName: String,
+    onRecover: () -> Unit,
+    onDiscard: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = {},
+        title = { Text(stringResource(R.string.main_pending_dkg_title)) },
+        text = { Text(stringResource(R.string.main_pending_dkg_text, groupName)) },
+        confirmButton = {
+            TextButton(onClick = onRecover) { Text(stringResource(R.string.main_pending_dkg_recover)) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDiscard) { Text(stringResource(R.string.main_pending_dkg_discard)) }
+        }
+    )
+}
+
+@Composable
+private fun DiscardPendingDkgDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.main_pending_dkg_discard_confirm_title)) },
+        text = { Text(stringResource(R.string.main_pending_dkg_discard_confirm_text)) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(
+                    stringResource(R.string.main_pending_dkg_discard),
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) { Text(stringResource(R.string.main_cancel)) }

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -335,6 +335,10 @@ fun MainScreen(
     var showSignPolicyScreen by remember { mutableStateOf(false) }
     var showRelayAuthWhitelistScreen by remember { mutableStateOf(false) }
     var pendingDkgShare by remember { mutableStateOf<PendingShareInfo?>(null) }
+    // A failed marker read is NOT "nothing pending": frost_run_dkg fail-closes on the
+    // same error, so collapsing it to null blocks group creation while hiding the only
+    // control that can clear the block.
+    var pendingDkgUnreadable by remember { mutableStateOf(false) }
     var showDiscardDkgConfirm by remember { mutableStateOf(false) }
     var dkgDiscardInProgress by remember { mutableStateOf(false) }
     var dkgRecoveryInProgress by remember { mutableStateOf(false) }
@@ -516,14 +520,16 @@ fun MainScreen(
                 ?: RelayConfigInfo(emptyList(), emptyList(), emptyList())
             val r = config.frostRelays
             val pr = config.profileRelays
-            val pdkg = runCatching { keepMobile.pendingDkgShare() }.getOrNull()
+            val pdkg = runCatching { keepMobile.pendingDkgShare() }
             AccountInitial(a, k, r, pr, pdkg)
         }
         allAccounts = initial.accounts
         activeAccountKey = initial.activeKey
         relays = initial.relays
         profileRelays = initial.profileRelays
-        pendingDkgShare = initial.pendingDkgShare
+        initial.pendingDkgShare
+            .onSuccess { pendingDkgShare = it; pendingDkgUnreadable = false }
+            .onFailure { pendingDkgUnreadable = true }
     }
 
     LaunchedEffect(Unit) {
@@ -558,7 +564,6 @@ fun MainScreen(
                     // Marker-only read, no biometric; safe to poll.
                     val pdkg = runCatching { keepMobile.pendingDkgShare() }
                         .onFailure { if (it is CancellationException) throw it }
-                        .getOrNull()
                     PollResult(h, s, a, k, dc, db, pdkg)
                 }
                 hasShare = pollResult.hasShare
@@ -569,7 +574,12 @@ fun MainScreen(
                 activeDidBackup = pollResult.activeDidBackup
                 // Don't clobber the dialog state mid-recovery: an in-flight biometric
                 // chain hasn't cleared the marker yet, so a poll would re-show it.
-                if (!dkgRecoveryInProgress) pendingDkgShare = pollResult.pendingDkgShare
+                if (!dkgRecoveryInProgress) {
+                    // Keep the last known marker on a read failure rather than clearing it.
+                    pollResult.pendingDkgShare
+                        .onSuccess { pendingDkgShare = it; pendingDkgUnreadable = false }
+                        .onFailure { pendingDkgUnreadable = true }
+                }
                 refreshCertificatePins()
                 profileRelays = withContext(Dispatchers.IO) { loadProfileRelays(pollResult.activeAccountKey) }
                 delay(10_000)
@@ -1161,37 +1171,47 @@ fun MainScreen(
     val pendingDkgDiscardAuthSubtitle = stringResource(R.string.main_pending_dkg_discard_auth_subtitle)
     val pendingDkgDiscardLabel = stringResource(R.string.main_pending_dkg_discard)
     val pendingDkgDiscardFailedMessage = stringResource(R.string.main_pending_dkg_discard_failed)
+    val pendingDkgStillUnreadableMessage = stringResource(R.string.main_pending_dkg_still_unreadable)
 
-    pendingDkgShare?.let { pending ->
-        if (showDiscardDkgConfirm) {
+    // Reaching neither a marker nor an error means there is nothing to confirm; drop a
+    // stale confirm so a later poll can't re-present the destructive dialog unprompted.
+    LaunchedEffect(pendingDkgShare, pendingDkgUnreadable) {
+        if (pendingDkgShare == null && !pendingDkgUnreadable) showDiscardDkgConfirm = false
+    }
+
+    fun startPendingDkgDiscard() {
+        // Single-flight: a double-tap must not launch two concurrent discards
+        // (the native call takes no lock of its own).
+        if (dkgDiscardInProgress) return
+        dkgDiscardInProgress = true
+        // Destructive: gate behind a verified auth factor. Uses the auth-only
+        // prompt (not the DKG vault cipher) so discard still works when the
+        // stash is unrecoverable -- its whole reason to exist.
+        requireAuthThen(
+            pendingDkgDiscardAuthTitle,
+            pendingDkgDiscardAuthSubtitle,
+            pendingDkgDiscardLabel,
+            onCancel = { dkgDiscardInProgress = false }
+        ) {
+            val ok = withContext(Dispatchers.IO) {
+                runCatching { accountActions.discardPendingDkgShare() }.isSuccess
+            }
+            if (ok) {
+                pendingDkgShare = null
+                pendingDkgUnreadable = false
+            } else {
+                Toast.makeText(appContext, pendingDkgDiscardFailedMessage, Toast.LENGTH_LONG).show()
+            }
+            showDiscardDkgConfirm = false
+            dkgDiscardInProgress = false
+        }
+    }
+
+    val pendingDkg = pendingDkgShare
+    when {
+        showDiscardDkgConfirm && (pendingDkg != null || pendingDkgUnreadable) -> {
             DiscardPendingDkgDialog(
-                onConfirm = {
-                    // Single-flight: a double-tap must not launch two concurrent discards
-                    // (the native call takes no lock of its own).
-                    if (!dkgDiscardInProgress) {
-                        dkgDiscardInProgress = true
-                        // Destructive: gate behind a verified auth factor. Uses the auth-only
-                        // prompt (not the DKG vault cipher) so discard still works when the
-                        // stash is unrecoverable -- its whole reason to exist.
-                        requireAuthThen(
-                            pendingDkgDiscardAuthTitle,
-                            pendingDkgDiscardAuthSubtitle,
-                            pendingDkgDiscardLabel,
-                            onCancel = { dkgDiscardInProgress = false }
-                        ) {
-                            val ok = withContext(Dispatchers.IO) {
-                                runCatching { accountActions.discardPendingDkgShare() }.isSuccess
-                            }
-                            if (ok) {
-                                pendingDkgShare = null
-                            } else {
-                                Toast.makeText(appContext, pendingDkgDiscardFailedMessage, Toast.LENGTH_LONG).show()
-                            }
-                            showDiscardDkgConfirm = false
-                            dkgDiscardInProgress = false
-                        }
-                    }
-                },
+                onConfirm = { startPendingDkgDiscard() },
                 onDismiss = {
                     // Backing out of the confirm dialog itself; auth-cancel is handled by
                     // requireAuthThen's onCancel above.
@@ -1199,9 +1219,10 @@ fun MainScreen(
                     showDiscardDkgConfirm = false
                 }
             )
-        } else if (!dkgRecoveryInProgress) {
+        }
+        pendingDkg != null && !dkgRecoveryInProgress -> {
             PendingDkgShareDialog(
-                groupName = pending.name,
+                groupName = pendingDkg.name,
                 onRecover = {
                     // Single-flight: a same-frame double-tap must not start two recoveries.
                     if (!dkgRecoveryInProgress) try {
@@ -1214,15 +1235,36 @@ fun MainScreen(
                                 dkgRecoveryInProgress = false
                                 if (info != null) {
                                     pendingDkgShare = null
+                                    pendingDkgUnreadable = false
                                     Toast.makeText(appContext, pendingDkgRecoveredMessage, Toast.LENGTH_SHORT).show()
                                 } else {
                                     Toast.makeText(appContext, pendingDkgRecoverFailedMessage, Toast.LENGTH_LONG).show()
                                 }
                             },
-                            onDismiss = { dkgRecoveryInProgress = false }
+                            onDismiss = { reason ->
+                                dkgRecoveryInProgress = false
+                                // Null means the user cancelled; anything else has to be shown.
+                                if (reason != null) {
+                                    Toast.makeText(appContext, reason, Toast.LENGTH_LONG).show()
+                                }
+                            }
                         )
                     } catch (e: BiometricHelper.BiometricNotReadyException) {
                         Toast.makeText(appContext, e.message ?: biometricUnavailableMessage, Toast.LENGTH_LONG).show()
+                    }
+                },
+                onDiscard = { showDiscardDkgConfirm = true }
+            )
+        }
+        pendingDkgUnreadable -> {
+            PendingDkgUnreadableDialog(
+                onRetry = {
+                    coroutineScope.launch {
+                        withContext(Dispatchers.IO) { runCatching { keepMobile.pendingDkgShare() } }
+                            .onSuccess { pendingDkgShare = it; pendingDkgUnreadable = false }
+                            .onFailure {
+                                Toast.makeText(appContext, pendingDkgStillUnreadableMessage, Toast.LENGTH_LONG).show()
+                            }
                     }
                 },
                 onDiscard = { showDiscardDkgConfirm = true }
@@ -2013,7 +2055,7 @@ private data class AccountInitial(
     val activeKey: String?,
     val relays: List<String>,
     val profileRelays: List<String>,
-    val pendingDkgShare: PendingShareInfo?
+    val pendingDkgShare: Result<PendingShareInfo?>
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -2049,7 +2091,7 @@ private data class PollResult(
     val activeAccountKey: String?,
     val descriptorCount: Int,
     val activeDidBackup: Boolean?,
-    val pendingDkgShare: PendingShareInfo?
+    val pendingDkgShare: Result<PendingShareInfo?>
 )
 
 @Composable
@@ -2082,6 +2124,24 @@ private fun PendingDkgShareDialog(
         text = { Text(stringResource(R.string.main_pending_dkg_text, groupName)) },
         confirmButton = {
             TextButton(onClick = onRecover) { Text(stringResource(R.string.main_pending_dkg_recover)) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDiscard) { Text(stringResource(R.string.main_pending_dkg_discard)) }
+        }
+    )
+}
+
+@Composable
+private fun PendingDkgUnreadableDialog(
+    onRetry: () -> Unit,
+    onDiscard: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = {},
+        title = { Text(stringResource(R.string.main_pending_dkg_unreadable_title)) },
+        text = { Text(stringResource(R.string.main_pending_dkg_unreadable_text)) },
+        confirmButton = {
+            TextButton(onClick = onRetry) { Text(stringResource(R.string.main_pending_dkg_retry)) }
         },
         dismissButton = {
             TextButton(onClick = onDiscard) { Text(stringResource(R.string.main_pending_dkg_discard)) }

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -364,6 +364,8 @@ fun MainScreen(
     // Re-auth gate for security-downgrade actions (e.g. clearing/removing a certificate
     // pin, which re-opens trust-on-first-use for that host).
     var pendingAuthGateAction by remember { mutableStateOf<(suspend () -> Unit)?>(null) }
+    // Runs when the pin gate is dismissed without a verified pin; neutralized on success.
+    var pendingAuthGateCancel by remember { mutableStateOf<() -> Unit>({}) }
     var authGateTitle by remember { mutableStateOf("") }
     var authGateMessage by remember { mutableStateOf("") }
     var authGateConfirm by remember { mutableStateOf("") }
@@ -431,23 +433,29 @@ fun MainScreen(
     // Runs [action] only after a verified auth factor: biometric when available, else a
     // PIN prompt, else (no factor configured) immediately, consistent with the rest of the
     // app in that config. Used to gate security-downgrade actions like clearing a cert pin.
-    val requireAuthThen: (String, String, String, suspend () -> Unit) -> Unit =
-        { title, message, confirmLabel, action ->
-            when {
-                biometricAvailable -> coroutineScope.launch {
-                    // Downgrade gate (cert-pin clear/retire, app-lock weakening): force a
-                    // live prompt rather than accepting an open biometric-timeout window.
-                    if (onBiometricAuth?.invoke(title, message, true) == true) action()
-                }
-                pinEnabled -> {
-                    authGateTitle = title
-                    authGateMessage = message
-                    authGateConfirm = confirmLabel
-                    pendingAuthGateAction = action
-                }
-                else -> coroutineScope.launch { action() }
+    fun requireAuthThen(
+        title: String,
+        message: String,
+        confirmLabel: String,
+        onCancel: () -> Unit = {},
+        action: suspend () -> Unit
+    ) {
+        when {
+            biometricAvailable -> coroutineScope.launch {
+                // Downgrade gate (cert-pin clear/retire, app-lock weakening): force a
+                // live prompt rather than accepting an open biometric-timeout window.
+                if (onBiometricAuth?.invoke(title, message, true) == true) action() else onCancel()
             }
+            pinEnabled -> {
+                authGateTitle = title
+                authGateMessage = message
+                authGateConfirm = confirmLabel
+                pendingAuthGateCancel = onCancel
+                pendingAuthGateAction = action
+            }
+            else -> coroutineScope.launch { action() }
         }
+    }
 
     val accountActions = remember {
         AccountActions(
@@ -621,13 +629,19 @@ fun MainScreen(
             onVerify = { pin ->
                 val verified = withContext(Dispatchers.IO) { pinStore.verifyPin(pin) }
                 if (verified) {
+                    // Success dismisses the dialog too; drop the cancel so it doesn't fire.
+                    pendingAuthGateCancel = {}
                     action()
                     true
                 } else {
                     false
                 }
             },
-            onDismiss = { pendingAuthGateAction = null }
+            onDismiss = {
+                pendingAuthGateCancel()
+                pendingAuthGateCancel = {}
+                pendingAuthGateAction = null
+            }
         )
     }
 
@@ -665,7 +679,7 @@ fun MainScreen(
                         appContext.getString(R.string.settings_biometric_timeout_reauth_title),
                         appContext.getString(R.string.settings_biometric_timeout_reauth_text),
                         appContext.getString(R.string.settings_reauth_confirm),
-                        applyTimeout,
+                        action = applyTimeout,
                     )
                 } else {
                     coroutineScope.launch { applyTimeout() }
@@ -683,7 +697,7 @@ fun MainScreen(
                         appContext.getString(R.string.settings_biometric_lock_disable_reauth_title),
                         appContext.getString(R.string.settings_biometric_lock_disable_reauth_text),
                         appContext.getString(R.string.settings_reauth_confirm),
-                        applyLockOnLaunch,
+                        action = applyLockOnLaunch,
                     )
                 } else {
                     coroutineScope.launch { applyLockOnLaunch() }
@@ -1162,7 +1176,8 @@ fun MainScreen(
                         requireAuthThen(
                             pendingDkgDiscardAuthTitle,
                             pendingDkgDiscardAuthSubtitle,
-                            pendingDkgDiscardLabel
+                            pendingDkgDiscardLabel,
+                            onCancel = { dkgDiscardInProgress = false }
                         ) {
                             val ok = withContext(Dispatchers.IO) {
                                 runCatching { accountActions.discardPendingDkgShare() }.isSuccess
@@ -1178,8 +1193,8 @@ fun MainScreen(
                     }
                 },
                 onDismiss = {
-                    // Also clears the guard if the user backed out after an auth cancel;
-                    // requireAuthThen has no failure callback to reset it otherwise.
+                    // Backing out of the confirm dialog itself; auth-cancel is handled by
+                    // requireAuthThen's onCancel above.
                     dkgDiscardInProgress = false
                     showDiscardDkgConfirm = false
                 }
@@ -1188,7 +1203,8 @@ fun MainScreen(
             PendingDkgShareDialog(
                 groupName = pending.name,
                 onRecover = {
-                    try {
+                    // Single-flight: a same-frame double-tap must not start two recoveries.
+                    if (!dkgRecoveryInProgress) try {
                         requireBiometricReady()
                         dkgRecoveryInProgress = true
                         accountActions.recoverPendingDkgShare(

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -336,6 +336,7 @@ fun MainScreen(
     var showRelayAuthWhitelistScreen by remember { mutableStateOf(false) }
     var pendingDkgShare by remember { mutableStateOf<PendingShareInfo?>(null) }
     var showDiscardDkgConfirm by remember { mutableStateOf(false) }
+    var dkgDiscardInProgress by remember { mutableStateOf(false) }
     var dkgRecoveryInProgress by remember { mutableStateOf(false) }
     var importState by remember { mutableStateOf<ImportState>(ImportState.Idle) }
     var createGroupState by remember { mutableStateOf<CreateGroupState>(CreateGroupState.Idle) }
@@ -1142,18 +1143,46 @@ fun MainScreen(
     val pendingDkgRecoverSubtitle = stringResource(R.string.main_pending_dkg_recover_subtitle)
     val pendingDkgRecoveredMessage = stringResource(R.string.main_pending_dkg_recovered)
     val pendingDkgRecoverFailedMessage = stringResource(R.string.main_pending_dkg_recover_failed)
+    val pendingDkgDiscardAuthTitle = stringResource(R.string.main_pending_dkg_discard_auth_title)
+    val pendingDkgDiscardAuthSubtitle = stringResource(R.string.main_pending_dkg_discard_auth_subtitle)
+    val pendingDkgDiscardLabel = stringResource(R.string.main_pending_dkg_discard)
+    val pendingDkgDiscardFailedMessage = stringResource(R.string.main_pending_dkg_discard_failed)
 
     pendingDkgShare?.let { pending ->
         if (showDiscardDkgConfirm) {
             DiscardPendingDkgDialog(
                 onConfirm = {
-                    coroutineScope.launch {
-                        withContext(Dispatchers.IO) { accountActions.discardPendingDkgShare() }
-                        pendingDkgShare = null
-                        showDiscardDkgConfirm = false
+                    // Single-flight: a double-tap must not launch two concurrent discards
+                    // (the native call takes no lock of its own).
+                    if (!dkgDiscardInProgress) {
+                        dkgDiscardInProgress = true
+                        // Destructive: gate behind a verified auth factor. Uses the auth-only
+                        // prompt (not the DKG vault cipher) so discard still works when the
+                        // stash is unrecoverable -- its whole reason to exist.
+                        requireAuthThen(
+                            pendingDkgDiscardAuthTitle,
+                            pendingDkgDiscardAuthSubtitle,
+                            pendingDkgDiscardLabel
+                        ) {
+                            val ok = withContext(Dispatchers.IO) {
+                                runCatching { accountActions.discardPendingDkgShare() }.isSuccess
+                            }
+                            if (ok) {
+                                pendingDkgShare = null
+                            } else {
+                                Toast.makeText(appContext, pendingDkgDiscardFailedMessage, Toast.LENGTH_LONG).show()
+                            }
+                            showDiscardDkgConfirm = false
+                            dkgDiscardInProgress = false
+                        }
                     }
                 },
-                onDismiss = { showDiscardDkgConfirm = false }
+                onDismiss = {
+                    // Also clears the guard if the user backed out after an auth cancel;
+                    // requireAuthThen has no failure callback to reset it otherwise.
+                    dkgDiscardInProgress = false
+                    showDiscardDkgConfirm = false
+                }
             )
         } else if (!dkgRecoveryInProgress) {
             PendingDkgShareDialog(

--- a/app/src/main/res/values/strings_main.xml
+++ b/app/src/main/res/values/strings_main.xml
@@ -68,6 +68,9 @@
     <string name="main_pending_dkg_recover_failed">Recovery failed. Please try again.</string>
     <string name="main_pending_dkg_discard_confirm_title">Discard Pending Share?</string>
     <string name="main_pending_dkg_discard_confirm_text">This permanently deletes the pending share. This can\'t be undone, and the group will need to be created again.</string>
+    <string name="main_pending_dkg_discard_auth_title">Discard Pending Share</string>
+    <string name="main_pending_dkg_discard_auth_subtitle">Authenticate to permanently discard the pending share</string>
+    <string name="main_pending_dkg_discard_failed">Couldn\'t discard the share. Please try again.</string>
     <string name="main_pin_mismatch_title">Certificate Pin Mismatch</string>
     <string name="main_pin_mismatch_text">The certificate for <xliff:g id="hostname" example="relay.example.com">%1$s</xliff:g> has changed. This could indicate a security issue or a legitimate certificate rotation.</string>
     <string name="main_clear_pin_and_retry">Clear Pin &amp; Retry</string>

--- a/app/src/main/res/values/strings_main.xml
+++ b/app/src/main/res/values/strings_main.xml
@@ -70,6 +70,12 @@
     <string name="main_pending_dkg_discard_confirm_text">This permanently deletes the pending share. This can\'t be undone, and the group will need to be created again.</string>
     <string name="main_pending_dkg_discard_auth_title">Discard Pending Share</string>
     <string name="main_pending_dkg_discard_auth_subtitle">Authenticate to permanently discard the pending share</string>
+    <string name="main_pending_dkg_recover_passphrase_required">This share needs its ceremony passphrase to recover, which isn\'t available on this device.</string>
+    <string name="main_pending_dkg_recover_unavailable">Couldn\'t access the secure vault to recover this share.</string>
+    <string name="main_pending_dkg_unreadable_title">Pending Share Unreadable</string>
+    <string name="main_pending_dkg_unreadable_text">A completed signing group share is pending, but its record can\'t be read right now. Creating a new group stays blocked until it is recovered or discarded.</string>
+    <string name="main_pending_dkg_retry">Retry</string>
+    <string name="main_pending_dkg_still_unreadable">Still can\'t read the pending share.</string>
     <string name="main_pending_dkg_discard_failed">Couldn\'t discard the share. Please try again.</string>
     <string name="main_pin_mismatch_title">Certificate Pin Mismatch</string>
     <string name="main_pin_mismatch_text">The certificate for <xliff:g id="hostname" example="relay.example.com">%1$s</xliff:g> has changed. This could indicate a security issue or a legitimate certificate rotation.</string>

--- a/app/src/main/res/values/strings_main.xml
+++ b/app/src/main/res/values/strings_main.xml
@@ -58,6 +58,16 @@
     <string name="main_kill_switch_dialog_text">This will block all signing requests until you disable it. You will need biometric authentication to re-enable signing.</string>
     <string name="main_enable">Enable</string>
     <string name="main_cancel">Cancel</string>
+    <string name="main_pending_dkg_title">Recover Signing Group Share</string>
+    <string name="main_pending_dkg_text">Your share for the group \"<xliff:g id="name" example="Family Wallet">%1$s</xliff:g>\" completed but wasn\'t saved. Recover it to finish setup, or discard it to start over.</string>
+    <string name="main_pending_dkg_recover">Recover</string>
+    <string name="main_pending_dkg_discard">Discard</string>
+    <string name="main_pending_dkg_recover_title">Recover Share</string>
+    <string name="main_pending_dkg_recover_subtitle">Unlock to recover your signing group share</string>
+    <string name="main_pending_dkg_recovered">Share recovered</string>
+    <string name="main_pending_dkg_recover_failed">Recovery failed. Please try again.</string>
+    <string name="main_pending_dkg_discard_confirm_title">Discard Pending Share?</string>
+    <string name="main_pending_dkg_discard_confirm_text">This permanently deletes the pending share. This can\'t be undone, and the group will need to be created again.</string>
     <string name="main_pin_mismatch_title">Certificate Pin Mismatch</string>
     <string name="main_pin_mismatch_text">The certificate for <xliff:g id="hostname" example="relay.example.com">%1$s</xliff:g> has changed. This could indicate a security issue or a legitimate certificate rotation.</string>
     <string name="main_clear_pin_and_retry">Clear Pin &amp; Retry</string>

--- a/app/src/main/res/values/strings_main.xml
+++ b/app/src/main/res/values/strings_main.xml
@@ -75,6 +75,7 @@
     <string name="main_pending_dkg_unreadable_title">Pending Share Unreadable</string>
     <string name="main_pending_dkg_unreadable_text">A completed signing group share is pending, but its record can\'t be read right now. Creating a new group stays blocked until it is recovered or discarded.</string>
     <string name="main_pending_dkg_retry">Retry</string>
+    <string name="main_pending_dkg_later">Later</string>
     <string name="main_pending_dkg_still_unreadable">Still can\'t read the pending share.</string>
     <string name="main_pending_dkg_discard_failed">Couldn\'t discard the share. Please try again.</string>
     <string name="main_pin_mismatch_title">Certificate Pin Mismatch</string>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added recovery and discard options for pending signing-group shares.
  - Users can recover pending shares with biometric verification or discard them with authentication and confirmation.
  - Added retry options when pending-share information cannot be read.
  - Added localized prompts, status updates, success feedback, and failure messages.

- **Bug Fixes**
  - Unreadable pending shares are no longer treated as absent.
  - Canceling authorization correctly stops discard actions.
  - Prevented duplicate recovery or discard requests while an operation is in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->