### PR TITLE
Route background NIP-55 pubkey verification through shared checkPubkey helper

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/nip55/Nip55ContentProvider.kt
+++ b/app/src/main/kotlin/io/privkey/keep/nip55/Nip55ContentProvider.kt
@@ -417,19 +417,11 @@ class Nip55ContentProvider : ContentProvider() {
 
         return runCatching { h.handleRequest(request, callerPackage) }
             .mapCatching { response ->
-                if (requestType == Nip55RequestType.GET_PUBLIC_KEY) {
-                    if (response.result.isEmpty()) {
-                        throw IllegalStateException("Handler returned empty pubkey")
-                    }
-                    val groupPubkey = app.getStorage()?.getShareMetadata()?.groupPubkey
-                    if (groupPubkey == null || groupPubkey.isEmpty()) {
-                        throw IllegalStateException("Stored pubkey unavailable for verification")
-                    }
-                    val storedPubkey = groupPubkey.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
-                    if (!MessageDigest.isEqual(response.result.toByteArray(Charsets.UTF_8), storedPubkey.toByteArray(Charsets.UTF_8))) {
-                        if (BuildConfig.DEBUG) Log.e(TAG, "Pubkey verification failed: mismatch detected")
-                        throw IllegalStateException("Pubkey verification failed")
-                    }
+                // Same self-verification as the foreground path: compare the handler's
+                // returned pubkey against the independently-read stored group pubkey
+                // (keystore share metadata) through the single shared checkPubkey helper.
+                checkPubkey(requestType, response.result, app.getStorage()?.getShareMetadata()?.groupPubkey)?.let {
+                    throw IllegalStateException("Pubkey verification failed")
                 }
                 runCatching {
                     runWithTimeout { store.logOperation(callerPackage, requestType, eventKind, "allow", wasAutomatic = true) }


### PR DESCRIPTION
Routes the background NIP-55 pubkey verification (Nip55ContentProvider) through the same `checkPubkey` helper the foreground path uses, removing the last inline copy of the self-verification block.

Behavior-preserving dedup: `checkPubkey` still receives a `groupPubkey` read independently from keystore share metadata, so the independent-second-source property that makes the check meaningful is preserved. Same non-GET_PUBLIC_KEY skip, same empty-result rejection, same fail-closed on null/empty stored pubkey, same hex encoding, same constant-time `MessageDigest.isEqual`.

Relates to #414 — see that issue for the decision to keep the check in Kotlin rather than relocating into Rust.