### PR TITLE
Log encryption failure cause under DEBUG in encryptWithCipher

### DIFF
--- a/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
+++ b/app/src/main/kotlin/io/privkey/keep/storage/AndroidKeystoreStorage.kt
@@ -247,7 +247,10 @@ class AndroidKeystoreStorage(
 
     private fun encryptWithCipher(cipher: Cipher, data: ByteArray): ByteArray = runCatching {
         cipher.doFinal(data)
-    }.getOrElse { throw KeepMobileException.StorageException("Failed to encrypt share") }
+    }.getOrElse { e ->
+        if (BuildConfig.DEBUG) Log.e(TAG, "Encryption failed: ${e::class.simpleName}: ${e.message}", e)
+        throw KeepMobileException.StorageException("Failed to encrypt share")
+    }
 
     private fun decryptWithCipher(cipher: Cipher, encryptedBase64: String): ByteArray = runCatching {
         cipher.doFinal(Base64.decode(encryptedBase64, Base64.NO_WRAP))


### PR DESCRIPTION
Mirrors decryptWithCipher: logs the discarded cause under BuildConfig.DEBUG before throwing StorageException, so encrypt failures are diagnosable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic logging for encryption failures in debug builds while preserving existing production behavior and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->