### PR TITLE
Gate group creation on pending DKG share

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -544,6 +544,7 @@ fun MainScreen(
     }
 
     LaunchedEffect(Unit) {
+        val dkgEpochAtRead = pendingDkgEpoch
         val initial = withContext(Dispatchers.IO) {
             val a = storage.listAllShares().map { it.toAccountInfo() }
             val k = storage.getActiveShareKey()
@@ -558,9 +559,15 @@ fun MainScreen(
         activeAccountKey = initial.activeKey
         relays = initial.relays
         profileRelays = initial.profileRelays
-        initial.pendingDkgShare
-            .onSuccess { pendingDkgShare = it; pendingDkgUnreadable = false }
-            .onFailure { pendingDkgUnreadable = true }
+        // A discard/recover that bumps the epoch while this read was in flight has
+        // already cleared the marker; drop the stale write so this read can't resurrect
+        // it, mirroring the poll guard below. Complete the check either way so the gate
+        // doesn't latch on WAIT.
+        if (pendingDkgEpoch == dkgEpochAtRead) {
+            initial.pendingDkgShare
+                .onSuccess { pendingDkgShare = it; pendingDkgUnreadable = false }
+                .onFailure { pendingDkgUnreadable = true }
+        }
         pendingDkgCheckComplete = true
     }
 

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -287,6 +287,25 @@ private fun showRelayHostCheckToast(context: Context, result: RelayHostCheck) {
     Toast.makeText(context, resId, Toast.LENGTH_LONG).show()
 }
 
+/** Outcome of the pending-DKG gate that guards entry into the group-creation ceremony. */
+enum class GroupCreationGate { WAIT, BLOCK, ALLOW }
+
+/**
+ * Decide whether a Create Group request may proceed. Fail-closed: while the initial
+ * marker read is still outstanding ([pendingCheckComplete] false) we cannot rule out a
+ * pending share owning the single slot, so we WAIT rather than ALLOW. A known share or an
+ * unreadable marker BLOCKs; only a completed check with a clear slot ALLOWs.
+ */
+fun groupCreationGate(
+    pendingCheckComplete: Boolean,
+    hasPendingShare: Boolean,
+    pendingUnreadable: Boolean,
+): GroupCreationGate = when {
+    !pendingCheckComplete -> GroupCreationGate.WAIT
+    hasPendingShare || pendingUnreadable -> GroupCreationGate.BLOCK
+    else -> GroupCreationGate.ALLOW
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MainScreen(
@@ -339,6 +358,11 @@ fun MainScreen(
     // same error, so collapsing it to null blocks group creation while hiding the only
     // control that can clear the block.
     var pendingDkgUnreadable by remember { mutableStateOf(false) }
+    // False until the initial marker read resolves. Both the share and unreadable flags
+    // default to "nothing pending", so a Create Group tap fired before that first read
+    // lands would sail past the gate even when a completed-but-unrecovered stash owns
+    // the slot. Group creation stays fail-closed until this flips true.
+    var pendingDkgCheckComplete by remember { mutableStateOf(false) }
     // Bumped on every local mutation of the marker state. A poll captures it before its
     // read and drops the result if it changed, so a read that started before a discard
     // can't land afterward and resurrect the marker it just cleared. A plain
@@ -537,6 +561,7 @@ fun MainScreen(
         initial.pendingDkgShare
             .onSuccess { pendingDkgShare = it; pendingDkgUnreadable = false }
             .onFailure { pendingDkgUnreadable = true }
+        pendingDkgCheckComplete = true
     }
 
     LaunchedEffect(Unit) {
@@ -988,19 +1013,32 @@ fun MainScreen(
     }
 
     if (showCreateGroupScreen) {
-        // A completed-but-unrecovered DKG stash owns the single pending slot, so a
-        // new ceremony would run the whole multi-round DKG only to be refused at
-        // persistence (frost_run_dkg). Refuse at the door instead and re-surface the
-        // recover/discard dialog, sparing the user -- and every peer -- that wasted
-        // round trip. Covers the deferred-unreadable path #492 made reachable.
-        if (pendingDkgShare != null || pendingDkgUnreadable) {
-            val blockedMessage = stringResource(R.string.main_pending_dkg_blocks_create_group)
-            LaunchedEffect(Unit) {
-                showCreateGroupScreen = false
-                pendingDkgDeferred = false
-                Toast.makeText(appContext, blockedMessage, Toast.LENGTH_LONG).show()
+        when (groupCreationGate(pendingDkgCheckComplete, pendingDkgShare != null, pendingDkgUnreadable)) {
+            GroupCreationGate.WAIT -> {
+                // The initial marker read hasn't resolved yet, so we don't know whether a
+                // pending stash owns the single slot. Fail closed: hold the ceremony behind
+                // a spinner rather than let a Create tap in this window slip past the block
+                // below and kick off a DKG that persistence would only reject.
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+                return
             }
-            return
+            GroupCreationGate.BLOCK -> {
+                // A completed-but-unrecovered DKG stash owns the single pending slot, so a
+                // new ceremony would run the whole multi-round DKG only to be refused at
+                // persistence (frost_run_dkg). Refuse at the door instead and re-surface the
+                // recover/discard dialog, sparing the user -- and every peer -- that wasted
+                // round trip. Covers the deferred-unreadable path #492 made reachable.
+                val blockedMessage = stringResource(R.string.main_pending_dkg_blocks_create_group)
+                LaunchedEffect(Unit) {
+                    showCreateGroupScreen = false
+                    pendingDkgDeferred = false
+                    Toast.makeText(appContext, blockedMessage, Toast.LENGTH_LONG).show()
+                }
+                return
+            }
+            GroupCreationGate.ALLOW -> Unit
         }
         // Cache the fallback lookup so the getRelayConfig FFI is not re-run on every
         // recomposition; recompute only when the preferred relays change.

--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -988,6 +988,20 @@ fun MainScreen(
     }
 
     if (showCreateGroupScreen) {
+        // A completed-but-unrecovered DKG stash owns the single pending slot, so a
+        // new ceremony would run the whole multi-round DKG only to be refused at
+        // persistence (frost_run_dkg). Refuse at the door instead and re-surface the
+        // recover/discard dialog, sparing the user -- and every peer -- that wasted
+        // round trip. Covers the deferred-unreadable path #492 made reachable.
+        if (pendingDkgShare != null || pendingDkgUnreadable) {
+            val blockedMessage = stringResource(R.string.main_pending_dkg_blocks_create_group)
+            LaunchedEffect(Unit) {
+                showCreateGroupScreen = false
+                pendingDkgDeferred = false
+                Toast.makeText(appContext, blockedMessage, Toast.LENGTH_LONG).show()
+            }
+            return
+        }
         // Cache the fallback lookup so the getRelayConfig FFI is not re-run on every
         // recomposition; recompute only when the preferred relays change.
         val groupRelays = remember(relays) {

--- a/app/src/main/res/values/strings_main.xml
+++ b/app/src/main/res/values/strings_main.xml
@@ -78,6 +78,7 @@
     <string name="main_pending_dkg_later">Later</string>
     <string name="main_pending_dkg_still_unreadable">Still can\'t read the pending share.</string>
     <string name="main_pending_dkg_discard_failed">Couldn\'t discard the share. Please try again.</string>
+    <string name="main_pending_dkg_blocks_create_group">Recover or discard your pending signing group share before creating a new group.</string>
     <string name="main_pin_mismatch_title">Certificate Pin Mismatch</string>
     <string name="main_pin_mismatch_text">The certificate for <xliff:g id="hostname" example="relay.example.com">%1$s</xliff:g> has changed. This could indicate a security issue or a legitimate certificate rotation.</string>
     <string name="main_clear_pin_and_retry">Clear Pin &amp; Retry</string>

--- a/app/src/test/kotlin/io/privkey/keep/GroupCreationGateTest.kt
+++ b/app/src/test/kotlin/io/privkey/keep/GroupCreationGateTest.kt
@@ -1,0 +1,56 @@
+package io.privkey.keep
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Coverage for [groupCreationGate], the fail-closed guard on the group-creation ceremony.
+ * The share/unreadable flags default to "nothing pending", so a Create Group tap fired
+ * before the initial marker read resolves must not slip past the block and start a DKG
+ * that persistence would only reject. Pure logic; the Compose flow is emulator-bound and
+ * out of unit scope.
+ */
+class GroupCreationGateTest {
+
+    @Test
+    fun tapDuringInitialReadWaits() =
+        assertEquals(
+            GroupCreationGate.WAIT,
+            groupCreationGate(pendingCheckComplete = false, hasPendingShare = false, pendingUnreadable = false),
+        )
+
+    @Test
+    fun incompleteCheckWaitsEvenWithKnownShare() =
+        assertEquals(
+            GroupCreationGate.WAIT,
+            groupCreationGate(pendingCheckComplete = false, hasPendingShare = true, pendingUnreadable = false),
+        )
+
+    @Test
+    fun incompleteCheckWaitsEvenWhenUnreadable() =
+        assertEquals(
+            GroupCreationGate.WAIT,
+            groupCreationGate(pendingCheckComplete = false, hasPendingShare = false, pendingUnreadable = true),
+        )
+
+    @Test
+    fun completedCheckWithPendingShareBlocks() =
+        assertEquals(
+            GroupCreationGate.BLOCK,
+            groupCreationGate(pendingCheckComplete = true, hasPendingShare = true, pendingUnreadable = false),
+        )
+
+    @Test
+    fun completedCheckWithUnreadableMarkerBlocks() =
+        assertEquals(
+            GroupCreationGate.BLOCK,
+            groupCreationGate(pendingCheckComplete = true, hasPendingShare = false, pendingUnreadable = true),
+        )
+
+    @Test
+    fun completedCheckWithClearSlotAllows() =
+        assertEquals(
+            GroupCreationGate.ALLOW,
+            groupCreationGate(pendingCheckComplete = true, hasPendingShare = false, pendingUnreadable = false),
+        )
+}


### PR DESCRIPTION
Refuses to open the Create Group flow while a completed-but-unrecovered DKG share occupies the single pending slot, instead of letting the user run the entire multi-round ceremony only to be refused at persistence in \`frost_run_dkg\`.

The pending-marker guard already lives in \`frost_run_dkg\` (keep-mobile), which is correct for the safety property but lands at the *end* of the ceremony. \`frost_dkg_begin\` has no equivalent, and that is the call behind Begin. This became reachable in #492, which added a Later action so an unreadable pending share no longer blocks the whole app — the user could defer that dialog and then walk into a doomed ceremony, wasting their effort and every peer's.

## Change
- In \`MainActivity\`, gate the \`showCreateGroupScreen\` block: if a pending share exists (readable or unreadable), refuse at the door, clear \`pendingDkgDeferred\` so the recover/discard dialog re-surfaces, and toast a message pointing at recover/discard.
- Add string \`main_pending_dkg_blocks_create_group\`.

Fail-safe against all three Create Group entry points (they funnel through the same block) and covers the deferred-unreadable path.

No safety change — the stash was never clobberable (\`frost_run_dkg\` still refuses); this removes the wasted round trip and the confusing dead end.

## Design note (bead follow-up question)
Left the main readable pending dialog modal (Recover/Discard, no Later). The unreadable dialog needs Later because it has no immediate remedy; the readable one does (Recover is one biometric), so there's no dead-end to escape and keeping it modal nudges prompt persistence of the completed share.

## Verification
\`:app:compileDebugKotlin\` passes clean (also rebuilds keep-mobile against the pin).

Closes #493. Maps to keep-android-5ry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented creation of a new signing group while an existing or unreadable pending setup is detected.
  * Ensured group creation waits for the pending-state check to finish before proceeding.
  * Prevented the flow from becoming stuck when the initial status check fails.
  * Added a clear localized message explaining how to recover or discard the pending share before continuing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->