### PR TITLE
Guard initial account load against storage decrypt fault (#496)

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
+++ b/app/src/main/kotlin/io/privkey/keep/MainActivity.kt
@@ -545,28 +545,38 @@ fun MainScreen(
 
     LaunchedEffect(Unit) {
         val dkgEpochAtRead = pendingDkgEpoch
-        val initial = withContext(Dispatchers.IO) {
-            val a = storage.listAllShares().map { it.toAccountInfo() }
-            val k = storage.getActiveShareKey()
-            val config = runCatching { keepMobile.getRelayConfig(k) }.getOrNull()
-                ?: RelayConfigInfo(emptyList(), emptyList(), emptyList())
-            val r = config.frostRelays
-            val pr = config.profileRelays
-            val pdkg = runCatching { keepMobile.pendingDkgShare() }
-            AccountInitial(a, k, r, pr, pdkg)
-        }
-        allAccounts = initial.accounts
-        activeAccountKey = initial.activeKey
-        relays = initial.relays
-        profileRelays = initial.profileRelays
-        // A discard/recover that bumps the epoch while this read was in flight has
-        // already cleared the marker; drop the stale write so this read can't resurrect
-        // it, mirroring the poll guard below. Complete the check either way so the gate
-        // doesn't latch on WAIT.
-        if (pendingDkgEpoch == dkgEpochAtRead) {
-            initial.pendingDkgShare
-                .onSuccess { pendingDkgShare = it; pendingDkgUnreadable = false }
-                .onFailure { pendingDkgUnreadable = true }
+        // listAllShares/getActiveShareKey read Keystore-encrypted prefs; a transient
+        // decrypt fault must not crash launch. On failure treat the pending-DKG slot as
+        // unreadable so the group-creation gate fails closed rather than open.
+        runCatching {
+            val initial = withContext(Dispatchers.IO) {
+                val a = storage.listAllShares().map { it.toAccountInfo() }
+                val k = storage.getActiveShareKey()
+                val config = runCatching { keepMobile.getRelayConfig(k) }.getOrNull()
+                    ?: RelayConfigInfo(emptyList(), emptyList(), emptyList())
+                val r = config.frostRelays
+                val pr = config.profileRelays
+                val pdkg = runCatching { keepMobile.pendingDkgShare() }
+                AccountInitial(a, k, r, pr, pdkg)
+            }
+            allAccounts = initial.accounts
+            activeAccountKey = initial.activeKey
+            relays = initial.relays
+            profileRelays = initial.profileRelays
+            // A discard/recover that bumps the epoch while this read was in flight has
+            // already cleared the marker; drop the stale write so this read can't resurrect
+            // it, mirroring the poll guard below. Complete the check either way so the gate
+            // doesn't latch on WAIT.
+            if (pendingDkgEpoch == dkgEpochAtRead) {
+                initial.pendingDkgShare
+                    .onSuccess { pendingDkgShare = it; pendingDkgUnreadable = false }
+                    .onFailure { pendingDkgUnreadable = true }
+            }
+        }.onFailure {
+            if (it is CancellationException) throw it
+            if (pendingDkgEpoch == dkgEpochAtRead) {
+                pendingDkgUnreadable = true
+            }
         }
         pendingDkgCheckComplete = true
     }


### PR DESCRIPTION
Fixes keep-android-06v (GH #496).

`MainActivity`'s initial-account `LaunchedEffect` wrapped `getRelayConfig` and `pendingDkgShare` in `runCatching` but left `storage.listAllShares()` and `storage.getActiveShareKey()` unguarded. Both read Keystore-encrypted prefs, so a transient decrypt fault threw out of the `LaunchedEffect` and crashed the app on launch, repeating while the fault persisted with no recovery path.

Wrap the whole `withContext` block in `runCatching`, rethrow `CancellationException`, and on failure set `pendingDkgUnreadable = true` (respecting the epoch guard) so the group-creation gate fails closed rather than reading a bare-`false` slot as clear. `pendingDkgCheckComplete` is still set either way so the gate doesn't latch on WAIT.

Compiles clean (`:app:compileDebugKotlin`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability when loading account and relay data.
  * Prevented transient secure-storage read failures from crashing the app.
  * Safely blocks group creation when pending setup information cannot be read.
  * Preserved cancellation handling and prevented outdated loading results from overwriting current data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->