### PR TITLE
Extend StrongBox use-time probe to auth-gated keys

### DIFF
--- a/app/src/androidTest/kotlin/io/privkey/keep/storage/StrongBoxAuthKeyFallbackTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/storage/StrongBoxAuthKeyFallbackTest.kt
@@ -1,0 +1,83 @@
+package io.privkey.keep.storage
+
+import android.security.keystore.KeyInfo
+import android.security.keystore.KeyProperties
+import androidx.biometric.BiometricManager
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.security.KeyStore
+import javax.crypto.SecretKey
+import javax.crypto.SecretKeyFactory
+
+/**
+ * The auth-gated StrongBox key cannot be exercised at use time without a biometric,
+ * so its use-time capability is validated against a throwaway non-auth probe key. If
+ * that probe fails, the auth key must be regenerated on the TEE rather than left on a
+ * StrongBox that will later reject the operation. On working StrongBox hardware the
+ * probe would always pass, so it is forced to fail here to reach the downgrade path.
+ */
+@RunWith(AndroidJUnit4::class)
+class StrongBoxAuthKeyFallbackTest {
+
+    private val ctx get() = InstrumentationRegistry.getInstrumentation().targetContext
+    private val shareKey = "__keep_strongbox_auth_fallback_test"
+    private lateinit var keyStore: KeyStore
+    private lateinit var alias: String
+
+    @Before fun setup() {
+        keyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+        alias = AndroidKeystoreStorage(ctx, requireUserAuth = true).keystoreAliasFor(shareKey)
+        if (keyStore.containsAlias(alias)) keyStore.deleteEntry(alias)
+    }
+
+    @After fun teardown() {
+        if (keyStore.containsAlias(alias)) keyStore.deleteEntry(alias)
+    }
+
+    private fun assumeBiometricEnrolled() = assumeTrue(
+        "requires an enrolled strong biometric",
+        BiometricManager.from(ctx)
+            .canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG) ==
+            BiometricManager.BIOMETRIC_SUCCESS
+    )
+
+    private fun securityLevelOf(key: SecretKey): Int {
+        val info = SecretKeyFactory.getInstance(key.algorithm, "AndroidKeyStore")
+            .getKeySpec(key, KeyInfo::class.java) as KeyInfo
+        return info.securityLevel
+    }
+
+    /**
+     * With the use-time probe forced to fail, an auth-gated key on a StrongBox device
+     * must land on the TEE. Generation succeeding on StrongBox is not enough: a device
+     * that rejects the operation only at use time would otherwise keep a key it cannot
+     * use, and the auth path never gets to exercise it before storing a real share.
+     */
+    @Test fun authKeyDowngradesToTeeWhenStrongBoxProbeFails() {
+        assumeTrue(ctx.packageManager.hasSystemFeature("android.hardware.strongbox_keystore"))
+        assumeBiometricEnrolled()
+
+        val storage = AndroidKeystoreStorage(ctx, requireUserAuth = true).apply {
+            strongBoxUseTimeProbe = { false }
+        }
+        val key = storage.ensureShareKey(shareKey)
+
+        assertNotEquals(
+            "a failing StrongBox probe must downgrade the auth key off StrongBox",
+            KeyProperties.SECURITY_LEVEL_STRONGBOX,
+            securityLevelOf(key)
+        )
+        assertEquals(
+            "the downgraded auth key should be TEE-backed",
+            KeyProperties.SECURITY_LEVEL_TRUSTED_ENVIRONMENT,
+            securityLevelOf(key)
+        )
+    }
+}

--- a/app/src/androidTest/kotlin/io/privkey/keep/storage/StrongBoxAuthKeyFallbackTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/storage/StrongBoxAuthKeyFallbackTest.kt
@@ -64,9 +64,7 @@ class StrongBoxAuthKeyFallbackTest {
         assumeTrue(ctx.packageManager.hasSystemFeature("android.hardware.strongbox_keystore"))
         assumeBiometricEnrolled()
 
-        val storage = AndroidKeystoreStorage(ctx, requireUserAuth = true).apply {
-            strongBoxUseTimeProbe = { false }
-        }
+        val storage = AndroidKeystoreStorage(ctx, requireUserAuth = true, strongBoxUseTimeProbe = { false })
         val key = storage.ensureShareKey(shareKey)
 
         assertNotEquals(

--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
@@ -36,7 +36,8 @@ import javax.crypto.spec.SecretKeySpec
 
 class AndroidKeystoreStorage(
     private val context: Context,
-    private val requireUserAuth: Boolean = true
+    private val requireUserAuth: Boolean = true,
+    strongBoxUseTimeProbe: (() -> Boolean)? = null
 ) : SecureStorage {
 
     companion object {
@@ -98,11 +99,14 @@ class AndroidKeystoreStorage(
         load(null)
     }
 
-    // Test seam: the StrongBox use-time probe for auth-gated keys. Overridable so an
-    // instrumented test can force it to fail and assert the downgrade-to-TEE path,
-    // which cannot otherwise be provoked on hardware whose StrongBox works.
+    // Test seam: the StrongBox use-time probe for auth-gated keys. Injected via the
+    // constructor so an instrumented test can force it to fail and assert the
+    // downgrade-to-TEE path, which cannot otherwise be provoked on hardware whose
+    // StrongBox works. Immutable after construction so no app-module code can switch
+    // the downgrade off at runtime.
     @VisibleForTesting
-    internal var strongBoxUseTimeProbe: () -> Boolean = { canEncryptWithStrongBoxProbe() }
+    internal val strongBoxUseTimeProbe: () -> Boolean =
+        strongBoxUseTimeProbe ?: { canEncryptWithStrongBoxProbe() }
 
     private fun createEncryptedPrefs(name: String): SharedPreferences =
         KeystoreEncryptedPrefs.create(context, name)

--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
@@ -9,6 +9,7 @@ import android.security.keystore.KeyPermanentlyInvalidatedException
 import android.security.keystore.KeyProperties
 import android.util.Base64
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import io.privkey.keep.BuildConfig
 import io.privkey.keep.uniffi.KeepMobileException
 import io.privkey.keep.uniffi.SecureStorage
@@ -96,6 +97,12 @@ class AndroidKeystoreStorage(
     private val keyStore: KeyStore = KeyStore.getInstance("AndroidKeyStore").apply {
         load(null)
     }
+
+    // Test seam: the StrongBox use-time probe for auth-gated keys. Overridable so an
+    // instrumented test can force it to fail and assert the downgrade-to-TEE path,
+    // which cannot otherwise be provoked on hardware whose StrongBox works.
+    @VisibleForTesting
+    internal var strongBoxUseTimeProbe: () -> Boolean = { canEncryptWithStrongBoxProbe() }
 
     private fun createEncryptedPrefs(name: String): SharedPreferences =
         KeystoreEncryptedPrefs.create(context, name)
@@ -479,6 +486,14 @@ class AndroidKeystoreStorage(
         return getOrCreateKeyWithAlias(newAlias, requireUserAuth)
     }
 
+    // Creates (but does not use) the per-share key, so a test can trigger the
+    // auth-gated creation path without a biometric-bound cipher operation.
+    @VisibleForTesting
+    internal fun ensureShareKey(key: String): SecretKey = getOrCreateKeyForShare(key)
+
+    @VisibleForTesting
+    internal fun keystoreAliasFor(key: String): String = getKeystoreAlias(key)
+
     private fun isLegacyAccount(key: String): Boolean {
         val sharePrefs = getSharePrefs(key)
         if (!sharePrefs.contains(KEY_SHARE_DATA)) return false
@@ -517,13 +532,14 @@ class AndroidKeystoreStorage(
                 // use time (some Keymint implementations reject the operation only
                 // when the cipher runs, e.g. Pixel 9a on Android 17 throwing at
                 // doFinal). Generation-only fallback misses that, so a non-auth key
-                // is probed with a throwaway encrypt and a failure falls back to
-                // TEE. An auth-gated key cannot be exercised without a biometric, so
-                // it is left as generated and validated when the user authenticates.
+                // is probed directly with a throwaway encrypt. An auth-gated key
+                // cannot be exercised without a biometric, so its use-time behaviour
+                // is checked against a throwaway non-auth key with the same StrongBox
+                // params; a failure on either falls back to TEE.
                 val strongBoxOk = try {
                     keyGenerator.init(buildSpec(useStrongBox = true))
                     keyGenerator.generateKey()
-                    requireUserAuth || canEncryptWithKey(alias)
+                    if (requireUserAuth) strongBoxUseTimeProbe() else canEncryptWithKey(alias)
                 } catch (e: Exception) {
                     if (e !is ProviderException && e !is InvalidAlgorithmParameterException) throw e
                     if (BuildConfig.DEBUG) Log.w(TAG, "StrongBox key generation failed, falling back to TEE", e)
@@ -556,6 +572,36 @@ class AndroidKeystoreStorage(
     }.getOrElse { e ->
         if (BuildConfig.DEBUG) Log.w(TAG, "StrongBox key failed use-time probe, falling back to TEE", e)
         false
+    }
+
+    // An auth-gated key cannot be exercised without a biometric, so its StrongBox
+    // use-time capability is checked against a throwaway non-auth key built with the
+    // same StrongBox AES params. This costs one extra keygen the first time a key is
+    // created; the probe key is deleted regardless of outcome.
+    private fun canEncryptWithStrongBoxProbe(): Boolean {
+        val probeAlias = "keep_strongbox_aes_probe"
+        return try {
+            if (keyStore.containsAlias(probeAlias)) keyStore.deleteEntry(probeAlias)
+            KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore").apply {
+                init(
+                    KeyGenParameterSpec.Builder(
+                        probeAlias,
+                        KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+                    )
+                        .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                        .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                        .setKeySize(256)
+                        .setIsStrongBoxBacked(true)
+                        .build()
+                )
+            }.generateKey()
+            canEncryptWithKey(probeAlias)
+        } catch (e: Exception) {
+            if (BuildConfig.DEBUG) Log.w(TAG, "StrongBox probe key generation failed, falling back to TEE", e)
+            false
+        } finally {
+            if (keyStore.containsAlias(probeAlias)) keyStore.deleteEntry(probeAlias)
+        }
     }
 
     fun getCipherForShareEncryption(key: String): Cipher =

--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
@@ -579,7 +579,7 @@ class AndroidKeystoreStorage(
     // same StrongBox AES params. This costs one extra keygen the first time a key is
     // created; the probe key is deleted regardless of outcome.
     private fun canEncryptWithStrongBoxProbe(): Boolean {
-        val probeAlias = "keep_strongbox_aes_probe"
+        val probeAlias = "keep_strongbox_aes_probe_${java.util.UUID.randomUUID()}"
         return try {
             if (keyStore.containsAlias(probeAlias)) keyStore.deleteEntry(probeAlias)
             KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore").apply {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication-protected key creation on devices with StrongBox support.
  * Automatically falls back to the trusted execution environment when StrongBox validation fails.
  * Added cleanup and error handling for temporary security checks to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->