### PR TITLE
Extend StrongBox use-time probe to auth-gated keys

### DIFF
--- a/app/src/androidTest/kotlin/io/privkey/keep/storage/StrongBoxAuthKeyFallbackTest.kt
+++ b/app/src/androidTest/kotlin/io/privkey/keep/storage/StrongBoxAuthKeyFallbackTest.kt
@@ -1,0 +1,88 @@
+package io.privkey.keep.storage
+
+import android.security.keystore.KeyInfo
+import android.security.keystore.KeyProperties
+import androidx.biometric.BiometricManager
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.security.KeyStore
+import javax.crypto.SecretKey
+import javax.crypto.SecretKeyFactory
+
+/**
+ * The auth-gated StrongBox key cannot be exercised at use time without a biometric,
+ * so its use-time capability is validated against a throwaway non-auth probe key. If
+ * that probe fails, the auth key must be regenerated on the TEE rather than left on a
+ * StrongBox that will later reject the operation. On working StrongBox hardware the
+ * probe would always pass, so it is forced to fail here to reach the downgrade path.
+ */
+@RunWith(AndroidJUnit4::class)
+class StrongBoxAuthKeyFallbackTest {
+
+    private val ctx get() = InstrumentationRegistry.getInstrumentation().targetContext
+    private val shareKey = "__keep_strongbox_auth_fallback_test"
+    private lateinit var keyStore: KeyStore
+    private lateinit var alias: String
+
+    @Before fun setup() {
+        keyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+        alias = AndroidKeystoreStorage(ctx, requireUserAuth = true).keystoreAliasFor(shareKey)
+        if (keyStore.containsAlias(alias)) keyStore.deleteEntry(alias)
+    }
+
+    @After fun teardown() {
+        if (keyStore.containsAlias(alias)) keyStore.deleteEntry(alias)
+    }
+
+    private fun assumeBiometricEnrolled() = assumeTrue(
+        "requires an enrolled strong biometric",
+        BiometricManager.from(ctx)
+            .canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG) ==
+            BiometricManager.BIOMETRIC_SUCCESS
+    )
+
+    private fun keyInfoOf(key: SecretKey): KeyInfo =
+        SecretKeyFactory.getInstance(key.algorithm, "AndroidKeyStore")
+            .getKeySpec(key, KeyInfo::class.java) as KeyInfo
+
+    private fun securityLevelOf(key: SecretKey): Int = keyInfoOf(key).securityLevel
+
+    /**
+     * With the use-time probe forced to fail, an auth-gated key on a StrongBox device
+     * must land on the TEE. Generation succeeding on StrongBox is not enough: a device
+     * that rejects the operation only at use time would otherwise keep a key it cannot
+     * use, and the auth path never gets to exercise it before storing a real share.
+     */
+    @Test fun authKeyDowngradesToTeeWhenStrongBoxProbeFails() {
+        assumeTrue(ctx.packageManager.hasSystemFeature("android.hardware.strongbox_keystore"))
+        assumeBiometricEnrolled()
+
+        val storage = AndroidKeystoreStorage(ctx, requireUserAuth = true).apply {
+            strongBoxUseTimeProbe = { false }
+        }
+        val key = storage.ensureShareKey(shareKey)
+
+        assertNotEquals(
+            "a failing StrongBox probe must downgrade the auth key off StrongBox",
+            KeyProperties.SECURITY_LEVEL_STRONGBOX,
+            securityLevelOf(key)
+        )
+        assertEquals(
+            "the downgraded auth key should be TEE-backed",
+            KeyProperties.SECURITY_LEVEL_TRUSTED_ENVIRONMENT,
+            securityLevelOf(key)
+        )
+        assertTrue(
+            "the downgraded key must keep its biometric auth gate",
+            keyInfoOf(key).isUserAuthenticationRequired
+        )
+    }
+}

--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
@@ -9,6 +9,7 @@ import android.security.keystore.KeyPermanentlyInvalidatedException
 import android.security.keystore.KeyProperties
 import android.util.Base64
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import io.privkey.keep.BuildConfig
 import io.privkey.keep.uniffi.KeepMobileException
 import io.privkey.keep.uniffi.SecureStorage
@@ -97,6 +98,12 @@ class AndroidKeystoreStorage(
     private val keyStore: KeyStore = KeyStore.getInstance("AndroidKeyStore").apply {
         load(null)
     }
+
+    // Test seam: the StrongBox use-time probe for auth-gated keys. Overridable so an
+    // instrumented test can force it to fail and assert the downgrade-to-TEE path,
+    // which cannot otherwise be provoked on hardware whose StrongBox works.
+    @VisibleForTesting
+    internal var strongBoxUseTimeProbe: () -> Boolean = { canEncryptWithStrongBoxProbe() }
 
     private fun createEncryptedPrefs(name: String): SharedPreferences =
         KeystoreEncryptedPrefs.create(context, name)
@@ -480,6 +487,14 @@ class AndroidKeystoreStorage(
         return getOrCreateKeyWithAlias(newAlias, requireUserAuth)
     }
 
+    // Creates (but does not use) the per-share key, so a test can trigger the
+    // auth-gated creation path without a biometric-bound cipher operation.
+    @VisibleForTesting
+    internal fun ensureShareKey(key: String): SecretKey = getOrCreateKeyForShare(key)
+
+    @VisibleForTesting
+    internal fun keystoreAliasFor(key: String): String = getKeystoreAlias(key)
+
     private fun isLegacyAccount(key: String): Boolean {
         val sharePrefs = getSharePrefs(key)
         if (!sharePrefs.contains(KEY_SHARE_DATA)) return false
@@ -518,13 +533,16 @@ class AndroidKeystoreStorage(
                 // use time (some Keymint implementations reject the operation only
                 // when the cipher runs, e.g. Pixel 9a on Android 17 throwing at
                 // doFinal). Generation-only fallback misses that, so a non-auth key
-                // is probed with a throwaway encrypt and a failure falls back to
-                // TEE. An auth-gated key cannot be exercised without a biometric, so
-                // it is left as generated and validated when the user authenticates.
+                // is probed directly with a throwaway encrypt. An auth-gated key
+                // cannot be exercised without a biometric, so its use-time behaviour
+                // is checked against a throwaway non-auth StrongBox key. That proxy
+                // shares the algorithm/block-mode/StrongBox params but not the auth
+                // gate, so it catches algorithm-level use-time faults, not a rejection
+                // specific to auth-bound keys; a failure falls back to TEE.
                 val strongBoxOk = try {
                     keyGenerator.init(buildSpec(useStrongBox = true))
                     keyGenerator.generateKey()
-                    requireUserAuth || canEncryptWithKey(alias)
+                    if (requireUserAuth) strongBoxUseTimeProbe() else canEncryptWithKey(alias)
                 } catch (e: Exception) {
                     if (e !is ProviderException && e !is InvalidAlgorithmParameterException) throw e
                     if (BuildConfig.DEBUG) Log.w(TAG, "StrongBox key generation failed, falling back to TEE", e)
@@ -557,6 +575,37 @@ class AndroidKeystoreStorage(
     }.getOrElse { e ->
         if (BuildConfig.DEBUG) Log.w(TAG, "StrongBox key failed use-time probe, falling back to TEE", e)
         false
+    }
+
+    // An auth-gated key cannot be exercised without a biometric, so its StrongBox
+    // use-time capability is checked against a throwaway non-auth key built with the
+    // same algorithm/block-mode/StrongBox params (minus the auth gate, which cannot
+    // be exercised headlessly). This costs one extra keygen the first time a key is
+    // created; the probe key is deleted regardless of outcome.
+    private fun canEncryptWithStrongBoxProbe(): Boolean {
+        val probeAlias = "keep_strongbox_aes_probe"
+        return try {
+            if (keyStore.containsAlias(probeAlias)) keyStore.deleteEntry(probeAlias)
+            KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore").apply {
+                init(
+                    KeyGenParameterSpec.Builder(
+                        probeAlias,
+                        KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+                    )
+                        .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                        .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                        .setKeySize(256)
+                        .setIsStrongBoxBacked(true)
+                        .build()
+                )
+            }.generateKey()
+            canEncryptWithKey(probeAlias)
+        } catch (e: Exception) {
+            if (BuildConfig.DEBUG) Log.w(TAG, "StrongBox probe key generation failed, falling back to TEE", e)
+            false
+        } finally {
+            if (keyStore.containsAlias(probeAlias)) keyStore.deleteEntry(probeAlias)
+        }
     }
 
     fun getCipherForShareEncryption(key: String): Cipher =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication-protected key handling on Android devices with StrongBox.
  * When StrongBox validation fails, keys now fall back to the device’s Trusted Execution Environment.
  * Biometric authentication requirements remain enforced after fallback.

* **Reliability**
  * Added coverage for StrongBox failures and secure fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->